### PR TITLE
Base implementation of Tsvector & Lexeme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ iex> Postgrex.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'hey
     enum            "ok" ***
     bit             << 1::1, 0::1 >>
     varbit          << 1::1, 0::1 >>
+    tsvector        [%Postgrex.Lexeme{positions: [{1, :A}], word: "a"}]
 
 \* [Decimal](http://github.com/ericmj/decimal)
 

--- a/lib/postgrex/builtins.ex
+++ b/lib/postgrex/builtins.ex
@@ -257,6 +257,23 @@ defmodule Postgrex.Circle do
 
   defstruct [
     center: nil,
-    radius: nil 
+    radius: nil
+  ]
+end
+
+defmodule Postgrex.Lexeme do
+  @moduledoc """
+  Struct for Postgres Lexeme (A Tsvector type is composed of multiple lexemes)
+
+  ## Fields
+    * `word`
+    * `positions`
+  """
+
+  @type t :: %__MODULE__{word: String.t, positions: [{pos_integer, :A | :B | :C | nil}]}
+
+  defstruct [
+    word: nil,
+    positions: nil
   ]
 end

--- a/lib/postgrex/extensions/tsvector.ex
+++ b/lib/postgrex/extensions/tsvector.ex
@@ -1,0 +1,62 @@
+defmodule Postgrex.Extensions.TSVector do
+  @moduledoc false
+
+  import Postgrex.BinaryUtils, warn: false
+  use Bitwise
+  use Postgrex.BinaryExtension, [send: "tsvectorsend"]
+
+  def encode(_) do
+    quote location: :keep do
+      values when is_list(values) ->
+        encoded_tsvectors = unquote(__MODULE__).encode_tsvector(values)
+        <<byte_size(encoded_tsvectors)::int32, encoded_tsvectors::binary>>
+      other ->
+        raise ArgumentError, Postgrex.Utils.encode_msg(other, "a list of tsvectors")
+    end
+  end
+
+  def decode(_) do
+    quote do
+      <<len::int32, value::binary-size(len)>> ->
+        <<nb_lexemes::int32, words::binary>> = value
+        unquote(__MODULE__).decode_tsvector_values(words)
+    end
+  end
+
+  ## Helpers
+
+  def encode_tsvector(values) do
+    <<length(values)::int32, encode_lexemes(values)::binary>>
+  end
+
+  defp encode_lexemes(values) do
+    Enum.map(values, fn(x) -> encode_positions(x) end) |> IO.iodata_to_binary
+  end
+
+  defp encode_positions(%Postgrex.Lexeme{word: word, positions: positions}) do
+    positions = Enum.map(positions, fn({position, weight}) -> <<encode_weight_binary(weight)::2, position::14>> end)
+    [[word, 0], <<length(positions)::16>>, positions]
+  end
+
+  def decode_tsvector_values("") do
+    []
+  end
+
+  def decode_tsvector_values(words) do
+    [word, <<positions_count::16, rest::binary>>] = :binary.split(words, [<<0>>])
+    positions_bytes = positions_count * 2
+    <<positions::binary-size(positions_bytes), remaining_data::binary>> = rest
+    positions = for <<weight::2, position::14 <- positions>>, do: {position, decode_weight(weight)}
+    [%Postgrex.Lexeme{word: word, positions: positions} | decode_tsvector_values(remaining_data)]
+  end
+
+  defp encode_weight_binary(:A) do 3 end
+  defp encode_weight_binary(:B) do 2 end
+  defp encode_weight_binary(:C) do 1 end
+  defp encode_weight_binary(nil) do 0 end
+
+  defp decode_weight(0), do: nil
+  defp decode_weight(1), do: :C
+  defp decode_weight(2), do: :B
+  defp decode_weight(3), do: :A
+end

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -36,6 +36,7 @@ defmodule Postgrex.Utils do
     Postgrex.Extensions.Timestamp,
     Postgrex.Extensions.TimestampTZ,
     Postgrex.Extensions.TimeTZ,
+    Postgrex.Extensions.TSVector,
     Postgrex.Extensions.UUID,
     Postgrex.Extensions.VoidBinary,
     Postgrex.Extensions.VoidText]

--- a/test/tsvector_test.exs
+++ b/test/tsvector_test.exs
@@ -1,0 +1,53 @@
+defmodule TsvectorTest do
+  use ExUnit.Case, async: true
+  import Postgrex.TestHelper
+  alias Postgrex, as: P
+
+  setup do
+    opts = [database: "postgrex_test", backoff_type: :stop]
+    {:ok, pid} = P.start_link(opts)
+    {:ok, [pid: pid]}
+  end
+
+  test "encode basic tsvector", context do
+    assert [["'1'"]] = query("SELECT $1::tsvector::text", [[%Postgrex.Lexeme{positions: [], word: "1"}]])
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [], word: "1"}]])
+    assert [["'1' 'hello'"]] = query("SELECT $1::tsvector::text", [[%Postgrex.Lexeme{positions: [], word: "1"}, %Postgrex.Lexeme{positions: [], word: "hello"}]])
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1"}, %Postgrex.Lexeme{positions: [], word: "hello"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [], word: "1"}, %Postgrex.Lexeme{positions: [], word: "hello"}]])
+  end
+
+  test "encode tsvector with positions", context do
+    assert [[[%Postgrex.Lexeme{positions: [{1, nil}], word: "1"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [{1, nil}], word: "1"}]])
+  end
+
+  test "encode tsvector with multiple positions", context do
+    assert [[[%Postgrex.Lexeme{positions: [{1, nil}, {2, nil}], word: "1"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [{1, nil}, {2, nil}], word: "1"}]])
+  end
+
+  test "encode tsvector with position and weight", context do
+    assert [[[%Postgrex.Lexeme{positions: [{1, :A}], word: "car"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [{1, :A}], word: "car"}]])
+    assert [[[%Postgrex.Lexeme{positions: [{1, :B}], word: "car"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [{1, :B}], word: "car"}]])
+    assert [[[%Postgrex.Lexeme{positions: [{1, :C}], word: "car"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [{1, :C}], word: "car"}]])
+  end
+
+  test "encode tsvector with multiple positions and weights", context do
+        assert [[[%Postgrex.Lexeme{positions: [{1, :A}, {2, nil}, {3, :B}], word: "car"}]]] = query("SELECT $1::tsvector", [[%Postgrex.Lexeme{positions: [{1, :A}, {2, nil}, {3, :B}], word: "car"}]])
+  end
+
+  test "decode basic tsvectors", context do
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1"}]]] = query("SELECT '1'::tsvector", [])
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1"}]]] = query("SELECT '1 '::tsvector", [])
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1"}]]] = query("SELECT ' 1'::tsvector", [])
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1"}]]] = query("SELECT ' 1 '::tsvector", [])
+  end
+
+  test "decode tsvectors with multiple elements", context do
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1"}, %Postgrex.Lexeme{positions: [], word: "2"}]]] = query("SELECT '1 2'::tsvector", [])
+    assert [[[%Postgrex.Lexeme{positions: [], word: "1 2"}]]] = query("SELECT '''1 2'''::tsvector", [])
+  end
+
+  test "decode tsvectors with multiple positions and elements", context do
+    assert [[[%Postgrex.Lexeme{positions: [{8, nil}], word: "a"}, %Postgrex.Lexeme{positions: [{1, nil}, {2, :C}, {3, :B}, {4, :A}, {5, nil}], word: "w"}]]] = query("SELECT '''w'':4A,3B,2C,1D,5 a:8'::tsvector", [])
+    assert [[[%Postgrex.Lexeme{positions: [{3, :A}], word: "a"}, %Postgrex.Lexeme{positions: [{2, :A}], word: "b"}]]] = query("SELECT 'a:3A b:2a'::tsvector", [])
+  end
+end


### PR DESCRIPTION
Hi,

This PR adds the support for Tsvector extensions.

It's usually used with full text search features that are built in inside postgres.

I wanted to be able to use manually written tsvector and tsquery directory from ecto. However, no extension was available for it, so I implemented one.

If this seems good, I will look to implement tsquery after this PR merges as both are usually used together...

Thanks!

Links to the official postgres doc : https://www.postgresql.org/docs/8.3/static/datatype-textsearch.html

The query tests are the ones from postgresql directly here : https://github.com/postgres/postgres/blob/89fcea1ace40bc025beea2758a80bcd56a319a6f/src/test/regress/sql/tstypes.sql