### PR TITLE
Support application name

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -567,7 +567,6 @@ defmodule Postgrex.Protocol do
 
   defp startup(s, %{opts: opts} = status) do
     params = opts[:parameters] || []
-    params = Keyword.put_new(params, :fallback_application_name, "postgrex")
     user = Keyword.fetch!(opts, :username)
     database = Keyword.fetch!(opts, :database)
     msg = msg_startup(params: [user: user, database: database] ++ params)

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -567,6 +567,7 @@ defmodule Postgrex.Protocol do
 
   defp startup(s, %{opts: opts} = status) do
     params = opts[:parameters] || []
+    params = Keyword.put_new(params, :fallback_application_name, "postgrex")
     user = Keyword.fetch!(opts, :username)
     database = Keyword.fetch!(opts, :database)
     msg = msg_startup(params: [user: user, database: database] ++ params)

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -90,12 +90,10 @@ defmodule Postgrex.Utils do
 
   @spec default_app_name(Keyword.t) :: Keyword.t
   defp default_app_name(opts) do
-    if app_name = System.get_env("PGAPPNAME") do
-      params = Keyword.get(opts, :parameters, []) |> Keyword.put_new(:application_name, app_name)
-      Keyword.put(opts, :parameters, params)
-    else
-      opts
-    end
+    app_name = System.get_env("PGAPPNAME") || "postgrex"
+    params = Keyword.get(opts, :parameters) || [] 
+    params = Keyword.put_new(params, :application_name, app_name)
+    Keyword.put(opts, :parameters, params)
   end
 
   defp normalize_port(port) when is_binary(port), do: String.to_integer(port)

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -84,7 +84,18 @@ defmodule Postgrex.Utils do
     |> Keyword.put_new(:hostname, System.get_env("PGHOST") || "localhost")
     |> Keyword.update(:port, normalize_port(System.get_env("PGPORT")), &normalize_port/1)
     |> Keyword.put_new(:types, Postgrex.DefaultTypes)
+    |> default_app_name()
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  end
+
+  @spec default_app_name(Keyword.t) :: Keyword.t
+  defp default_app_name(opts) do
+    if app_name = System.get_env("PGAPPNAME") do
+      params = Keyword.get(ops, :parameters, []) |> Keyword.put_new(:application_name, app_name)
+      Keyword.put(opts, :parameters, params)
+    else
+      opts
+    end
   end
 
   defp normalize_port(port) when is_binary(port), do: String.to_integer(port)

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -91,7 +91,7 @@ defmodule Postgrex.Utils do
   @spec default_app_name(Keyword.t) :: Keyword.t
   defp default_app_name(opts) do
     if app_name = System.get_env("PGAPPNAME") do
-      params = Keyword.get(ops, :parameters, []) |> Keyword.put_new(:application_name, app_name)
+      params = Keyword.get(opts, :parameters, []) |> Keyword.put_new(:application_name, app_name)
       Keyword.put(opts, :parameters, params)
     else
       opts

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -65,12 +65,12 @@ defmodule LoginTest do
              password: "postgres", database: "postgrex_test" ]
 
     assert {:ok, pid} = P.start_link(opts)
-    assert "" == P.parameters(pid)["application_name"]
+    assert "postgres" == P.parameters(pid)["application_name"]
 
-    opts = opts ++ [parameters: [application_name: "postgrex"]]
+    opts = opts ++ [parameters: [application_name: "my_app"]]
     assert {:ok, pid} = P.start_link(opts)
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
-    assert "postgrex" == P.parameters(pid)["application_name"]
+    assert "my_app" == P.parameters(pid)["application_name"]
   end
 
   test "infinity timeout" do

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -65,7 +65,7 @@ defmodule LoginTest do
              password: "postgres", database: "postgrex_test" ]
 
     assert {:ok, pid} = P.start_link(opts)
-    assert "postgres" == P.parameters(pid)["application_name"]
+    assert "postgrex" == P.parameters(pid)["application_name"]
 
     opts = opts ++ [parameters: [application_name: "my_app"]]
     assert {:ok, pid} = P.start_link(opts)


### PR DESCRIPTION
It's very useful to set the application name so that pg_stat_activity will give us that clue as to what connections are created by what clients. This can currently be set by adding application_name to the parameters option in start_link. I propose to: 1) set fallback_application_name to "postgrex" so that if the user doesn't specify application_name there's at least that much of a clue as to where leaked connections are coming from, and, 2) support use of the "PGAPPNAME" env variable for consistency with other current PG tools.

I don't really know how you'd want to structure this, if you'd really want this logic split over two locations as I show here, or somehow consolidated. So I'm not really thinking of this as a literal pull request so much as a feature request illustrated with code ;-)
