### PR TITLE
Detect stale types when executing prepared queries

### DIFF
--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -4,9 +4,11 @@ defmodule Postgrex.Query do
 
     * `name` - The name of the prepared statement;
     * `statement` - The prepared statement;
+    * `param_oids` - List of oids for each parameter;
     * `param_formats` - List of formats for each parameters encoded to;
     * `encoders` - List of anonymous functions to encode each parameter;
     * `columns` - The column names;
+    * `result_oids` - List of oids for each column;
     * `result_formats` - List of formats for each column is decoded from;
     * `decoders` - List of anonymous functions to decode each column;
     * `types` - The type server table to fetch the type information from;
@@ -18,32 +20,34 @@ defmodule Postgrex.Query do
   @type t :: %__MODULE__{
     name:           iodata,
     statement:      iodata,
+    param_oids:     [Postgrex.Types.oid] | nil,
     param_formats:  [:binary | :text] | nil,
-    encoders:       [Postgrex.Types.oid] | [(term -> iodata)] | nil,
+    encoders:       [(term -> iodata)] | nil,
     columns:        [String.t] | nil,
+    result_oids:    [Postgrex.Types.oid] | nil,
     result_formats: [:binary | :text] | nil,
-    decoders:       [Postgrex.Types.oid] | [(binary -> term)] | nil,
+    decoders:       [(binary -> term)] | nil,
     types:          Postgrex.TypeServer.table | nil,
     null:           atom,
     copy_data:      boolean}
 
-  defstruct [:name, :statement, :param_formats, :encoders, :columns,
-    :result_formats, :decoders, :types, :null, :copy_data]
+  defstruct [:ref, :name, :statement, :param_oids, :param_formats, :encoders,
+    :columns, :result_oids, :result_formats, :decoders, :types, :null,
+    :copy_data]
 end
 
 defimpl DBConnection.Query, for: Postgrex.Query do
   import Postgrex.BinaryUtils
   require Postgrex.Messages
 
-  def parse(%{name: name, statement: statement} = query, opts) do
+  def parse(%{name: name} = query, opts) do
     copy_data? = opts[:copy_data] || false
-    # for query table to match on two identical statements they must be equal
-    %{query | name: IO.iodata_to_binary(name),
-      statement: IO.iodata_to_binary(statement), copy_data: copy_data?}
+    # for query table to match names must be equal
+    %{query | name: IO.iodata_to_binary(name), copy_data: copy_data?}
   end
 
   def describe(query, opts) do
-    %Postgrex.Query{encoders: poids, decoders: roids,
+    %Postgrex.Query{param_oids: poids, result_oids: roids,
                     types: types, null: conn_null, copy_data: data?} = query
     {pfs, encoders} = encoders(poids, types)
     encoders = if data?, do: encoders ++ [:copy_data], else: encoders

--- a/test/alter_test.exs
+++ b/test/alter_test.exs
@@ -1,0 +1,169 @@
+defmodule AlterTest do
+  use ExUnit.Case, async: false
+  import Postgrex.TestHelper
+
+  setup context do
+    options = [database: "postgrex_test", backoff_type: :stop,
+               prepare: context[:prepare] || :named]
+
+    on_exit(fn() ->
+      {:ok, pid} = Postgrex.start_link(options)
+      Postgrex.query(pid, "ALTER TABLE altering ALTER a type int2", [])
+    end)
+
+    {:ok, pid} = Postgrex.start_link(options)
+    {:ok, [pid: pid, options: options]}
+  end
+
+  test "prepare query, alter and execute returns error", context do
+    query = prepare("select", "SELECT a FROM altering")
+
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    assert %Postgrex.Error{postgres: %{code: :feature_not_supported}} = execute(query, [])
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "prepare query, close, alter and execute raises (and closes)", context do
+    query1 = prepare("select", "SELECT a FROM altering WHERE a=$1")
+    query2 = prepare("select", "SELECT a FROM altering")
+    close(query1)
+    close(query2)
+
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    assert_raise ArgumentError, ~r"stale type information",
+      fn() -> execute(query1, [1]) end
+    assert [[42]] = query("SELECT 42", [])
+
+    assert_raise ArgumentError, ~r"stale type information",
+      fn() -> execute(query2, []) end
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "transaction with prepare query, alter and execute errors", context do
+    query = prepare("select", "SELECT a FROM altering")
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :feature_not_supported}}} =
+        Postgrex.execute(conn, query, [])
+    end)
+  end
+
+  test "transaction with prepare query, alter, close and execute raises", context do
+    query1 = prepare("select", "SELECT a FROM altering WHERE a=$1")
+    query2 = prepare("select", "SELECT a FROM altering")
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+    assert :ok = close(query1)
+    assert :ok = close(query2)
+
+    transaction(fn(conn) ->
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query1, [1]) end
+    end)
+
+    assert [[42]] = query("SELECT 42", [])
+
+    transaction(fn(conn) ->
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query2, []) end
+    end)
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "transaction with prepare query, alter and savepoint execute errors", context do
+    query = prepare("select", "SELECT a FROM altering")
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :feature_not_supported}}} =
+        Postgrex.execute(conn, query, [], [mode: :savepoint])
+
+      assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+    end)
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "transaction with prepare query, close, alter and savepoint execute errors", context do
+    query1 = prepare("select", "SELECT a FROM altering WHERE a=$1")
+    query2 = prepare("select", "SELECT a FROM altering")
+    assert :ok = close(query1)
+    assert :ok = close(query2)
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    transaction(fn(conn) ->
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query1, [1], [mode: :savepoint]) end
+
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query2, [], [mode: :savepoint]) end
+
+      assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+    end)
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag prepare: :unnamed
+  test "prepare query, alter and execute raises with unnamed", context do
+    query1 = prepare("select", "SELECT a FROM altering WHERE a=$1")
+    query2 = prepare("select", "SELECT a FROM altering")
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    assert_raise ArgumentError, ~r"stale type information",
+      fn() -> execute(query1, [1]) end
+
+    assert [[42]] = query("SELECT 42", [])
+
+    assert_raise ArgumentError, ~r"stale type information",
+      fn() -> execute(query2, []) end
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag prepare: :unnamed
+  test "transaction with prepare query, alter and execute raises with unnamed", context do
+    query1 = prepare("select", "SELECT a FROM altering WHERE a=$1")
+    query2 = prepare("select", "SELECT a FROM altering")
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    transaction(fn(conn) ->
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query1, [1]) end
+
+      assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query2, []) end
+
+      assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+    end)
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag prepare: :unnamed
+  test "transaction with prepare query, alter and savepoint execute errors with unnamed", context do
+    query1 = prepare("select", "SELECT a FROM altering WHERE a=$1")
+    query2 = prepare("select", "SELECT a FROM altering")
+    assert :ok = query("ALTER TABLE altering ALTER a TYPE int4", [])
+
+    transaction(fn(conn) ->
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query1, [1], [mode: :savepoint]) end
+
+      assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+
+      assert_raise ArgumentError, ~r"stale type information",
+        fn() -> Postgrex.execute(conn, query2, [], [mode: :savepoint]) end
+
+      assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+    end)
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -761,11 +761,11 @@ defmodule QueryTest do
     params = Enum.into(params, [])
 
     capture_log fn ->
-      assert_raise ArgumentError,
+      assert_raise RuntimeError,
         "postgresql protocol can not handle 65536 parameters, the maximum is 65535",
         fn() -> query(query, params) end
       pid = context[:pid]
-      assert_receive {:EXIT, ^pid, {:shutdown, %ArgumentError{}}}
+      assert_receive {:EXIT, ^pid, {:shutdown, %RuntimeError{}}}
     end
   end
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -534,12 +534,11 @@ defmodule QueryTest do
     assert [[42]] = query("SELECT 42", [])
   end
 
-  test "prepare query and execute different query with same name raise", context do
+  test "prepare query and execute different queries with same name", context do
     assert (%Postgrex.Query{name: "select"} = query42) = prepare("select", "SELECT 42")
     assert close(query42) == :ok
     assert %Postgrex.Query{} = prepare("select", "SELECT 41")
-    assert %Postgrex.Error{postgres: %{code: :duplicate_prepared_statement}} =
-      execute(query42, [])
+    assert [[42]] = execute(query42, [])
 
     assert [[42]] = query("SELECT 42", [])
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -47,6 +47,8 @@ DROP TYPE IF EXISTS enum1;
 CREATE TYPE enum1 AS ENUM ('elixir', 'erlang');
 
 CREATE TABLE uniques (a int UNIQUE);
+
+CREATE TABLE altering (a int2)
 """
 
 sql_with_schemas = """


### PR DESCRIPTION
Match cached queries by name and referenced rather than name and statement.

Initial work towards #212. This PR means we should always error if types change.