### PR TITLE
Use system env during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir: 1.4.5
-otp_release: 19.3
+otp_release: 18.3
 cache: apt
 before_install:
   - sudo service postgresql stop

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -3,105 +3,84 @@ defmodule LoginTest do
   alias Postgrex, as: P
   import ExUnit.CaptureLog
 
-  test "login cleartext password" do
-    Process.flag(:trap_exit, true)
+  setup do
+    {:ok, [options: [database: "postgrex_test", backoff_type: :stop]]}
+  end
 
-    opts = [ hostname: "localhost", username: "postgrex_cleartext_pw",
-             password: "postgrex_cleartext_pw", database: "postgres" ]
-    assert {:ok, pid} = P.start_link(opts)
+  test "login cleartext password", context do
+    Process.flag(:trap_exit, true)
+    opts = [ username: "postgrex_cleartext_pw", password: "postgrex_cleartext_pw" ]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
-  test "login cleartext password failure" do
+  test "login cleartext password failure", context do
     Process.flag(:trap_exit, true)
-
-    opts = [ hostname: "localhost", username: "postgrex_cleartext_pw",
-             password: "wrong_password", database: "postgres",
-             backoff_type: :stop]
-
+    opts = [ username: "postgrex_cleartext_pw", password: "wrong_password" ]
     capture_log fn ->
-      assert {:ok, pid} = P.start_link(opts)
+      assert {:ok, pid} = P.start_link(opts ++ context[:options])
       assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: code}}, [_|_]}}
       assert code in [:invalid_authorization_specification, :invalid_password]
     end
   end
 
-  test "login md5 password" do
+  test "login md5 password", context do
     Process.flag(:trap_exit, true)
-
-    opts = [ hostname: "localhost", username: "postgrex_md5_pw",
-             password: "postgrex_md5_pw", database: "postgres" ]
-    assert {:ok, pid} = P.start_link(opts)
+    opts = [ username: "postgrex_md5_pw", password: "postgrex_md5_pw" ]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
-  test "login md5 password failure" do
+  test "login md5 password failure", context do
     Process.flag(:trap_exit, true)
-
-    opts = [ hostname: "localhost", username: "postgrex_md5_pw",
-             password: "wrong_password", database: "postgres",
-             backoff_type: :stop]
-
+    opts = [ username: "postgrex_md5_pw", password: "wrong_password" ]
     capture_log fn ->
-      assert {:ok, pid} = P.start_link(opts)
+      assert {:ok, pid} = P.start_link(opts ++ context[:options])
       assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: code}}, [_|_]}}
       assert code in [:invalid_authorization_specification, :invalid_password]
     end
   end
 
-  test "parameters" do
-    opts = [ hostname: "localhost", username: "postgres",
-             password: "postgres", database: "postgrex_test" ]
-
-    assert {:ok, pid} = P.start_link(opts)
+  test "parameters", context do
+    assert {:ok, pid} = P.start_link(context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
 
     assert String.match? P.parameters(pid)["server_version"], ~R"^\d+\.\d+"
   end
 
   @tag min_pg_version: "9.0"
-  test "setting parameters" do
-    opts = [ hostname: "localhost", username: "postgres",
-             password: "postgres", database: "postgrex_test" ]
-
-    assert {:ok, pid} = P.start_link(opts)
+  test "setting parameters", context do
+    assert {:ok, pid} = P.start_link(context[:options])
     assert "" == P.parameters(pid)["application_name"]
-
-    opts = opts ++ [parameters: [application_name: "postgrex"]]
-    assert {:ok, pid} = P.start_link(opts)
+    opts = [parameters: [application_name: "postgrex"]]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
     assert "postgrex" == P.parameters(pid)["application_name"]
   end
 
-  test "infinity timeout" do
-    opts = [ hostname: "localhost", username: "postgres",
-             password: "postgres", database: "postgrex_test",
-             timeout: :infinity ]
-
-    assert {:ok, pid} = P.start_link(opts)
+  test "infinity timeout", context do
+    opts = [ timeout: :infinity ]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
   @tag :ssl
-  test "ssl" do
-    opts = [ hostname: "localhost", username: "postgres",
-             password: "postgres", database: "postgrex_test",
-             ssl: true ]
-    assert {:ok, pid} = P.start_link(opts)
+  test "ssl", context do
+    opts = [ ssl: true ]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
-  test "env var defaults" do
-    opts = [ database: "postgrex_test" ]
-    assert {:ok, pid} = P.start_link(opts)
+  test "env var defaults", context do
+    assert {:ok, pid} = P.start_link(context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
-  test "env var default db name" do
+  test "env var default db name", context do
     previous_db_name = System.get_env("PGDATABASE")
     try do
       set_db_name("postgrex_test")
-      opts = []
+      opts = [] ++ Keyword.delete(context[:options], :database)
       assert {:ok, pid} = P.start_link(opts)
       assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
     after
@@ -109,14 +88,14 @@ defmodule LoginTest do
     end
   end
 
-  test "env var default db name (no such database)" do
+  test "env var default db name (no such database)", context do
     previous_db_name = System.get_env("PGDATABASE")
     try do
       set_db_name("doesntexist")
       Process.flag(:trap_exit, true)
 
       capture_log fn ->
-        opts = [ sync_connect: true, backoff_type: :stop ]
+        opts = [ sync_connect: true ] ++ Keyword.delete(context[:options], :database)
         assert {:error, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}} =
                P.start_link(opts)
       end
@@ -125,76 +104,71 @@ defmodule LoginTest do
     end
   end
 
-  test "sync connect" do
-    opts = [ database: "postgres", sync_connect: true ]
-    assert {:ok, pid} = P.start_link(opts)
+  test "sync connect", context do
+    opts = [ sync_connect: true ]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
-  test "non existent database" do
+  test "non existent database", context do
     Process.flag(:trap_exit, true)
 
     capture_log fn ->
-      opts = [ database: "doesntexist", sync_connect: true ,
-               backoff_type: :stop ]
+      opts = [ database: "doesntexist", sync_connect: true ]
       assert {:error, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}} =
-             P.start_link(opts)
+             P.start_link(opts ++ context[:options])
 
       assert_receive {:EXIT, _, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}}
     end
 
     capture_log fn ->
-      opts = [ database: "doesntexist", backoff_type: :stop ]
-      {:ok, pid} = P.start_link(opts)
+      opts = [ database: "doesntexist" ]
+      {:ok, pid} = P.start_link(opts ++ context[:options])
       assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}}
     end
   end
 
-  test "non-existent domain" do
+  test "non-existent domain", context do
     Process.flag(:trap_exit, true)
-    opts = [ hostname: "doesntexist", port: 5432, username: "postgrex_cleartext_pw",
-             password: "password", database: "postgres", backoff_type: :stop ]
+    opts = [ hostname: "doesntexist", sync_connect: true, connect_timeout: 100 ]
 
     capture_log fn ->
-      assert {:ok, pid} = P.start_link(opts)
-      assert_receive {:EXIT, ^pid, {%DBConnection.ConnectionError{message: message}, [_|_]}}
-      assert message == "tcp connect (doesntexist:5432): non-existing domain - :nxdomain"
+      assert {:error, {%DBConnection.ConnectionError{message: message}, [_|_]}} =
+        P.start_link(opts ++ context[:options])
+      assert_receive {:EXIT, _, {%DBConnection.ConnectionError{message: ^message}, [_|_]}}
+      assert message =~ ~r"tcp connect \(doesntexist:\d+\): non-existing domain - :nxdomain"
     end
   end
 
-  test "unix domain socket connection" do
-    Process.flag(:trap_exit, true)
+  @tag :unix
+  test "unix domain socket connection", context do
     socket = System.get_env("PG_SOCKET_DIR") || "/tmp"
 
-    opts = [ socket: socket, port: 5432, username: "postgres",
-             password: "postgres", database: "postgres", backoff_type: :stop ]
-
+    opts = [ socket: socket ]
     capture_log fn ->
-      assert {:ok, pid} = P.start_link(opts)
+      assert {:ok, pid} = P.start_link(opts ++ context[:options])
       assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
     end
   end
 
-  test "non-existent unix domain socket" do
+  @tag :unix
+  test "non-existent unix domain socket", context do
     Process.flag(:trap_exit, true)
-    opts = [ socket: "/not_a_dir", port: 5432, username: "postgres",
-             password: "postgres", database: "postgres", backoff_type: :stop ]
+    opts = [ socket: "/doesntexist" ]
 
     capture_log fn ->
-      assert {:ok, pid} = P.start_link(opts)
+      assert {:ok, pid} = P.start_link(opts ++ context[:options])
       assert_receive {:EXIT, ^pid, {%DBConnection.ConnectionError{message: message}, [_|_]}}
-      assert message == "tcp connect (/not_a_dir/.s.PGSQL.5432): no such file or directory - :enoent"
+      assert message =~ ~r"tcp connect \(/doesntexist/.s.PGSQL.\d+\): no such file or directory - :enoent"
     end
   end
 
-  test "after connect function run" do
+  test "after connect function run", context do
     parent = self()
     after_connect = fn(conn) -> send(parent, P.query(conn, "SELECT 42", [])) end
-    opts = [ hostname: "localhost", username: "postgres",
-             password: "postgres", database: "postgrex_test",
-             after_connect: after_connect ]
+    opts = [ after_connect: after_connect ]
 
-    {:ok, _} = P.start_link(opts)
+    {:ok, _} = P.start_link(opts ++ context[:options])
 
     assert_receive {:ok, %Postgrex.Result{}}
   end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -9,14 +9,14 @@ defmodule LoginTest do
 
   test "login cleartext password", context do
     Process.flag(:trap_exit, true)
-    opts = [ username: "postgrex_cleartext_pw", password: "postgrex_cleartext_pw" ]
+    opts = [username: "postgrex_cleartext_pw", password: "postgrex_cleartext_pw"]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
   test "login cleartext password failure", context do
     Process.flag(:trap_exit, true)
-    opts = [ username: "postgrex_cleartext_pw", password: "wrong_password" ]
+    opts = [username: "postgrex_cleartext_pw", password: "wrong_password"]
     capture_log fn ->
       assert {:ok, pid} = P.start_link(opts ++ context[:options])
       assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: code}}, [_|_]}}
@@ -26,14 +26,14 @@ defmodule LoginTest do
 
   test "login md5 password", context do
     Process.flag(:trap_exit, true)
-    opts = [ username: "postgrex_md5_pw", password: "postgrex_md5_pw" ]
+    opts = [username: "postgrex_md5_pw", password: "postgrex_md5_pw"]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
   test "login md5 password failure", context do
     Process.flag(:trap_exit, true)
-    opts = [ username: "postgrex_md5_pw", password: "wrong_password" ]
+    opts = [username: "postgrex_md5_pw", password: "wrong_password"]
     capture_log fn ->
       assert {:ok, pid} = P.start_link(opts ++ context[:options])
       assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: code}}, [_|_]}}
@@ -59,14 +59,14 @@ defmodule LoginTest do
   end
 
   test "infinity timeout", context do
-    opts = [ timeout: :infinity ]
+    opts = [timeout: :infinity]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
   @tag :ssl
   test "ssl", context do
-    opts = [ ssl: true ]
+    opts = [ssl: true]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
@@ -95,7 +95,7 @@ defmodule LoginTest do
       Process.flag(:trap_exit, true)
 
       capture_log fn ->
-        opts = [ sync_connect: true ] ++ Keyword.delete(context[:options], :database)
+        opts = [sync_connect: true] ++ Keyword.delete(context[:options], :database)
         assert {:error, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}} =
                P.start_link(opts)
       end
@@ -105,7 +105,7 @@ defmodule LoginTest do
   end
 
   test "sync connect", context do
-    opts = [ sync_connect: true ]
+    opts = [sync_connect: true]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
@@ -114,7 +114,7 @@ defmodule LoginTest do
     Process.flag(:trap_exit, true)
 
     capture_log fn ->
-      opts = [ database: "doesntexist", sync_connect: true ]
+      opts = [database: "doesntexist", sync_connect: true]
       assert {:error, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}} =
              P.start_link(opts ++ context[:options])
 
@@ -122,7 +122,7 @@ defmodule LoginTest do
     end
 
     capture_log fn ->
-      opts = [ database: "doesntexist" ]
+      opts = [database: "doesntexist"]
       {:ok, pid} = P.start_link(opts ++ context[:options])
       assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}}
     end
@@ -130,7 +130,7 @@ defmodule LoginTest do
 
   test "non-existent domain", context do
     Process.flag(:trap_exit, true)
-    opts = [ hostname: "doesntexist", sync_connect: true, connect_timeout: 100 ]
+    opts = [hostname: "doesntexist", sync_connect: true, connect_timeout: 100]
 
     capture_log fn ->
       assert {:error, {%DBConnection.ConnectionError{message: message}, [_|_]}} =
@@ -144,7 +144,7 @@ defmodule LoginTest do
   test "unix domain socket connection", context do
     socket = System.get_env("PG_SOCKET_DIR") || "/tmp"
 
-    opts = [ socket: socket ]
+    opts = [socket: socket]
     capture_log fn ->
       assert {:ok, pid} = P.start_link(opts ++ context[:options])
       assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
@@ -154,7 +154,7 @@ defmodule LoginTest do
   @tag :unix
   test "non-existent unix domain socket", context do
     Process.flag(:trap_exit, true)
-    opts = [ socket: "/doesntexist" ]
+    opts = [socket: "/doesntexist"]
 
     capture_log fn ->
       assert {:ok, pid} = P.start_link(opts ++ context[:options])
@@ -166,7 +166,7 @@ defmodule LoginTest do
   test "after connect function run", context do
     parent = self()
     after_connect = fn(conn) -> send(parent, P.query(conn, "SELECT 42", [])) end
-    opts = [ after_connect: after_connect ]
+    opts = [after_connect: after_connect]
 
     {:ok, _} = P.start_link(opts ++ context[:options])
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,10 +6,11 @@ pg_version =
       {String.to_integer(major), String.to_integer(minor || "0")}
   end
 
+otp_release = :erlang.system_info(:otp_release) |> List.to_integer()
 unix_socket_dir = System.get_env("PG_SOCKET_DIR") || "/tmp"
 port = System.get_env("PGPORT") || "5432"
 unix_socket_path = Path.join(unix_socket_dir, ".s.PGSQL.#{port}")
-unix_exclude = if File.exists?(unix_socket_path) do
+unix_exclude = if otp_release >= 20 and File.exists?(unix_socket_path) do
   []
 else
   [unix: true]

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,7 @@ pg_version =
       {String.to_integer(major), String.to_integer(minor || "0")}
   end
 
-otp_release = :erlang.system_info(:otp_release) |> List.to_integer()
+otp_release = :otp_release |> :erlang.system_info() |> List.to_integer()
 unix_socket_dir = System.get_env("PG_SOCKET_DIR") || "/tmp"
 port = System.get_env("PGPORT") || "5432"
 unix_socket_path = Path.join(unix_socket_dir, ".s.PGSQL.#{port}")
@@ -15,7 +15,6 @@ unix_exclude = if otp_release >= 20 and File.exists?(unix_socket_path) do
 else
   [unix: true]
 end
-
 
 notify_exclude = if pg_version == {8, 4} do
   [requires_notify_payload: true]
@@ -110,7 +109,7 @@ cmds =
       cmds
 end
 
-psql_env = System.get_env() |> Map.put_new("PGUSER", "postgres")
+psql_env = Map.put_new(System.get_env(), "PGUSER", "postgres")
 
 Enum.each(cmds, fn args ->
   {output, status} = System.cmd("psql", args, stderr_to_stdout: true, env: psql_env)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,17 @@ pg_version =
       {String.to_integer(major), String.to_integer(minor || "0")}
   end
 
-exclude = if pg_version == {8, 4} do
+unix_socket_dir = System.get_env("PG_SOCKET_DIR") || "/tmp"
+port = System.get_env("PGPORT") || "5432"
+unix_socket_path = Path.join(unix_socket_dir, ".s.PGSQL.#{port}")
+unix_exclude = if File.exists?(unix_socket_path) do
+  []
+else
+  [unix: true]
+end
+
+
+notify_exclude = if pg_version == {8, 4} do
   [requires_notify_payload: true]
 else
   []
@@ -21,7 +31,7 @@ version_exclusions =
     []
   end
 
-ExUnit.start exclude: version_exclusions ++ exclude
+ExUnit.start exclude: version_exclusions ++ notify_exclude ++ unix_exclude
 
 {:ok, _} = :application.ensure_all_started(:crypto)
 
@@ -76,12 +86,12 @@ CREATE SCHEMA test;
 """
 
 cmds = [
-  ["-U", "postgres", "-c", "DROP DATABASE IF EXISTS postgrex_test;"],
-  ["-U", "postgres", "-c", "DROP DATABASE IF EXISTS postgrex_test_with_schemas;"],
-  ["-U", "postgres", "-c", "CREATE DATABASE postgrex_test TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"],
-  ["-U", "postgres", "-c", "CREATE DATABASE postgrex_test_with_schemas TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"],
-  ["-U", "postgres", "-d", "postgrex_test", "-c", sql],
-  ["-U", "postgres", "-d", "postgrex_test_with_schemas", "-c", sql_with_schemas]
+  ["-c", "DROP DATABASE IF EXISTS postgrex_test;"],
+  ["-c", "DROP DATABASE IF EXISTS postgrex_test_with_schemas;"],
+  ["-c", "CREATE DATABASE postgrex_test TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"],
+  ["-c", "CREATE DATABASE postgrex_test_with_schemas TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"],
+  ["-d", "postgrex_test", "-c", sql],
+  ["-d", "postgrex_test_with_schemas", "-c", sql_with_schemas]
 ]
 
 pg_path = System.get_env("PGPATH")
@@ -89,18 +99,20 @@ pg_path = System.get_env("PGPATH")
 cmds =
   cond do
     !pg_version || pg_version >= {9, 1} ->
-      cmds ++ [["-U", "postgres", "-d", "postgrex_test_with_schemas", "-c", "CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA test;"],
-               ["-U", "postgres", "-d", "postgrex_test", "-c", "CREATE EXTENSION IF NOT EXISTS hstore;"]]
+      cmds ++ [["-d", "postgrex_test_with_schemas", "-c", "CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA test;"],
+               ["-d", "postgrex_test", "-c", "CREATE EXTENSION IF NOT EXISTS hstore;"]]
     pg_version == {9, 0} ->
-      cmds ++ [["-U", "postgres", "-d", "postgrex_test", "-f", "#{pg_path}/contrib/hstore.sql"]]
+      cmds ++ [["-d", "postgrex_test", "-f", "#{pg_path}/contrib/hstore.sql"]]
     pg_version < {9, 0} ->
-      cmds ++ [["-U", "postgres", "-d", "postgrex_test", "-c", "CREATE LANGUAGE plpgsql;"]]
+      cmds ++ [["-d", "postgrex_test", "-c", "CREATE LANGUAGE plpgsql;"]]
     true ->
       cmds
 end
 
+psql_env = System.get_env() |> Map.put_new("PGUSER", "postgres")
+
 Enum.each(cmds, fn args ->
-  {output, status} = System.cmd("psql", args, stderr_to_stdout: true)
+  {output, status} = System.cmd("psql", args, stderr_to_stdout: true, env: psql_env)
 
   if status != 0 do
     IO.puts """


### PR DESCRIPTION
This allows a user to define env to control configuration when testing postgrex. Mariaex and ecto have issues too but didn't consider fixing those yet. 