### PR TITLE
replace `unnest` with `generate_series` for compatibility

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -48,7 +48,13 @@ defmodule Postgrex.Types do
         [] ->
           ""
         _  ->
-          "WHERE t.oid NOT IN (SELECT unnest(ARRAY[#{Enum.join(oids, ",")}]))"
+          # equiv to `WHERE t.oid NOT IN (SELECT unnest(ARRAY[#{Enum.join(oids, ",")}]))`
+          """
+          WHERE t.oid NOT IN (
+            SELECT (ARRAY[#{Enum.join(oids, ",")}])[i]
+            FROM generate_series(1, #{length(oids)}) AS i
+          )
+          """
       end
 
     """

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -49,6 +49,7 @@ defmodule Postgrex.Types do
           ""
         _  ->
           # equiv to `WHERE t.oid NOT IN (SELECT unnest(ARRAY[#{Enum.join(oids, ",")}]))`
+          # `unnest` is not supported in redshift or postgres version prior to 8.4
           """
           WHERE t.oid NOT IN (
             SELECT (ARRAY[#{Enum.join(oids, ",")}])[i]


### PR DESCRIPTION
this restores compatibility with postgres versions prior to 8.4 and with redshift