### PR TITLE
Only test decode binary on OTP <= 19

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -331,12 +331,13 @@ defmodule QueryTest do
 
   @tag min_pg_version: "9.0"
   test "hstore copies binaries by default", context do
-    text = "hello world"
+    # For OTP 20+ refc binaries up to 64 bytes might be copied during a GC
+    text = String.duplicate("hello world", 6)
     assert [[bin]] = query("SELECT $1::text", [text])
     assert :binary.referenced_byte_size(bin) == byte_size(text)
 
-    assert [[%{"hello" => world}]] = query("SELECT $1::hstore", [%{"hello" => "world"}])
-    assert :binary.referenced_byte_size(world) == byte_size("world")
+    assert [[%{"hello" => value}]] = query("SELECT $1::hstore", [%{"hello" => text}])
+    assert :binary.referenced_byte_size(value) == byte_size(text)
   end
 
   test "decode bit string", context do

--- a/test/type_module_test.exs
+++ b/test/type_module_test.exs
@@ -23,6 +23,10 @@ defmodule TypeModuleTest do
 
   @tag min_pg_version: "9.0"
   test "hstore references binaries when decode_binary: :reference", context do
+    text = "hello world"
+    assert [[bin]] = query("SELECT $1::text", [text])
+    assert :binary.referenced_byte_size(bin) > byte_size(text)
+
     assert [[%{"hello" => world}]] = query("SELECT $1::hstore", [%{"hello" => "world"}])
     assert :binary.referenced_byte_size(world) > byte_size("world")
   end

--- a/test/type_module_test.exs
+++ b/test/type_module_test.exs
@@ -23,12 +23,13 @@ defmodule TypeModuleTest do
 
   @tag min_pg_version: "9.0"
   test "hstore references binaries when decode_binary: :reference", context do
-    text = "hello world"
+    # For OTP 20+ refc binaries up to 64 bytes might be copied during a GC
+    text = String.duplicate("hello world", 6)
     assert [[bin]] = query("SELECT $1::text", [text])
     assert :binary.referenced_byte_size(bin) > byte_size(text)
 
-    assert [[%{"hello" => world}]] = query("SELECT $1::hstore", [%{"hello" => "world"}])
-    assert :binary.referenced_byte_size(world) > byte_size("world")
+    assert [[%{"hello" => value}]] = query("SELECT $1::hstore", [%{"hello" => text}])
+    assert :binary.referenced_byte_size(value) > byte_size(text)
   end
 
   test "decode null with custom mapping", context do


### PR DESCRIPTION
This is an awkward situation as we are liberally copying (against documented advice) and in OTP 20 the binary GC is much improved. Therefore we add performance penalty in OTP 20 that shouldn't be required(?). I am unsure if we can deprecate the feature once we are OTP 20+ because I don't know if the leaks could still occur.