### PR TITLE
Use prepare_stream and stream from DBConnection

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -401,7 +401,7 @@ defmodule Postgrex do
   end
 
   @doc """
-  Returns a stream for a prepared query on a connection.
+  Returns a stream for a query on a connection.
 
   Stream consumes memory in chunks of at most `max_rows` rows (see Options).
   This is useful for processing _large_ datasets.
@@ -413,10 +413,8 @@ defmodule Postgrex do
   queries or streams can be interspersed until the copy has finished. Otherwise
   it is possible to intersperse enumerable streams and queries.
 
-  When used as a `Collectable` the query must have been prepared with
-  `copy_data: true`, otherwise it will raise. Instead of using an extra
-  parameter for the copy data, the data from the enumerable is copied to the
-  database. No other queries or streams can be interspersed until the copy has
+  When used as a `Collectable` the values are passed as copy data with the
+  query. No other queries or streams can be interspersed until the copy has
   finished. If the query is not copying to the database the copy data will still
   be sent but is silently discarded.
 
@@ -438,8 +436,7 @@ defmodule Postgrex do
       end)
 
       Postgrex.transaction(pid, fn(conn) ->
-        query = Postgrex.prepare!(conn, "", "COPY posts FROM STDIN", [copy_data: true])
-        stream = Postgrex.stream(conn, query, [])
+        stream = Postgrex.stream(conn, "COPY posts FROM STDIN", [])
         Enum.into(File.stream!("posts"), stream)
       end)
   """

--- a/lib/postgrex/stream.ex
+++ b/lib/postgrex/stream.ex
@@ -1,15 +1,39 @@
 defmodule Postgrex.Stream do
-  defstruct [:conn, :options, :params, :portal, :query, :ref, state: :bind, num_rows: 0, max_rows: 500]
+  defstruct [:conn, :query, :params, :options, max_rows: 500]
   @type t :: %Postgrex.Stream{}
 end
-
+defmodule Postgrex.Cursor do
+  defstruct [:portal, :ref, :connection_id, :max_rows]
+  @type t :: %Postgrex.Cursor{}
+end
+defmodule Postgrex.Copy do
+  defstruct [:portal, :ref, :connection_id, :query]
+  @type t :: %Postgrex.Copy{}
+end
 defmodule Postgrex.CopyData do
-  defstruct [:query, :params, :ref]
+  defstruct [:data, :ref]
+  @type t :: %Postgrex.CopyData{}
+end
+defmodule Postgrex.CopyDone do
+  defstruct [:ref]
+  @type t :: %Postgrex.CopyDone{}
 end
 
 defimpl Enumerable, for: Postgrex.Stream do
-  def reduce(stream, acc, fun) do
-    Stream.resource(fn() -> start(stream) end, &next/1, &close/1).(acc, fun)
+  alias Postgrex.Query
+  def reduce(%Postgrex.Stream{query: %Query{} = query} = stream, acc, fun) do
+    %Postgrex.Stream{conn: conn, params: params, options: opts} = stream
+    stream = %DBConnection.Stream{conn: conn, query: query, params: params,
+                                  opts: opts}
+    DBConnection.reduce(stream, acc, fun)
+  end
+  def reduce(%Postgrex.Stream{query: statement} = stream, acc, fun) do
+    %Postgrex.Stream{conn: conn, params: params, options: opts} = stream
+    query = %Query{name: "" , statement: statement}
+    opts = Keyword.put(opts, :function, :prepare_open)
+    stream = %DBConnection.PrepareStream{conn: conn, query: query,
+                                         params: params, opts: opts}
+    DBConnection.reduce(stream, acc, fun)
   end
 
   def member?(_, _) do
@@ -19,166 +43,98 @@ defimpl Enumerable, for: Postgrex.Stream do
   def count(_) do
     {:error, __MODULE__}
   end
-
-  defp start(stream) do
-    %Postgrex.Stream{conn: conn, params: params, options: options} = stream
-    stream = maybe_generate_portal(stream)
-    _ = Postgrex.execute!(conn, stream, params, options)
-    %Postgrex.Stream{stream | state: :out}
-  end
-
-  defp next(%Postgrex.Stream{state: :done} = stream) do
-    {:halt, stream}
-  end
-  defp next(stream) do
-    %Postgrex.Stream{conn: conn, params: params, options: options,
-                     state: state, num_rows: num_rows} = stream
-    case Postgrex.execute!(conn, stream, params, options) do
-      %Postgrex.Result{command: :stream, rows: rows} = result
-          when state in [:out, :suspended] ->
-        stream =  %Postgrex.Stream{stream | state: :suspended,
-                                            num_rows: num_rows + length(rows)}
-        {[result], stream}
-      %Postgrex.Result{command: :copy_stream} = result when state == :out ->
-        {[result], %Postgrex.Stream{stream | state: :copy_out}}
-      %Postgrex.Result{command: :copy_stream} = result when state == :copy_out ->
-        {[result], stream}
-      %Postgrex.Result{} = result ->
-        {[result], %Postgrex.Stream{stream | state: :done}}
-    end
-  end
-
-  defp close(%Postgrex.Stream{conn: conn, options: options} = stream) do
-    DBConnection.close(conn, stream, options)
-  end
-
-  defp maybe_generate_portal(%Postgrex.Stream{portal: nil} = stream) do
-    ref = make_ref()
-    %Postgrex.Stream{stream | portal: inspect(ref), ref: ref}
-  end
-  defp maybe_generate_portal(stream) do
-    %Postgrex.Stream{stream | ref: make_ref()}
-  end
 end
 
 defimpl Collectable, for: Postgrex.Stream do
-  def into(stream) do
-    %Postgrex.Stream{conn: conn, params: params, options: options} = stream
-    copy_stream = %Postgrex.Stream{stream | state: :copy_in, ref: make_ref()}
-    _ = Postgrex.execute!(conn, copy_stream, params, options)
-    {:ok, make_into(copy_stream, stream)}
+  alias Postgrex.Stream
+  alias Postgrex.Query
+
+  def into(%Stream{conn: %DBConnection{}} = stream) do
+    %Stream{conn: conn, query: query, params: params, options: opts} = stream
+    case query do
+      %Query{} ->
+        copy = Postgrex.execute!(conn, stream, params, opts)
+        {:ok, make_into(conn, stream, copy, opts)}
+      query ->
+        stream = %Stream{stream | query: %Query{name: "", statement: query}}
+        {_, copy} = DBConnection.prepare_execute!(conn, stream, params, opts)
+        {:ok, make_into(conn, stream, copy, opts)}
+    end
+  end
+  def into(_) do
+    msg = "data can only be copied to database inside a transaction"
+    raise ArgumentError, msg
   end
 
-  defp make_into(copy_stream, stream) do
-    %Postgrex.Stream{conn: conn, query: query, params: params, ref: ref,
-                     options: options} = copy_stream
-    copy = %Postgrex.CopyData{query: query, params: params, ref: ref}
+  defp make_into(conn, stream, %Postgrex.Copy{ref: ref} = copy, opts) do
     fn
       :ok, {:cont, data} ->
-        _ = Postgrex.execute!(conn, copy, data, options)
+        copy_data = %Postgrex.CopyData{ref: ref, data: data}
+        _ = Postgrex.execute!(conn, copy, copy_data, opts)
         :ok
-      :ok, :done ->
-        done_stream = %Postgrex.Stream{copy_stream | state: :copy_done}
-        Postgrex.execute!(conn, done_stream, params, options)
+      :ok, close when close in [:done, :halt] ->
+        Postgrex.execute!(conn, copy, %Postgrex.CopyDone{ref: ref}, opts)
         stream
-      :ok, :halt ->
-        fail_stream = %Postgrex.Stream{copy_stream | state: :copy_fail}
-        Postgrex.execute(conn, fail_stream, params, options)
     end
   end
 end
 
 defimpl DBConnection.Query, for: Postgrex.Stream do
-  require Postgrex.Messages
+  alias Postgrex.Stream
 
-  def parse(stream, _) do
-    raise "can not prepare #{inspect stream}"
-  end
-
-  def describe(stream, _) do
-    raise "can not describe #{inspect stream}"
+  def parse(%Stream{query: query} = stream, opts) do
+    %Stream{stream | query: DBConnection.Query.parse(query, opts)}
   end
 
-  def encode(%Postgrex.Stream{query: %Postgrex.Query{types: nil} = query}, _, _) do
-    raise ArgumentError, "query #{inspect query} has not been prepared"
+  def describe(%Stream{query: query} = stream, opts) do
+    %Stream{stream | query: DBConnection.Query.describe(query, opts)}
   end
 
-  def encode(%Postgrex.Stream{query: query, state: :bind}, params, opts) do
-    case query do
-      %Postgrex.Query{encoders: [_|_] = encoders, copy_data: true} ->
-        {encoders, [:copy_data]} = Enum.split(encoders, -1)
-        {params, _} = Enum.split(params, -1)
-        query = %Postgrex.Query{query | encoders: encoders}
-        DBConnection.Query.encode(query, params, opts)
-      %Postgrex.Query{} = query ->
-        DBConnection.Query.encode(query, params, opts)
-    end
+  def encode(%Stream{query: query}, params, opts) do
+    DBConnection.Query.encode(query, params, opts)
   end
 
-  def encode(%Postgrex.Stream{state: :out, query: query}, params, _) do
-    case query do
-      %Postgrex.Query{copy_data: true} ->
-        {_, [copy_data]} = Enum.split(params, -1)
-        try do
-          Postgrex.Messages.encode_msg(Postgrex.Messages.msg_copy_data(data: copy_data))
-        rescue
-          ArgumentError ->
-            raise ArgumentError,
-            "expected iodata to copy to database, got: " <> inspect(copy_data)
-        end
-      _ ->
-        []
-    end
-  end
-
-  def encode(%Postgrex.Stream{query: query, state: :copy_in}, params, opts) do
-    case query do
-      %Postgrex.Query{encoders: [_|_] = encoders, copy_data: true} ->
-        {encoders, [:copy_data]} = Enum.split(encoders, -1)
-        query = %Postgrex.Query{query | encoders: encoders}
-        DBConnection.Query.encode(query, params, opts)
-      %Postgrex.Query{} = query ->
-        raise ArgumentError, "query #{inspect query} has not enabled copy data"
-    end
-  end
-
-  def encode(%Postgrex.Stream{state: state}, _, _)
-      when state in [:suspended, :copy_out, :copy_done, :copy_fail] do
-    []
-  end
-
-  def decode(%Postgrex.Stream{state: state}, result, _)
-      when state in [:bind, :copy_in] do
-    result
-  end
-  def decode(%Postgrex.Stream{query: query}, result, opts) do
-    DBConnection.Query.decode(query, result, opts)
-  end
+  def decode(_, copy, _), do: copy
 end
 
-defimpl DBConnection.Query, for: Postgrex.CopyData do
-  require Postgrex.Messages
+defimpl DBConnection.Query, for: Postgrex.Copy do
+  alias Postgrex.Copy
+  import Postgrex.Messages
 
-  def parse(copy_data, _) do
-    raise "can not prepare #{inspect copy_data}"
+  def parse(copy, _) do
+    raise "can not prepare #{inspect copy}"
   end
 
-  def describe(copy_data, _) do
-    raise "can not describe #{inspect copy_data}"
+  def describe(copy, _) do
+    raise "can not describe #{inspect copy}"
   end
 
-  def encode(_, data, _) do
+  def encode(%Copy{ref: ref}, %Postgrex.CopyData{data: data, ref: ref}, _) do
     try do
-      Postgrex.Messages.encode_msg(Postgrex.Messages.msg_copy_data(data: data))
+      encode_msg(msg_copy_data(data: data))
     rescue
       ArgumentError ->
         raise ArgumentError,
           "expected iodata to copy to database, got: " <> inspect(data)
+    else
+      iodata ->
+        {:copy_data, iodata}
     end
   end
 
-  def decode(_, result, _) do
-    result
+  def encode(%Copy{ref: ref}, %Postgrex.CopyDone{ref: ref}, _) do
+    :copy_done
+  end
+
+  def decode(%Copy{query: query}, result, opts) do
+    case result do
+      %Postgrex.Result{command: :copy_stream} ->
+        result
+      %Postgrex.Result{command: :close} ->
+        result
+      _ ->
+        DBConnection.Query.decode(query, result, opts)
+    end
   end
 end
 
@@ -188,8 +144,8 @@ defimpl String.Chars, for: Postgrex.Stream do
   end
 end
 
-defimpl String.Chars, for: Postgrex.CopyData do
-  def to_string(%Postgrex.CopyData{query: query}) do
+defimpl String.Chars, for: Postgrex.Copy do
+  def to_string(%Postgrex.Copy{query: query}) do
     String.Chars.to_string(query)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Postgrex.Mixfile do
   defp deps do
     [{:ex_doc, "~> 0.12", only: :dev},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 1.0"},
+     {:db_connection, "~> 1.0", github: "fishcakez/db_connection", branch: "jf-stream"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Postgrex.Mixfile do
   defp deps do
     [{:ex_doc, "~> 0.12", only: :dev},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 1.0", github: "fishcakez/db_connection", branch: "jf-stream"},
+     {:db_connection, "~> 1.1"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
-  "db_connection": {:git, "https://github.com/fishcakez/db_connection.git", "ff9b3f6ecdf7553e4dfd664075ec607eed2c1c94", [branch: "jf-stream"]},
+  "db_connection": {:git, "https://github.com/fishcakez/db_connection.git", "fd699b3e54b2e80a38316849bbf1312cd49e8261", [branch: "jf-stream"]},
   "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
-  "db_connection": {:git, "https://github.com/fishcakez/db_connection.git", "fd699b3e54b2e80a38316849bbf1312cd49e8261", [branch: "jf-stream"]},
+  "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
-  "db_connection": {:hex, :db_connection, "1.0.0", "63c03e520d54886a66104d34e32397ba960db6e74b596ce221592c07d6a40d8d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
+  "db_connection": {:git, "https://github.com/fishcakez/db_connection.git", "ff9b3f6ecdf7553e4dfd664075ec607eed2c1c94", [branch: "jf-stream"]},
   "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -836,15 +836,9 @@ defmodule QueryTest do
     end
   end
 
-  test "COPY FROM STDIN with copy_data: false returns error", context do
+  test "COPY FROM STDIN  returns error", context do
     assert %Postgrex.Error{postgres: %{code: :query_canceled}} =
       query("COPY uniques FROM STDIN", [])
-  end
-
-  test "COPY FROM STDIN with copy_data: true but no copy data raises", context do
-    assert_raise ArgumentError,
-      ~r"parameters must be of length 1 with copy data as final parameter for query",
-      fn -> query("COPY uniques FROM STDIN", [], [copy_data: true]) end
   end
 
   test "COPY TO STDOUT", context do

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -425,21 +425,10 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
-  test "COPY FROM STDIN with copy_data: true", context do
-    transaction(fn(conn) ->
-      assert %Postgrex.Result{command: :copy, rows: nil, num_rows: 1} =
-        Postgrex.query!(conn, "COPY uniques FROM STDIN", ["2\n"], [copy_data: true])
-      assert %Postgrex.Result{rows: [[2]]} =
-        Postgrex.query!(conn, "SELECT * FROM uniques", [])
-      Postgrex.rollback(conn, :done)
-    end)
-  end
-
-  @tag mode: :transaction
   test "COPY FROM STDIN with copy_data: false, mode: :savepoint returns error", context do
     transaction(fn(conn) ->
       assert {:error, %Postgrex.Error{}} =
-        Postgrex.query(conn, "COPY uniques FROM STDIN", [], [mode: :savepoint, copy_data: false])
+        Postgrex.query(conn, "COPY uniques FROM STDIN", [], [mode: :savepoint])
       assert %Postgrex.Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
     end)
   end


### PR DESCRIPTION
* No longer require stream to be prepared before use
* Always bind params in a stream's start fun
* Always execute portal in a stream's first next fun
* Report `:num_rows` for each result in a stream
* Identify streams in logs with cursor/copy struct
* Drop support for `:copy_data` parameter