### PR TITLE
Accept GenServer.server() type in Postgrex.Notifications API

### DIFF
--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -16,6 +16,8 @@ defmodule Postgrex.Notifications do
 
   ## PUBLIC API ##
 
+  @type server :: GenServer.server()
+
   @doc """
   Start the notification connection process and connect to postgres.
 
@@ -36,7 +38,7 @@ defmodule Postgrex.Notifications do
 
     * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
-  @spec listen(pid, String.t, Keyword.t) :: {:ok, reference}
+  @spec listen(server, String.t, Keyword.t) :: {:ok, reference}
   def listen(pid, channel, opts \\ []) do
     message = {:listen, channel}
     timeout = opts[:timeout] || @timeout
@@ -46,7 +48,7 @@ defmodule Postgrex.Notifications do
   @doc """
   Listens to an asynchronous notification channel `channel`. See `listen/2`.
   """
-  @spec listen!(pid, String.t, Keyword.t) :: reference
+  @spec listen!(server, String.t, Keyword.t) :: reference
   def listen!(pid, channel, opts \\ []) do
     {:ok, ref} = listen(pid, channel, opts)
     ref
@@ -60,7 +62,7 @@ defmodule Postgrex.Notifications do
 
     * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
-  @spec unlisten(pid, reference, Keyword.t) :: :ok
+  @spec unlisten(server, reference, Keyword.t) :: :ok
   def unlisten(pid, ref, opts \\ []) do
     message = {:unlisten, ref}
     timeout = opts[:timeout] || @timeout
@@ -74,7 +76,7 @@ defmodule Postgrex.Notifications do
   Stops listening on the given channel by passing the reference returned from
   `listen/2`.
   """
-  @spec unlisten!(pid, reference, Keyword.t) :: :ok
+  @spec unlisten!(server, reference, Keyword.t) :: :ok
   def unlisten!(pid, ref, opts \\ []) do
     unlisten(pid, ref, opts)
   end


### PR DESCRIPTION
This fixes dialyzer warnings when using a named process for Postgrex.Notifications.

Eg: the following code:

```elixir
    Postgrex.Notifications.start_link(AsyncJobApi.Repo.config() ++ [name: AsyncJobApi.JobQueue.Notifier])
    Postgrex.Notifications.listen!(AsyncJobApi.JobQueue.Notifier, "jobs.completed")
```

Produces this warning:

```
[ElixirLS Dialyzer] The call 'Elixir.Postgrex.Notifications':'listen!'('Elixir.AsyncJobApi.JobQueue.Notifier',<<_:112>>) will never return since it differs in the 1st argument from the success typing arguments: (pid(),binary())
```