### PR TITLE
Specify time zone

### DIFF
--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -83,7 +83,7 @@ if Code.ensure_loaded?(Calendar) do
       assert [[%DateTime{year: 2001, month: 1, day: 1, hour: 0, minute: 0,
                          second: 0, microsecond: {0, 6},
                          time_zone: "Etc/UTC", utc_offset: 0}]] =
-       query("SELECT timestamp with time zone '2001-01-01 00:00:00'", [])
+       query("SELECT timestamp with time zone '2001-01-01 00:00:00 UTC'", [])
 
       assert :ok = query("SET SESSION TIME ZONE UTC", [])
       assert [[%DateTime{year: 2013, month: 9, day: 23, hour: 14, minute: 4,


### PR DESCRIPTION
Running the tests locally, I receive this:

      1) test decode timestamptz (CalendarTest)
         test/calendar_test.exs:82
         match (=) failed
         code: [[%DateTime{year: 2001, month: 1, day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 6}, time_zone: "Etc/UTC", utc_offset: 0}]] = query("SELECT timestamp with time zone '2001-01-01 00:00:00'", [])
         rhs:  [[%DateTime{calendar: Calendar.ISO, day: 31, hour: 23,
                  microsecond: {0, 6}, minute: 0, month: 12, second: 0,
                  std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 2000,
                  zone_abbr: "UTC"}]]
         stacktrace:
           test/calendar_test.exs:83: (test)

This is because the input is being interpreted using my development laptop's time zone (CET) which on January 1st would be on hour ahead of UTC.

Unless Postgrex should set the time zone to UTC upon connection, it seems like an error and this pull request resolves it.