### PR TITLE
fixes custom range domains not supported natively

### DIFF
--- a/lib/postgrex/type_info.ex
+++ b/lib/postgrex/type_info.ex
@@ -15,7 +15,7 @@ defmodule Postgrex.TypeInfo do
     * `input` - The name of the "input" function (the function postgres uses
       to convert the type from its text format);
     * `array_elem` - If this is an array, the array elements' oid;
-    * `base_type` - If this is a domain type, the base type's oid;
+    * `base_type` - If this is a range type, the base type's oid;
     * `comp_elems` - If this is a composite type (record), the tuple
       elements' oid;
   """

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -49,7 +49,7 @@ defmodule Postgrex.Types do
     {rngsubtype, join_range} =
       if version >= {9, 2, 0} do
         {"coalesce(r.rngsubtype, 0)",
-         "LEFT JOIN pg_range AS r ON r.rngtypid = t.oid"}
+         "LEFT JOIN pg_range AS r ON r.rngtypid = t.oid OR (t.typbasetype <> 0 AND r.rngtypid = t.typbasetype)"}
       else
         {"0", ""}
       end


### PR DESCRIPTION
For example, `CREATE DOMAIN public.validity_range AS tsrange CONSTRAINT …` will create a domain based on `tsrange`, and without the change, the end user must create a custom Postgrex extension to make use of such a type.

In this change, the relevant bootstrap query used by the Type Server to determine base types within a range type is updated to take such domain types into account, so the native Range extension can be used. In addition, the comment within Type Info was updated to reflect the true nature of the underlying value.