### PR TITLE
fixes array domains not supported natively

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -65,6 +65,24 @@ defmodule QueryTest do
     assert [[[[0]]]] = query("SELECT ARRAY[ARRAY[0]]", [])
   end
 
+  test "decode array domain", context do
+    assert [[[1.0, 2.0, 3.0]]] =
+           query("SELECT ARRAY[1, 2, 3]::floats_domain", [])
+
+    assert [[[%Postgrex.Point{x: 1.0, y: 1.0}, %Postgrex.Point{x: 2.0, y: 2.0}, %Postgrex.Point{x: 3.0, y: 3.0}]]] =
+           query("SELECT ARRAY[point '1,1', point '2,2', point '3,3']::points_domain", [])
+  end
+
+  test "encode array domain", context do
+    floats = [1.0, 2.0, 3.0]
+    floats_string = "{1,2,3}"
+    assert [[^floats_string]] = query("SELECT $1::floats_domain::text", [floats])
+
+    points = [%Postgrex.Point{x: 1.0, y: 1.0}, %Postgrex.Point{x: 2.0, y: 2.0}, %Postgrex.Point{x: 3.0, y: 3.0}]
+    points_string = "{\"(1,1)\",\"(2,2)\",\"(3,3)\"}"
+    assert [[^points_string]] = query("SELECT $1::points_domain::text", [points])
+  end
+
   test "decode interval", context do
     assert [[%Postgrex.Interval{months: 0, days: 0, secs: 0}]] =
            query("SELECT interval '0'", [])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -54,6 +54,12 @@ DROP TYPE IF EXISTS missing_comp;
 CREATE TABLE altering (a int2);
 
 CREATE TABLE calendar (a timestamp without time zone, b timestamp with time zone);
+
+DROP DOMAIN IF EXISTS points_domain;
+CREATE DOMAIN points_domain AS point[] CONSTRAINT is_populated CHECK (COALESCE(array_length(VALUE, 1), 0) >= 1);
+
+DROP DOMAIN IF EXISTS floats_domain;
+CREATE DOMAIN floats_domain AS float[] CONSTRAINT is_populated CHECK (COALESCE(array_length(VALUE, 1), 0) >= 1);
 """
 
 sql_with_schemas = """


### PR DESCRIPTION
Array domains do not have `typelem` set in `pg_types` and are not supported out-of-the-box.

For example, this creates an array with a constraint ensuring that it has at least one element.

    CREATE DOMAIN public.page_quads AS polygon[]
       CONSTRAINT is_populated
       CHECK (COALESCE(array_length(VALUE, 1), 0) >= 1);

In this changeset, the bootstrap query used by the Type Server is updated again, so to support this use case without requiring a custom Postgrex extension.

Within the change, I have limited this to PostgreSQL 9.0 and upwards but the version check may actually be unnecessary.