### PR TITLE
Use double quotes to listen/unlisten

### DIFF
--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -106,7 +106,7 @@ defmodule Postgrex.Notifications do
     # If this is the first listener for the given channel, we need to actually
     # issue the LISTEN query.
     if Map.size(s.listener_channels[channel]) == 1 do
-      listener_query("LISTEN #{channel}", {:ok, ref}, from, s)
+      listener_query("LISTEN \"#{channel}\"", {:ok, ref}, from, s)
     else
       {:reply, {:ok, ref}, s}
     end
@@ -125,7 +125,7 @@ defmodule Postgrex.Notifications do
         # UNLISTEN query.
         if Map.size(s.listener_channels[channel]) == 0 do
           s = update_in(s.listener_channels, &Map.delete(&1, channel))
-          listener_query("UNLISTEN #{channel}", :ok, from, s)
+          listener_query("UNLISTEN \"#{channel}\"", :ok, from, s)
         else
           {:reply, :ok, s}
         end
@@ -141,7 +141,7 @@ defmodule Postgrex.Notifications do
 
         if Map.size(s.listener_channels[channel]) == 0 do
           s = update_in(s.listener_channels, &Map.delete(&1, channel))
-          listener_query("UNLISTEN #{channel}", :ok, nil, s)
+          listener_query("UNLISTEN \"#{channel}\"", :ok, nil, s)
         else
           {:noreply, s}
         end


### PR DESCRIPTION
I'm trying to listen to the channel with a name containing a hyphen ( "test-test" )
This raises an error

> ** (MatchError) no match of right hand side value: %Postgrex.Error{connection_id: 27143, message: nil, postgres: %{code: :syntax_error, file: "scan.l", line: "1052", message: "syntax error at or near \"-\"", pg_code: "42601", position: "13", routine: "scanner_yyerror", severity: "ERROR"}}

This pull-request fixes this bug