### PR TITLE
Test against elixir 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ env:
     - PGVERSION=9.6
 matrix:
   include:
-    - elixir: 1.4.0-rc.0
+    - elixir: 1.4.0
       otp_release: 19.1
       env: PGVERSION=9.6
-    - elixir: 1.4.0-rc.0
+    - elixir: 1.4.0
       otp_release: 18.3
       env: PGVERSION=9.6
 notifications:


### PR DESCRIPTION
Elixir 1.4 is now released in stable :tada: .

We can test against it instead of the release candidate.

Thanks!