### PR TITLE
Avoid loading information about table-types at start

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -57,7 +57,14 @@ defmodule Postgrex.Types do
     filter_oids =
       case oids do
         [] ->
-          ""
+          # avoid loading information about table-types
+          # since there might be a lot them and most likely
+          # they won't be used; subsequent bootstrap will
+          # fetch them along with any other "new" types
+          """
+          WHERE (t.typrelid=0)
+          AND (t.typelem = 0 OR t.typelem NOT IN (SELECT oid FROM pg_catalog.pg_type WHERE typrelid!=0))
+          """
         _  ->
           # equiv to `WHERE t.oid NOT IN (SELECT unnest(ARRAY[#{Enum.join(oids, ",")}]))`
           # `unnest` is not supported in redshift or postgres version prior to 8.4


### PR DESCRIPTION
In one of our analytical databases, we have approx. 200k tables, this way we have more than 400k types in the result when you factor in array types automatically created by postgres. Therefore this bootstrap statement runs long enough to cause all other connection processes that are waiting in `fetch` to exit which, in turn, causes a restart of the pool's supervisor, thus type info is never obtained. While relaxing pool's `max_restarts` helps to mask the problem the bootstrap query still runs for tens of seconds and obstructs any useful work. 

Proposed change avoids loading potentially enormous chunk of data at start, but will load everything if a subsequent bootstrap is triggered (e.g by `prepare`)

In the case of our app it cuts initial bootstrap runtime from tens of seconds down to ~300ms and subsequent bootstrap queries are avoided. 