### PR TITLE
fix parsing of version string from latest pgdg repository build

### DIFF
--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -63,6 +63,8 @@ defmodule Postgrex.Utils do
   def parse_version(version) do
     list =
       version
+      |> String.split(" ")
+      |> hd
       |> String.split(".")
       |> Enum.map(&elem(Integer.parse(&1), 0))
 


### PR DESCRIPTION
Version string for an official postgres repo build looks like this:

10.2 (Ubuntu 10.2-1.pgdg16.04+1)

which the version parser chokes on since it's only expecting something like "10.2".