### PR TITLE
Port changes to version parsing

### DIFF
--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -60,12 +60,13 @@ defmodule Postgrex.Utils do
   Converts pg major.minor.patch (http://www.postgresql.org/support/versioning) version to an integer
   """
   def parse_version(version) do
-    list =
-      version
-      |> String.split(".")
-      |> Enum.map(&elem(Integer.parse(&1), 0))
+    [version_string | _] = String.split(version, " ", parts: 2)
+    segments =
+      version_string
+      |> String.split(".", parts: 3)
+      |> Enum.map(&String.to_integer/1)
 
-    case list do
+    case segments do
       [major, minor, patch] -> {major, minor, patch}
       [major, minor] -> {major, minor, 0}
       [major] -> {major, 0, 0}


### PR DESCRIPTION
Commit dd6ac4eb claims to backport version parsing from master, but
there are no changes on master to version parsing. This commit improves
resiliency of the version parser.