### PR TITLE
Make postgrex respect env var PGDATABASE like libpq.

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -34,7 +34,7 @@ defmodule Postgrex do
 
     * `:hostname` - Server hostname (default: PGHOST env variable, then localhost);
     * `:port` - Server port (default: PGPORT env variable, then 5432);
-    * `:database` - Database (required);
+    * `:database` - Database (default: PGDATABASE env variable; otherwise required);
     * `:username` - Username (default: PGUSER env variable, then USER env var);
     * `:password` - User password (default PGPASSWORD);
     * `:parameters` - Keyword list of connection parameters;

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -52,6 +52,7 @@ defmodule Postgrex.Utils do
     opts
     |> Keyword.put_new(:username, System.get_env("PGUSER") || System.get_env("USER"))
     |> Keyword.put_new(:password, System.get_env("PGPASSWORD"))
+    |> Keyword.put_new(:database, System.get_env("PGDATABASE"))
     |> Keyword.put_new(:hostname, System.get_env("PGHOST") || "localhost")
     |> Keyword.update(:port, normalize_port(System.get_env("PGPORT")), &normalize_port/1)
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -97,6 +97,14 @@ defmodule LoginTest do
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
+  test "env var default db name" do
+    System.put_env("PGDATABASE", "postgrex_test")
+    opts = []
+    assert {:ok, pid} = P.start_link(opts)
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+    System.delete_env("PGDATABASE")
+  end
+
   test "sync connect" do
     opts = [ database: "postgres", sync_connect: true ]
     assert {:ok, pid} = P.start_link(opts)

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -119,14 +119,6 @@ defmodule LoginTest do
         opts = [ sync_connect: true, backoff_type: :stop ]
         assert {:error, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}} =
                P.start_link(opts)
-
-        assert_receive {:EXIT, _, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}}
-      end
-
-      capture_log fn ->
-        opts = [ backoff_type: :stop ]
-        {:ok, pid} = P.start_link(opts)
-        assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}}
       end
     after
       set_db_name(previous_db_name)


### PR DESCRIPTION
I'd like to be able to configure my database name in production via environment variable and this would help. (FWIW I'm an Elixir and Ecto newbie. Happy to make changes if needed.)