### PR TITLE
Update ex_doc to 0.14.3 and minor docs update for start_link

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -63,7 +63,8 @@ defmodule Postgrex do
     and decoding (default: `nil`);
 
   `Postgrex` uses the `DBConnection` framework and supports all `DBConnection`
-  options. See `DBConnection` for more information.
+  options like `:idle`, `:after_connect` etc.
+  See `DBConnection.start_link/2` for more information.
   """
   @spec start_link(Keyword.t) :: {:ok, pid} | {:error, Postgrex.Error.t | term}
   def start_link(opts) do

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
   "db_connection": {:hex, :db_connection, "1.0.0-rc.4", "fad1f772c151cc6bde82412b8d72319968bc7221df8ef7d5e9d7fde7cb5c86b7", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]}}
+  "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
This PR does two things:

1. Updates ex_doc to 0.14.3, so that we can cross link to DBConnection docs
2. Updates `Postgrex.start_link` to mention `after_connect` as dicussed on: https://github.com/elixir-ecto/db_connection/issues/63#issuecomment-253910368

Rendered:

![rendered](https://cloud.githubusercontent.com/assets/76071/19408833/9c794bda-92c6-11e6-9b55-8d5cd7bf122a.png)
