### PR TITLE
Updated documentation to include mandatory params

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -91,16 +91,17 @@ defmodule Postgrex.Connection do
 
   ## Examples
 
-      Postgrex.Connection.query(pid, "CREATE TABLES posts (id serial, title text)")
+      Postgrex.Connection.query(pid, "CREATE TABLE posts (id serial, title text)", [])
 
-      Postgrex.Connection.query(pid, "INSERT INTO posts (title) VALUES ('my title')")
+      Postgrex.Connection.query(pid, "INSERT INTO posts (title) VALUES ('my title')", [])
 
-      Postgrex.Connection.query(pid, "SELECT title FROM posts")
+      Postgrex.Connection.query(pid, "SELECT title FROM posts", [])
 
-      Postgrex.Connection.query(pid, "SELECT $1 + $2", [40, 2]")
+      Postgrex.Connection.query(pid, "SELECT id FROM posts WHERE title like $1", ["%my%"])
 
-      Postgrex.Connection.query(pid, "SELECT $1 || $2", ['4', '2'],
+      Postgrex.Connection.query(pid, "SELECT $1 || $2", ["4", "2"],
                                 param_types: ["text", "text"], result_types: ["text"])
+
   """
   @spec query(pid, iodata, list, Keyword.t) :: {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def query(pid, statement, params, opts \\ []) do


### PR DESCRIPTION
Examples were not working,

iex(23)> Postgrex.Connection.query(pid, "CREATE TABLE posts (id serial, title text)") 
*\* (UndefinedFunctionError) undefined function: Postgrex.Connection.query/2
    Postgrex.Connection.query(#PID<0.228.0>, "CREATE TABLE posts (id serial, title text)")

Looking at the code it seems like the params is no longer optional, so I updated the documentation (the other option is to continue to make the params optional)

Also note that the $1 + $2 query was throwing type exceptions in my version of postgres (9.3), so I changed it slightly.
