### PR TITLE
Only sync with backend once when doing query/4

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -114,7 +114,11 @@ defmodule Postgrex do
   @spec query(conn, iodata, list, Keyword.t) :: {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def query(conn, statement, params, opts \\ []) do
     query = %Query{name: "", statement: statement}
-    case DBConnection.prepare_execute(conn, query, params, defaults(opts)) do
+    opts =
+      opts
+      |> defaults()
+      |> Keyword.put(:function, :prepare_execute)
+    case DBConnection.prepare_execute(conn, query, params, opts) do
       {:ok, _, result} ->
         {:ok, result}
       {:error, %ArgumentError{} = err} ->
@@ -133,7 +137,11 @@ defmodule Postgrex do
   @spec query!(conn, iodata, list, Keyword.t) :: Postgrex.Result.t
   def query!(conn, statement, params, opts \\ []) do
     query = %Query{name: "", statement: statement}
-    {_, result} = DBConnection.prepare_execute!(conn, query, params, defaults(opts))
+    opts =
+      opts
+      |> defaults()
+      |> Keyword.put(:function, :prepare_execute)
+    {_, result} = DBConnection.prepare_execute!(conn, query, params, opts)
     result
   end
 
@@ -167,7 +175,11 @@ defmodule Postgrex do
   @spec prepare(conn, iodata, iodata, Keyword.t) :: {:ok, Postgrex.Query.t} | {:error, Postgrex.Error.t}
   def prepare(conn, name, statement, opts \\ []) do
     query = %Query{name: name, statement: statement}
-    case DBConnection.prepare(conn, query, defaults(opts)) do
+    opts =
+      opts
+      |> defaults()
+      |> Keyword.put(:function, :prepare)
+    case DBConnection.prepare(conn, query, opts) do
       {:error, %ArgumentError{} = err} ->
         raise err
       {:error, %RuntimeError{} = err} ->
@@ -183,7 +195,11 @@ defmodule Postgrex do
   """
   @spec prepare!(conn, iodata, iodata, Keyword.t) :: Postgrex.Query.t
   def prepare!(conn, name, statement, opts \\ []) do
-    DBConnection.prepare!(conn, %Query{name: name, statement: statement}, defaults(opts))
+    opts =
+      opts
+      |> defaults()
+      |> Keyword.put(:function, :prepare)
+    DBConnection.prepare!(conn, %Query{name: name, statement: statement}, opts)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Postgrex.Mixfile do
   defp deps do
     [{:ex_doc, "~> 0.12", only: :dev},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 1.0-rc"},
+     {:db_connection, "~> 1.0-rc.4"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
-  "db_connection": {:hex, :db_connection, "1.0.0-rc.0", "debd4f4c126bf4cb3b984c82096cee15b18c18ecf339631e1105122dc4b59111", [:mix], [{:sbroker, "~> 1.0.0-beta.2", [hex: :sbroker, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:connection, "~> 1.0.2", [hex: :connection, optional: false]}]},
+  "db_connection": {:hex, :db_connection, "1.0.0-rc.4", "fad1f772c151cc6bde82412b8d72319968bc7221df8ef7d5e9d7fde7cb5c86b7", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
* Parse query on backend once (instead of twice) when unnamed
* Savepoint once (instead of twice) when savepointing queries

Requires latest DBConnection!

Closes #219. Closes #218.