### PR TITLE
add support for redshift

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -169,6 +169,10 @@ defmodule Postgrex.Types do
     end)
   end
 
+  defp parse_oids(nil) do
+    []
+  end
+
   defp parse_oids("{}") do
     []
   end


### PR DESCRIPTION
the query used in type bootstrapping can return null when made against aws redshift
where an empty array would be returned by postgrex