### PR TITLE
renamed nil? to is_nil

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -46,7 +46,7 @@ defmodule Postgrex.Connection do
       |> Dict.put_new(:username, System.get_env("PGUSER") || System.get_env("USER"))
       |> Dict.put_new(:password, System.get_env("PGPASSWORD"))
       |> Dict.put_new(:hostname, System.get_env("PGHOST") || "localhost")
-      |> Enum.reject(fn {_k,v} -> nil?(v) end)
+      |> Enum.reject(fn {_k,v} -> is_nil(v) end)
     case :gen_server.start_link(__MODULE__, [], []) do
       {:ok, pid} ->
         timeout = opts[:connect_timeout] || @timeout
@@ -606,7 +606,7 @@ defmodule Postgrex.Connection do
 
   defp message(:executing, msg_command_complete(tag: tag), %{statement: stat} = s) do
     reply =
-      if nil?(stat) do
+      if is_nil(stat) do
         create_result(tag)
       else
         try do
@@ -796,7 +796,7 @@ defmodule Postgrex.Connection do
     {command, nrows} = decode_tag(tag)
 
     # Fix for PostgreSQL 8.4 (doesn't include number of selected rows in tag)
-    if nil?(nrows) and command == :select do
+    if is_nil(nrows) and command == :select do
       nrows = length(rows)
     end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -240,7 +240,7 @@ defmodule Postgrex.Protocol do
   defp format(:binary), do: 1
 
   defp encode_param(param) do
-    if nil?(param) do
+    if is_nil(param) do
       <<-1 :: int32>>
     else
       [<<IO.iodata_length(param) :: int32>>, param]

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -96,7 +96,7 @@ defmodule Postgrex.Types do
     result = case format(types, info.oid, formatter) do
       :binary ->
         if bin = bin || default.(value), do: {:binary, bin}
-      :text when not nil?(bin) ->
+      :text when not is_nil(bin) ->
         {:text, bin}
       :text when is_binary(value) ->
         {:text, value}
@@ -104,7 +104,7 @@ defmodule Postgrex.Types do
         nil
     end
 
-    if nil?(result) do
+    if is_nil(result) do
       throw {:postgrex_encode, "unable to encode value `#{inspect value}` as type #{info.type}"}
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Postgrex.Mixfile do
   def project do
     [app: :postgrex,
      version: "0.6.0-dev",
-     elixir: "~> 0.15.0 or ~> 1.0.0-rc1",
+     elixir: "~> 1.0.0-rc1",
      deps: deps,
      build_per_environment: false,
      name: "Postgrex",

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:package, "0.2.4"},
   "earmark": {:package, "0.1.10"},
-  "ex_doc": {:package, "0.5.2"},
+  "ex_doc": {:package, "0.6.0"},
   "hoedown": {:git, "git://github.com/hoedown/hoedown.git", "0610117f44b173a4e2112afb2f510156a32355b5", []},
   "markdown": {:git, "git://github.com/devinus/markdown.git", "a428908a6dd88f351775d1d3da530a1a2aa0d6cb", []}}


### PR DESCRIPTION
In prep for 1.0.0, but needs to drop support for 0.15.0
