### PR TITLE
Simplify query in bootstrap_query method

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -48,13 +48,8 @@ defmodule Postgrex.Types do
         [] ->
           ""
         _  ->
-          # equiv to `WHERE t.oid NOT IN (SELECT unnest(ARRAY[#{Enum.join(oids, ",")}]))`
-          # `unnest` is not supported in redshift or postgres version prior to 8.4
           """
-          WHERE t.oid NOT IN (
-            SELECT (ARRAY[#{Enum.join(oids, ",")}])[i]
-            FROM generate_series(1, #{length(oids)}) AS i
-          )
+          WHERE t.oid NOT IN (#{Enum.join(oids, ",")})
           """
       end
 


### PR DESCRIPTION
Previously, bootstrap_query constructed a pretty complicated `SELECT`
statement that used a subquery, array and generate_series to exclude
rows whose oids were part of a predefined set. The query looked like
this:

```
SELECT ... WHERE t.oid NOT IN
  (SELECT (ARRAY[integer, literals, ...])[i]
   FROM generate_series(1, length_of_above_array))
```

This subquery is now replaced by a simpler list of integer literals,
which should be more performant and easier to understand.

Now, the query looks like this:

```
SELECT ... WHERE t.oid NOT IN (integer, literals, ...)
```

This should work in all versions of Postgres and Redshift, and works around a typing issue in CockroachDB: https://github.com/cockroachdb/cockroach/issues/14554