### PR TITLE
Fix Postgrex.TypeModule.decode_tuple/5 pattern on Postgrex.Types.fetch/2 error return

### DIFF
--- a/lib/postgrex/type_module.ex
+++ b/lib/postgrex/type_module.ex
@@ -443,11 +443,11 @@ defmodule Postgrex.TypeModule do
             msg = "oid `#{oid}` was bootstrapped in text format and can not " <>
                   "be decoded inside an anonymous record"
             raise RuntimeError, msg
-          {:error, %TypeInfo{type: pg_type}} ->
+          {:error, %TypeInfo{type: pg_type}, _mod} ->
             msg = "type `#{pg_type}` can not be handled by the configured " <>
                   "extensions"
             raise RuntimeError, msg
-          {:error, nil} ->
+          {:error, nil, _mod} ->
             msg = "oid `#{oid}` was not bootstrapped and lacks type information"
             raise RuntimeError, msg
         end


### PR DESCRIPTION
`Postgrex.Types.fetch/2` error return is `{:error, TypeInfo.t | nil, module}` but `Postgrex.TypeModule.decode_tuple/5` would try to match to the error tuples `{:error, TypeInfo.t | nil}`, which would cause the following dialyzer error if you used `Postgrex.Types.define/3`:

```erlang
/home/lotte/projects/helm/deps/postgrex/lib/postgrex/type_module.ex:717:
  The pattern
    {'error', #{'__struct__':='Elixir.Postgrex.TypeInfo', 'type':=_@60}}
  can never match the type
    {'error', 'nil' | #{'__struct__':='Elixir.Postgrex.TypeInfo', ...}, atom()}

/home/lotte/projects/helm/deps/postgrex/lib/postgrex/type_module.ex:717:
  The pattern
    {'error', 'nil'}
  can never match the type
    {'error', 'nil' | #{'__struct__':='Elixir.Postgrex.TypeInfo', ...}, atom()}
```
_note that i edited the dialyzer output for readability_

After applying this PR, those warnings should not occur anymore