### PR TITLE
pass uuid as string

### DIFF
--- a/lib/postgrex/extensions/uuid.ex
+++ b/lib/postgrex/extensions/uuid.ex
@@ -9,6 +9,10 @@ defmodule Postgrex.Extensions.UUID do
     quote location: :keep do
       uuid when is_binary(uuid) and byte_size(uuid) == 16 ->
         [<<16 :: int32>> | uuid]
+      << a::64, 45::8, b::32, 45::8, c::32, 45::8, d::32, 45::8, e::96 >> ->
+        {:ok, uuid } = String.upcase(<< a::64, b::32, c::32, d::32, e::96 >>)
+          |> Base.decode16
+          [<<16 :: int32>> | uuid]
       other ->
         raise ArgumentError,
           Postgrex.Utils.encode_msg(other, "a binary of 16 bytes")

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -522,6 +522,11 @@ defmodule QueryTest do
     assert [[^uuid]] = query("SELECT $1::uuid", [uuid])
   end
 
+  test "encode stringified uuid", context do
+    uuid = <<160,238,188,153,156,11,78,248,187,109,107,185,189,56,10,17>>
+    assert [[^uuid]] = query("SELECT $1::uuid", ["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"])
+  end
+
   test "encode date", context do
     assert [[%Postgrex.Date{year: 1, month: 1, day: 1}]] =
            query("SELECT $1::date", [%Postgrex.Date{year: 1, month: 1, day: 1}])


### PR DESCRIPTION
As you can see in the tests, I'd like to pass my UUIDs also represented as a string.

This PR implements this feature :)

cheers