### PR TITLE
Add support for Elixir 1.3+ Calendar types

### DIFF
--- a/lib/postgrex/extensions/calendar.ex
+++ b/lib/postgrex/extensions/calendar.ex
@@ -1,0 +1,131 @@
+if Code.ensure_loaded?(Calendar) do
+  defmodule Postgrex.Extensions.Calendar.Date do
+    @moduledoc false
+    import Postgrex.BinaryUtils
+    use Postgrex.BinaryExtension, [send: "date_send"]
+
+    @gd_epoch :calendar.date_to_gregorian_days({2000, 1, 1})
+    @max_days :calendar.date_to_gregorian_days({5874898, 1, 1})
+
+    def encode(_, %Date{} = date, _, _) do
+      days =
+        date
+        |> Date.to_erl()
+        |> :calendar.date_to_gregorian_days()
+      if days < @max_days do
+        <<days - @gd_epoch :: int32>>
+      else
+        raise ArgumentError, "#{inspect date} is beyond the maximum year 5874987"
+      end
+    end
+    def encode(type_info, value, _, _) do
+      raise ArgumentError,
+        Postgrex.Utils.encode_msg(type_info, value, Date)
+    end
+
+    def decode(_, <<days :: int32>>, _, _) do
+      days + @gd_epoch
+      |> :calendar.gregorian_days_to_date()
+      |> Date.from_erl!()
+    end
+  end
+
+  defmodule Postgrex.Extensions.Calendar.NaiveDateTime do
+    @moduledoc false
+    import Postgrex.BinaryUtils
+    use Postgrex.BinaryExtension, [send: "timestamp_send"]
+
+    @gs_epoch :calendar.datetime_to_gregorian_seconds({{2000, 1, 1}, {0, 0, 0}})
+    @max_sec :calendar.datetime_to_gregorian_seconds({{294277, 1, 1}, {0, 0, 0}})
+
+    def encode(_, %NaiveDateTime{microsecond: {microsecs, _}} = naive, _, _) do
+      erl = NaiveDateTime.to_erl(naive)
+      case :calendar.datetime_to_gregorian_seconds(erl) - @gs_epoch do
+        sec when sec < @max_sec ->
+          <<sec * 1_000_000 + microsecs :: int64>>
+        _ ->
+          raise ArgumentError, "#{inspect naive} is beyond the maximum year 294276"
+      end
+    end
+    def encode(type_info, value, _, _) do
+      raise ArgumentError,
+        Postgrex.Utils.encode_msg(type_info, value, NaiveDateTime)
+    end
+
+    def decode(_, <<microsecs :: int64>>, _, _) when microsecs < 0 do
+      secs = div(microsecs, 1_000_000) - 1
+      microsecs = 1_000_000 + rem(microsecs, 1_000_000)
+      to_naive(secs, microsecs)
+    end
+    def decode(_, <<microsecs :: int64>>, _, _) do
+      secs = div(microsecs, 1_000_000)
+      microsecs = rem(microsecs, 1_000_000)
+      to_naive(secs, microsecs)
+    end
+
+    defp to_naive(secs, microsecs) do
+      secs + @gs_epoch
+      |> :calendar.gregorian_seconds_to_datetime()
+      |> NaiveDateTime.from_erl!({microsecs, 6})
+    end
+  end
+
+  defmodule Postgrex.Extensions.Calendar.DateTime do
+    @moduledoc false
+    import Postgrex.BinaryUtils
+    use Postgrex.BinaryExtension, [send: "timestamptz_send"]
+
+    @unix_epoch_sec :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
+    @gs_epoch_sec :calendar.datetime_to_gregorian_seconds({{2000, 1, 1}, {0, 0, 0}}) - @unix_epoch_sec
+    @gs_epoch @gs_epoch_sec |> DateTime.from_unix!() |> DateTime.to_unix(:microseconds)
+    @max_unix_sec :calendar.datetime_to_gregorian_seconds({{294277, 1, 1}, {0, 0, 0}}) - @unix_epoch_sec
+    @max_unix @max_unix_sec |> DateTime.from_unix!() |> DateTime.to_unix(:microseconds)
+
+    def encode(_, %DateTime{utc_offset: 0, std_offset: 0} = date_time, _, _) do
+      case DateTime.to_unix(date_time, :microseconds) do
+        microsecs when microsecs < @max_unix ->
+          <<microsecs - @gs_epoch :: int64>>
+        _ ->
+          raise ArgumentError, "#{inspect date_time} is beyond the maximum year 294276"
+      end
+    end
+    def encode(_, %DateTime{} = date_time, _, _) do
+      raise ArgumentError, "#{inspect date_time} is not in UTC"
+    end
+    def encode(type_info, value, _, _) do
+      raise ArgumentError,
+        Postgrex.Utils.encode_msg(type_info, value, DateTime)
+    end
+
+    def decode(_, <<microsecs :: int64>>, _, _) do
+      DateTime.from_unix!(microsecs + @gs_epoch, :microseconds)
+    end
+  end
+
+  defmodule Postgrex.Extensions.Calendar.Time do
+    @moduledoc false
+    import Postgrex.BinaryUtils
+    use Postgrex.BinaryExtension, [send: "time_send"]
+
+    def encode(_, %Time{microsecond: {microsec, _}} = time, _, _) do
+      sec =
+        time
+        |> Time.to_erl()
+        |> :calendar.time_to_seconds()
+
+      <<sec * 1_000_000 + microsec :: int64>>
+    end
+    def encode(type_info, value, _, _) do
+      raise ArgumentError,
+        Postgrex.Utils.encode_msg(type_info, value, Time)
+    end
+
+    def decode(_, <<microsec :: int64>>, _, _) do
+      sec = div(microsec, 1_000_000)
+      microsec = rem(microsec, 1_000_000)
+      sec
+      |> :calendar.seconds_to_time()
+      |> Time.from_erl!(microsec)
+    end
+  end
+end

--- a/lib/postgrex/extensions/time.ex
+++ b/lib/postgrex/extensions/time.ex
@@ -4,6 +4,8 @@ defmodule Postgrex.Extensions.Time do
   import Postgrex.BinaryUtils
   use Postgrex.BinaryExtension, [send: "time_send", send: "timetz_send"]
 
+  @us_day (:calendar.time_to_seconds({23, 59, 59}) + 1) * 1_000_000
+
   def encode(%TypeInfo{send: "time_send"}, %Postgrex.Time{hour: hour, min: min, sec: sec, usec: usec}, _, _)
   when hour in 0..23 and min in 0..59 and sec in 0..59 and usec in 0..999_999  do
     time = {hour, min, sec}
@@ -27,10 +29,16 @@ defmodule Postgrex.Extensions.Time do
 
   ## Helpers
 
-  defp decode_time(microsecs) do
+  defp decode_time(microsecs) when microsecs < 0 do
+    decode_time(@us_day + microsecs)
+  end
+  defp decode_time(microsecs) when microsecs < @us_day do
     secs = div(microsecs, 1_000_000)
     usec = rem(microsecs, 1_000_000)
     {hour, min, sec} = :calendar.seconds_to_time(secs)
     %Postgrex.Time{hour: hour, min: min, sec: sec, usec: usec}
+  end
+  defp decode_time(microsecs) do
+    decode_time(microsecs - @us_day)
   end
 end

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -1,0 +1,177 @@
+if Code.ensure_loaded?(Calendar) do
+  defmodule CalendarTest do
+    use ExUnit.Case, async: true
+    import Postgrex.TestHelper
+    alias Postgrex, as: P
+
+    setup do
+      extensions = [{Postgrex.Extensions.Calendar.Time, []},
+                    {Postgrex.Extensions.Calendar.Date, []},
+                    {Postgrex.Extensions.Calendar.NaiveDateTime, []},
+                    {Postgrex.Extensions.Calendar.DateTime, []}]
+      opts = [database: "postgrex_test", backoff_type: :stop,
+              extensions: extensions]
+      {:ok, pid} = P.start_link(opts)
+      {:ok, [pid: pid]}
+    end
+
+    test "decode time", context do
+      assert [[~T[00:00:00.000000]]] = query("SELECT time '00:00:00'", [])
+      assert [[~T[01:02:03.000000]]] = query("SELECT time '01:02:03'", [])
+      assert [[~T[23:59:59.000000]]] = query("SELECT time '23:59:59'", [])
+      assert [[~T[04:05:06.000000]]] = query("SELECT time '04:05:06 PST'", [])
+
+      assert [[~T[00:00:00.123000]]] = query("SELECT time '00:00:00.123'", [])
+      assert [[~T[00:00:00.123456]]] = query("SELECT time '00:00:00.123456'", [])
+      assert [[~T[01:02:03.123456]]] = query("SELECT time '01:02:03.123456'", [])
+    end
+
+    test "decode date", context do
+      assert [[~D[0001-01-01]]] = query("SELECT date '0001-01-01'", [])
+      assert [[~D[0001-02-03]]] = query("SELECT date '0001-02-03'", [])
+      assert [[~D[2013-09-23]]] = query("SELECT date '2013-09-23'", [])
+    end
+
+    test "decode timestamp", context do
+      assert [[~N[2001-01-01 00:00:00.000000]]] =
+        query("SELECT timestamp '2001-01-01 00:00:00'", [])
+
+      assert :ok = query("SET SESSION TIME ZONE UTC", [])
+      assert [[~N[2013-09-23 14:04:37.123000]]] =
+        query("SELECT timestamp '2013-09-23 14:04:37.123'", [])
+
+      assert [[~N[2013-09-23 14:04:37.000000]]] =
+        query("SELECT timestamp '2013-09-23 14:04:37 PST'", [])
+
+      assert :ok = query("SET SESSION TIME ZONE +1", [])
+      assert [[~N[2013-09-23 14:04:37.000000]]] =
+        query("SELECT timestamp '2013-09-23 14:04:37 PST'", [])
+
+      assert [[~N[1980-01-01 00:00:00.123456]]] =
+        query("SELECT timestamp '1980-01-01 00:00:00.123456'", [])
+    end
+
+    test "decode timestamptz", context do
+      assert [[%DateTime{year: 2001, month: 1, day: 1, hour: 0, minute: 0,
+                         second: 0, microsecond: {0, 6},
+                         time_zone: "Etc/UTC", utc_offset: 0}]] =
+       query("SELECT timestamp with time zone '2001-01-01 00:00:00'", [])
+
+      assert :ok = query("SET SESSION TIME ZONE UTC", [])
+      assert [[%DateTime{year: 2013, month: 9, day: 23, hour: 14, minute: 4,
+                         second: 37, microsecond: {123000, 6},
+                         time_zone: "Etc/UTC", utc_offset: 0}]] =
+      query("SELECT timestamp with time zone '2013-09-23 14:04:37.123'", [])
+
+      assert [[%DateTime{year: 2013, month: 9, day: 23, hour: 22, minute: 4,
+                         second: 37, microsecond: {0, 6},
+                         time_zone: "Etc/UTC", utc_offset: 0}]] =
+      query("SELECT timestamp with time zone '2013-09-23 14:04:37 PST'", [])
+
+      assert :ok = query("SET SESSION TIME ZONE +1", [])
+
+      assert [[%DateTime{year: 2013, month: 9, day: 23, hour: 22, minute: 4,
+                         second: 37, microsecond: {0, 6},
+                         time_zone: "Etc/UTC", utc_offset: 0}]] =
+        query("SELECT timestamp with time zone '2013-09-23 14:04:37 PST'", [])
+
+      assert [[%DateTime{year: 1980, month: 1, day: 1, hour: 0, minute: 0,
+                         second: 0, microsecond: {123456, 6},
+                         time_zone: "Etc/UTC", utc_offset: 0}]] =
+        query("SELECT timestamp with time zone '1980-01-01 01:00:00.123456'", [])
+    end
+
+    test "encode time", context do
+      assert [["00:00:00"]] = query("SELECT $1::time::text", [~T[00:00:00.0000]])
+      assert [["01:02:03"]] = query("SELECT $1::time::text", [~T[01:02:03]])
+      assert [["23:59:59"]] = query("SELECT $1::time::text", [~T[23:59:59]])
+      assert [["04:05:06.123456"]] = query("SELECT $1::time::text", [~T[04:05:06.123456]])
+    end
+
+    test "encode date", context do
+      assert [["0001-01-01"]] = query("SELECT $1::date::text", [~D[0001-01-01]])
+      assert [["0001-02-03"]] = query("SELECT $1::date::text", [~D[0001-02-03]])
+      assert [["2013-09-23"]] = query("SELECT $1::date::text", [~D[2013-09-23]])
+      assert [["1999-12-31"]] = query("SELECT $1::date::text", [~D[1999-12-31]])
+    end
+
+    test "encode timestamp", context do
+      assert [["2001-01-01 00:00:00"]] =
+        query("SELECT $1::timestamp::text", [~N[2001-01-01 00:00:00.000000]])
+
+      assert :ok = query("SET SESSION TIME ZONE UTC", [])
+      assert [["2013-09-23 14:04:37.123"]] =
+        query("SELECT $1::timestamp::text", [~N[2013-09-23 14:04:37.123000]])
+
+      assert [["2013-09-23 14:04:37"]] =
+        query("SELECT $1::timestamp::text", [~N[2013-09-23 14:04:37.000000]])
+
+      assert :ok = query("SET SESSION TIME ZONE +1", [])
+
+      assert [["2013-09-23 14:04:37"]] =
+        query("SELECT $1::timestamp::text", [~N[2013-09-23 14:04:37.000000]])
+
+      assert [["1980-01-01 00:00:00.123456"]] =
+        query("SELECT $1::timestamp::text", [~N[1980-01-01 00:00:00.123456]])
+    end
+
+    test "encode timestamptz", context do
+      assert :ok = query("SET SESSION TIME ZONE UTC", [])
+
+      assert [["2001-01-01 00:00:00+00"]] =
+        query("SELECT $1::timestamp with time zone::text",
+              [%DateTime{year: 2001, month: 1, day: 1, hour: 0, minute: 0,
+                  second: 0, microsecond: {0, 6}, time_zone: "Etc/UTC",
+                  zone_abbr: "UTC", utc_offset: 0, std_offset: 0}])
+
+      assert [["2013-09-23 14:04:37.123+00"]] =
+        query("SELECT $1::timestamp with time zone::text",
+              [%DateTime{year: 2013, month: 9, day: 23, hour: 14, minute: 4,
+                         second: 37, microsecond: {123000, 6},
+                         time_zone: "Etc/UTC", zone_abbr: "UTC", utc_offset: 0,
+                         std_offset: 0}])
+
+      assert_raise ArgumentError, ~r"is not in UTC",
+        fn() ->
+          query("SELECT $1::timestamp with time zone::text",
+              [%DateTime{year: 2013, month: 9, day: 23, hour: 14, minute: 4,
+                         second: 37, microsecond: {123000, 6},
+                         time_zone: "PST", zone_abbr: "PST", utc_offset: 8,
+                         std_offset: 0}])
+        end
+
+      assert :ok = query("SET SESSION TIME ZONE +1", [])
+
+      assert [["2013-09-23 15:04:37.123+01"]] =
+        query("SELECT $1::timestamp with time zone::text",
+              [%DateTime{year: 2013, month: 9, day: 23, hour: 14, minute: 4,
+                         second: 37, microsecond: {123000, 6},
+                         time_zone: "Etc/UTC", zone_abbr: "UTC", utc_offset: 0,
+                         std_offset: 0}])
+
+      assert [["1980-01-01 01:00:00.123456+01"]] =
+        query("SELECT $1::timestamp with time zone::text",
+              [%DateTime{year: 1980, month: 1, day: 1, hour: 0, minute: 0,
+                         second: 0, microsecond: {123456, 6},
+                         time_zone: "Etc/UTC", zone_abbr: "UTC", utc_offset: 0,
+                         std_offset: 0}])
+    end
+
+    test "persit timestamp and timestamptz", context  do
+      assert :ok = query("SET SESSION TIME ZONE +1", [])
+      assert :ok = query("INSERT INTO calendar VALUES (timestamp without time zone '2001-01-01 00:00:00', timestamp with time zone '2001-01-01 00:00:00 UTC')", [])
+
+      assert [[~N[2001-01-01 00:00:00.000000],
+               %DateTime{year: 2001,  month: 1, day: 1, hour: 0, minute: 0,
+                         second: 0}]] =
+        query("SELECT a, b FROM calendar", [])
+
+      assert :ok = query("SET SESSION TIME ZONE +2", [])
+
+      assert [[~N[2001-01-01 00:00:00.000000],
+               %DateTime{year: 2001,  month: 1, day: 1, hour: 0, minute: 0,
+                         second: 0}]] =
+        query("SELECT a, b FROM calendar", [])
+    end
+  end
+end

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -28,6 +28,7 @@ if Code.ensure_loaded?(Calendar) do
       assert [[~T[00:00:00.000000]]] = query("SELECT time with time zone '00:00:00 UTC'", [])
       assert [[~T[01:02:03.000000]]] = query("SELECT time with time zone '01:02:03 UTC'", [])
       assert [[~T[23:00:00.000000]]] = query("SELECT time with time zone '00:00:00+1'", [])
+      assert [[~T[01:00:00.000000]]] = query("SELECT time with time zone '23:00:00-2'", [])
 
       assert :ok = query("SET SESSION TIME ZONE UTC", [])
 

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -16,6 +16,8 @@ if Code.ensure_loaded?(Calendar) do
       assert [[~T[01:02:03.000000]]] = query("SELECT time '01:02:03'", [])
       assert [[~T[23:59:59.000000]]] = query("SELECT time '23:59:59'", [])
       assert [[~T[04:05:06.000000]]] = query("SELECT time '04:05:06 PST'", [])
+      assert [[~T[04:05:06.000000]]] = query("SELECT time '04:05:06-8'", [])
+      assert [[~T[04:05:06.000000]]] = query("SELECT time '04:05:06-8'", [])
 
       assert [[~T[00:00:00.123000]]] = query("SELECT time '00:00:00.123'", [])
       assert [[~T[00:00:00.123456]]] = query("SELECT time '00:00:00.123456'", [])
@@ -31,6 +33,7 @@ if Code.ensure_loaded?(Calendar) do
 
       assert [[~T[23:59:59.000000]]] = query("SELECT time with time zone '23:59:59'", [])
       assert [[~T[12:05:06.000000]]] = query("SELECT time with time zone '04:05:06 PST'", [])
+      assert [[~T[12:05:06.000000]]] = query("SELECT time with time zone '04:05:06-8'", [])
 
       assert [[~T[00:00:00.123000]]] = query("SELECT time with time zone '00:00:00.123'", [])
       assert [[~T[00:00:00.123456]]] = query("SELECT time with time zone '00:00:00.123456 UTC'", [])
@@ -43,6 +46,7 @@ if Code.ensure_loaded?(Calendar) do
       assert :ok = query("SET SESSION TIME ZONE +1", [])
 
       assert [[~T[12:05:06.000000]]] = query("SELECT time with time zone '04:05:06 PST'", [])
+      assert [[~T[12:05:06.000000]]] = query("SELECT time with time zone '04:05:06-8'", [])
       assert [[~T[01:02:03.123456]]] = query("SELECT time with time zone '01:02:03.123456 UTC'", [])
     end
 
@@ -62,6 +66,9 @@ if Code.ensure_loaded?(Calendar) do
 
       assert [[~N[2013-09-23 14:04:37.000000]]] =
         query("SELECT timestamp '2013-09-23 14:04:37 PST'", [])
+
+      assert [[~N[2013-09-23 14:04:37.000000]]] =
+        query("SELECT timestamp '2013-09-23 14:04:37-8'", [])
 
       assert :ok = query("SET SESSION TIME ZONE +1", [])
       assert [[~N[2013-09-23 14:04:37.000000]]] =
@@ -87,6 +94,10 @@ if Code.ensure_loaded?(Calendar) do
                          second: 37, microsecond: {0, 6},
                          time_zone: "Etc/UTC", utc_offset: 0}]] =
       query("SELECT timestamp with time zone '2013-09-23 14:04:37 PST'", [])
+      assert [[%DateTime{year: 2013, month: 9, day: 23, hour: 22, minute: 4,
+                         second: 37, microsecond: {0, 6},
+                         time_zone: "Etc/UTC", utc_offset: 0}]] =
+      query("SELECT timestamp with time zone '2013-09-23 14:04:37-8'", [])
 
       assert :ok = query("SET SESSION TIME ZONE +1", [])
 
@@ -94,6 +105,10 @@ if Code.ensure_loaded?(Calendar) do
                          second: 37, microsecond: {0, 6},
                          time_zone: "Etc/UTC", utc_offset: 0}]] =
         query("SELECT timestamp with time zone '2013-09-23 14:04:37 PST'", [])
+      assert [[%DateTime{year: 2013, month: 9, day: 23, hour: 22, minute: 4,
+                         second: 37, microsecond: {0, 6},
+                         time_zone: "Etc/UTC", utc_offset: 0}]] =
+        query("SELECT timestamp with time zone '2013-09-23 14:04:37-8'", [])
 
       assert [[%DateTime{year: 1980, month: 1, day: 1, hour: 0, minute: 0,
                          second: 0, microsecond: {123456, 6},
@@ -169,7 +184,7 @@ if Code.ensure_loaded?(Calendar) do
           query("SELECT $1::timestamp with time zone::text",
               [%DateTime{year: 2013, month: 9, day: 23, hour: 14, minute: 4,
                          second: 37, microsecond: {123000, 6},
-                         time_zone: "PST", zone_abbr: "PST", utc_offset: 8,
+                         time_zone: "PST", zone_abbr: "PST", utc_offset: -8,
                          std_offset: 0}])
         end
 

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -5,12 +5,8 @@ if Code.ensure_loaded?(Calendar) do
     alias Postgrex, as: P
 
     setup do
-      extensions = [{Postgrex.Extensions.Calendar.Time, []},
-                    {Postgrex.Extensions.Calendar.Date, []},
-                    {Postgrex.Extensions.Calendar.NaiveDateTime, []},
-                    {Postgrex.Extensions.Calendar.DateTime, []}]
       opts = [database: "postgrex_test", backoff_type: :stop,
-              extensions: extensions]
+              extensions: [{Postgrex.Extensions.Calendar, []}]]
       {:ok, pid} = P.start_link(opts)
       {:ok, [pid: pid]}
     end

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -22,6 +22,30 @@ if Code.ensure_loaded?(Calendar) do
       assert [[~T[01:02:03.123456]]] = query("SELECT time '01:02:03.123456'", [])
     end
 
+    test "decode timetz", context do
+      assert [[~T[00:00:00.000000]]] = query("SELECT time with time zone '00:00:00 UTC'", [])
+      assert [[~T[01:02:03.000000]]] = query("SELECT time with time zone '01:02:03 UTC'", [])
+      assert [[~T[23:00:00.000000]]] = query("SELECT time with time zone '00:00:00+1'", [])
+
+      assert :ok = query("SET SESSION TIME ZONE UTC", [])
+
+      assert [[~T[23:59:59.000000]]] = query("SELECT time with time zone '23:59:59'", [])
+      assert [[~T[12:05:06.000000]]] = query("SELECT time with time zone '04:05:06 PST'", [])
+
+      assert [[~T[00:00:00.123000]]] = query("SELECT time with time zone '00:00:00.123'", [])
+      assert [[~T[00:00:00.123456]]] = query("SELECT time with time zone '00:00:00.123456 UTC'", [])
+      assert [[~T[01:02:03.123456]]] = query("SELECT time with time zone '01:02:03.123456'", [])
+
+      assert [[~T[01:02:03.123456]]] = query("SELECT time with time zone '16:01:03.123456+1459'", [])
+
+      assert [[~T[16:01:03.123456]]] = query("SELECT time with time zone '01:02:03.123456-1459'", [])
+
+      assert :ok = query("SET SESSION TIME ZONE +1", [])
+
+      assert [[~T[12:05:06.000000]]] = query("SELECT time with time zone '04:05:06 PST'", [])
+      assert [[~T[01:02:03.123456]]] = query("SELECT time with time zone '01:02:03.123456 UTC'", [])
+    end
+
     test "decode date", context do
       assert [[~D[0001-01-01]]] = query("SELECT date '0001-01-01'", [])
       assert [[~D[0001-02-03]]] = query("SELECT date '0001-02-03'", [])
@@ -82,6 +106,19 @@ if Code.ensure_loaded?(Calendar) do
       assert [["01:02:03"]] = query("SELECT $1::time::text", [~T[01:02:03]])
       assert [["23:59:59"]] = query("SELECT $1::time::text", [~T[23:59:59]])
       assert [["04:05:06.123456"]] = query("SELECT $1::time::text", [~T[04:05:06.123456]])
+    end
+
+    test "encode timetz", context do
+      assert :ok = query("SET SESSION TIME ZONE UTC", [])
+
+      assert [["00:00:00+00"]] = query("SELECT $1::timetz::text", [~T[00:00:00.0000]])
+      assert [["01:02:03+00"]] = query("SELECT $1::timetz::text", [~T[01:02:03]])
+      assert [["23:59:59+00"]] = query("SELECT $1::timetz::text", [~T[23:59:59]])
+      assert [["04:05:06.123456+00"]] = query("SELECT $1::timetz::text", [~T[04:05:06.123456]])
+
+      assert :ok = query("SET SESSION TIME ZONE +1", [])
+
+      assert [["04:05:06.123456+00"]] = query("SELECT $1::timetz::text", [~T[04:05:06.123456]])
     end
 
     test "encode date", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -75,6 +75,10 @@ defmodule QueryTest do
 
     assert [[%Postgrex.Time{hour: 2, min: 5, sec: 6, usec: 0}]] =
            query("SELECT timetz '04:05:06+02'", [])
+    assert [[%Postgrex.Time{hour: 22, min: 5, sec: 6, usec: 0}]] =
+           query("SELECT timetz '00:05:06+02'", [])
+    assert [[%Postgrex.Time{hour: 1, min: 5, sec: 6, usec: 0}]] =
+           query("SELECT timetz '23:05:06-02'", [])
   end
 
   test "decode date", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -48,7 +48,9 @@ CREATE TYPE enum1 AS ENUM ('elixir', 'erlang');
 
 CREATE TABLE uniques (a int UNIQUE);
 
-CREATE TABLE altering (a int2)
+CREATE TABLE altering (a int2);
+
+CREATE TABLE calendar (a timestamp without time zone, b timestamp with time zone);
 """
 
 sql_with_schemas = """


### PR DESCRIPTION
Initial work on Calendar types. Closes #192.

- [x] configuration
- [x] docs
- [x] timestamptz before 1970 (being handled in Elixir see https://github.com/elixir-lang/elixir/issues/5124)
- [x] use a single extension
- [x] support timetz

/cc @lau