### PR TITLE
PG Code in Error Message - Closes #242

### DIFF
--- a/lib/postgrex/error.ex
+++ b/lib/postgrex/error.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Error do
 
   def message(e) do
     if kw = e.postgres do
-      "#{kw[:severity]} (#{kw[:code]}): #{kw[:message]}"
+      "#{kw[:severity]} #{kw[:pg_code]} (#{kw[:code]}): #{kw[:message]}"
       <> build_metadata(kw)
       <> build_detail(kw)
     else

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -13,6 +13,6 @@ defmodule ErrorTest do
     assert message =~ "duplicate key value violates unique constraint"
     assert message =~ "table: uniques"
     assert message =~ "constraint: uniques_a_key"
-    assert message =~ ~r"\b\d{5}\b"
+    assert message =~ "ERROR 23505"
   end
 end

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -13,5 +13,6 @@ defmodule ErrorTest do
     assert message =~ "duplicate key value violates unique constraint"
     assert message =~ "table: uniques"
     assert message =~ "constraint: uniques_a_key"
+    assert message =~ ~r"\b\d{5}\b"
   end
 end

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -55,7 +55,7 @@ defmodule StreamTest do
       stream = %Postgrex.Stream{stream | portal: "E2MANY"}
 
       _ = for _ <- stream do
-        assert_raise Postgrex.Error, ~r"ERROR \(duplicate_cursor\)",
+        assert_raise Postgrex.Error, ~r"\(duplicate_cursor\)",
           fn() -> Enum.take(stream, 1) end
       end
     end)
@@ -137,7 +137,7 @@ defmodule StreamTest do
     query = prepare("", "insert into uniques values (CAST($1::text AS int))")
 
     transaction(fn(conn) ->
-      assert_raise Postgrex.Error, ~r"ERROR \(invalid_text_representation\)",
+      assert_raise Postgrex.Error, ~r"\(invalid_text_representation\)",
         fn -> stream(query, ["EBADF"]) |> Enum.take(1) end
     end)
 
@@ -148,7 +148,7 @@ defmodule StreamTest do
     query = prepare("", "insert into uniques values (1), (1)")
 
     transaction(fn(conn) ->
-      assert_raise Postgrex.Error, ~r"ERROR \(unique_violation\)",
+      assert_raise Postgrex.Error, ~r"\(unique_violation\)",
         fn -> stream(query, []) |> Enum.take(1) end
     end)
 
@@ -637,7 +637,7 @@ defmodule StreamTest do
 
     transaction(fn(conn) ->
       stream = stream(query, ["EBADF"])
-      assert_raise Postgrex.Error, ~r"ERROR \(invalid_text_representation\)",
+      assert_raise Postgrex.Error, ~r"\(invalid_text_representation\)",
         fn() -> Enum.into(["42\n"], stream) end
     end)
 
@@ -645,7 +645,7 @@ defmodule StreamTest do
 
     transaction(fn(conn) ->
       stream = stream(query, ["EBADF"], [mode: :savepoint])
-      assert_raise Postgrex.Error, ~r"ERROR \(invalid_text_representation\)",
+      assert_raise Postgrex.Error, ~r"\(invalid_text_representation\)",
         fn() -> Enum.into(["42\n"], stream) end
 
       assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
@@ -659,7 +659,7 @@ defmodule StreamTest do
 
     transaction(fn(conn) ->
       stream = stream(query, [])
-      assert_raise Postgrex.Error, ~r"ERROR \(unique_violation\)",
+      assert_raise Postgrex.Error, ~r"\(unique_violation\)",
         fn() -> Enum.into(["42\n"], stream) end
     end)
 
@@ -667,7 +667,7 @@ defmodule StreamTest do
 
     transaction(fn(conn) ->
       stream = stream(query, [], [mode: :savepoint])
-      assert_raise Postgrex.Error, ~r"ERROR \(unique_violation\)",
+      assert_raise Postgrex.Error, ~r"\(unique_violation\)",
         fn() -> Enum.into(["42\n"], stream) end
 
       assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])


### PR DESCRIPTION
1. Modified Postgrex error messages to format `SEVERITY PGCODE
(PGCODE_TO_NAME): MESSAGE`
2. Changed regex on `ERROR (PGCODE_TO_NAME)` to match on `(PGCODE_TO_NAME)` in seven `stream_test` test.
tests consistent with changes in 1.
3. Added assertion to `error_test` to regex match 5 numeric digits in
error message consistent with changes in 1.