### PR TITLE
Try to cast params if param types change

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -258,6 +258,8 @@ defmodule Postgrex do
     case DBConnection.execute(conn, query, params, defaults(opts)) do
       {:ok, _} = ok ->
         ok
+      {:ok, _query, result} ->
+        {:ok, result}
       {:error, %Postgrex.Error{}} = error ->
         error
       {:error, err} ->
@@ -269,9 +271,15 @@ defmodule Postgrex do
   Runs an (extended) prepared query and returns the result or raises
   `Postgrex.Error` if there was an error. See `execute/4`.
   """
-  @spec execute!(conn, Postgrex.Query.t, list, Keyword.t) :: Postgrex.Result.t
+  @spec execute!(conn, Postgrex.Query.t, list, Keyword.t) ::
+    Postgrex.Result.t
   def execute!(conn, query, params, opts \\ []) do
-    DBConnection.execute!(conn, query, params, defaults(opts))
+    case DBConnection.execute!(conn, query, params, defaults(opts)) do
+      {_query, result} ->
+        result
+      result ->
+        result
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Postgrex.Mixfile do
     [{:ex_doc, "~> 0.14", only: :docs},
      {:poison, ">= 0.0.0", only: :test},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 1.1", github: "elixir-ecto/db_connection", ref: "24473f6"},
+     {:db_connection, "~> 1.1", github: "elixir-ecto/db_connection", ref: "4947966"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "db_connection": {:git, "https://github.com/elixir-ecto/db_connection.git", "24473f673760ded3636f3086e0e2d768605ea1e8", [ref: "24473f6"]},
+  "db_connection": {:git, "https://github.com/elixir-ecto/db_connection.git", "49479667131329376adf1c2c0e9a16bcf470aa84", [ref: "4947966"]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Casting params when preparing a query with known types will prevent errors when types have changed as we can use the encode terms for the params, the new types to decode the result and get a refreshed query struct back.

The only case when we can't handle it gracefully (no error) is if we can't cast the param types from old to new. This will produce a native Postgrex.Error so we no longer have to create a custom error and relies on the database as source. However in that situation a user should be using a new query. This shouldn't occur for Ecto as it should require a schema code reload to get into such a state. Fortunately Ecto will be able to handle the error and reset the query cache in a similar way to when the types change and the query has already been prepared.

Depends on #347.