### PR TITLE
Use simple queries for transactions

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -144,7 +144,7 @@ defmodule Postgrex.Protocol do
   @spec handle_prepare(Postgrex.Query.t | Postgrex.Stream.t, Keyword.t, state) ::
     {:ok, Postgrex.Query.t, state} |
     {:error, %ArgumentError{} | Postgrex.Error.t, state} |
-    {:error | :disconnect, %RuntimeError{}, state} |
+    {:disconnect, %RuntimeError{}, state} |
     {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_prepare(%Query{} = query, _, %{postgres: {_, _}} = s) do
     lock_error(s, :prepare, query)
@@ -204,7 +204,7 @@ defmodule Postgrex.Protocol do
   @spec handle_execute(Postgrex.Query.t, list, Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
     {:error, %ArgumentError{} | Postgrex.Error.t, state} |
-    {:error | :disconnect, %RuntimeError{}, state} |
+    {:disconnect, %RuntimeError{}, state} |
     {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_execute(%Query{ref: ref, name: name} = query, params, opts,
       %{postgres: {_, ref}} = s) do
@@ -239,7 +239,7 @@ defmodule Postgrex.Protocol do
   @spec handle_execute(Postgrex.Stream.t, list, Keyword.t, state) ::
     {:ok, Copy.t, state} |
     {:error, %ArgumentError{} | Postgrex.Error.t, state} |
-    {:error | :disconnect, %RuntimeError{}, state} |
+    {:disconnect, %RuntimeError{}, state} |
     {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_execute(%Stream{query: query}, params, opts, s) do
     %{connection_id: connection_id} = s
@@ -252,7 +252,7 @@ defmodule Postgrex.Protocol do
                        Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
     {:error, %ArgumentError{} | Postgrex.Error.t, state} |
-    {:error | :disconnect, %RuntimeError{}, state} |
+    {:disconnect, %RuntimeError{}, state} |
     {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_execute(%Copy{ref: ref} = copy, {:copy_data, iodata}, opts, s) do
     case s do
@@ -281,7 +281,7 @@ defmodule Postgrex.Protocol do
   @spec handle_close(Postgrex.Query.t | Postgrex.Stream.t, Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
     {:error, %ArgumentError{} | Postgrex.Error.t, state} |
-    {:error | :disconnect, %RuntimeError{}, state} |
+    {:disconnect, %RuntimeError{}, state} |
     {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_close(%Query{ref: ref} = query, opts, %{postgres: {_, ref}} = s) do
     status = %{notify: notify(opts), mode: mode(opts)}
@@ -301,7 +301,7 @@ defmodule Postgrex.Protocol do
   @spec handle_declare(Postgrex.Query.t, list, Keyword.t, state) ::
     {:ok, Postgrex.Cursor.t, state} |
     {:error, %ArgumentError{} | Postgrex.Error.t, state} |
-    {:error | :disconnect, %RuntimeError{}, state} |
+    {:disconnect, %RuntimeError{}, state} |
     {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_declare(query, params, opts, s) do
     %{connection_id: connection_id} = s
@@ -1224,7 +1224,7 @@ defmodule Postgrex.Protocol do
   defp lock_error(s, fun, query) do
     msg = "connection is locked copying to or from the database and " <>
       "can not #{fun} #{inspect query}"
-    {:error, RuntimeError.exception(msg), s}
+    {:disconnect, RuntimeError.exception(msg), s}
   end
 
   defp transaction_error(s, status) do

--- a/lib/postgrex/stream.ex
+++ b/lib/postgrex/stream.ex
@@ -1,6 +1,6 @@
 defmodule Postgrex.Stream do
   @moduledoc false
-  defstruct [:conn, :query, :params, :options, max_rows: 500]
+  defstruct [:conn, :query, :params, :options]
   @type t :: %Postgrex.Stream{}
 end
 defmodule Postgrex.Cursor do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -861,23 +861,6 @@ defmodule QueryTest do
       fn -> execute(%Postgrex.Query{name: "hi", statement: "BEGIN"}, []) end
   end
 
-  test "raise when trying to prepare or close reserved query", context do
-    assert_raise ArgumentError, ~r/uses reserved name/,
-      fn -> prepare("POSTGREX_BEGIN", "COMMIT") end
-
-    query = prepare("BEGIN", "BEGIN")
-    query = %Postgrex.Query{query | name: "POSTGREX_BEGIN"}
-
-    assert_raise ArgumentError, ~r/uses reserved name/, fn -> close(query) end
-  end
-
-  test "raise when trying to execute reserved query", context do
-    query = prepare("", "BEGIN")
-
-    assert_raise ArgumentError, ~r/uses reserved name/,
-      fn -> execute(%{query | name: "POSTGREX_COMMIT"}, []) end
-  end
-
   test "query struct interpolates to statement" do
     assert "#{%Postgrex.Query{statement: "BEGIN"}}" == "BEGIN"
   end

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -146,15 +146,6 @@ defmodule StreamTest do
     end)
   end
 
-  test "raise when trying to stream reserved query", context do
-    query = prepare("", "BEGIN")
-
-    transaction(fn(conn) ->
-      assert_raise ArgumentError, ~r/uses reserved name/,
-        fn -> stream(%{query | name: "POSTGREX_COMMIT"}, []) |> Enum.take(1) end
-    end)
-  end
-
   test "stream struct interpolates to statement", context do
     query = prepare("", "BEGIN")
     transaction(fn(conn) ->
@@ -538,16 +529,6 @@ defmodule StreamTest do
     transaction(fn(conn) ->
       stream = stream(query, [])
       assert_raise ArgumentError, ~r/has not been prepared/,
-        fn -> Enum.into(["5\n"], stream) end
-    end)
-  end
-
-  test "raise when trying to COPY FROM reserved query", context do
-    query = prepare("", "COPY uniques FROM STDIN")
-
-    transaction(fn(conn) ->
-      stream = stream(%Postgrex.Query{query | name: "POSTGREX_BEGIN"}, [])
-      assert_raise ArgumentError, ~r/uses reserved name/,
         fn -> Enum.into(["5\n"], stream) end
     end)
   end

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -346,17 +346,11 @@ defmodule StreamTest do
     end)
   end
 
-  test "stream from COPY FROM STDIN", context do
+  test "stream from COPY FROM STDIN disconnects", context do
     query = prepare("", "COPY uniques FROM STDIN")
     transaction(fn(conn) ->
-      assert_raise Postgrex.Error, ~r"\(query_canceled\)",
+      assert_raise RuntimeError, ~r"trying to copy in but no copy data to send",
         fn() -> stream(query, []) |> Enum.to_list() end
-      Postgrex.rollback(conn, :done)
-    end)
-
-    transaction(fn(conn) ->
-      assert_raise Postgrex.Error, ~r"\(protocol_violation\)",
-        fn() -> stream(query, [], [mode: :savepoint]) |> Enum.to_list() end
       Postgrex.rollback(conn, :done)
     end)
   end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -240,8 +240,8 @@ defmodule TransactionTest do
       assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
         P.query(conn, "INSERT INTO uniques VALUES (1), (1)", [])
 
-      assert {:error, %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}} =
-        P.query(conn, "SELECT 42", [], [mode: :savepoint])
+      assert_raise DBConnection.TransactionError, "transaction is aborted",
+        fn -> P.query(conn, "SELECT 42", [], [mode: :savepoint]) end
 
       assert {:error, %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}} =
         P.query(conn, "SELECT 42", [])


### PR DESCRIPTION
Use the same transaction/savepoint messages whether using named queries or otherwise. The control flow is refactored to be more explicit by using with special form.

Closes #323.