### PR TITLE
Automatically encode/decode /32 or /128 netmasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v0.14.0-dev
 
+* Postgrex.INET will add a /32 netmask to an IPv4 address and a /128 netmask to
+  an IPv6 address during encoding where `netmask: nil`. When decoding, a /32
+  netmask (for IPv4) or /128 netmask (for IPv6) will be removed, resulting in
+  `netmask: nil` for the struct.
+
 * Backwards incompatible changes
   * Invoke `encode_to_iodata!` instead of `encode!` in JSON encoder
   * Remove Postgrex.CIDR and use Postgrex.INET to encode both inet/cidr (as Postgres may perform implicit/explicit casting at any time)

--- a/lib/postgrex/builtins.ex
+++ b/lib/postgrex/builtins.ex
@@ -49,7 +49,7 @@ defmodule Postgrex.INET do
 
   """
 
-  @type t :: %__MODULE__{address: :inet.ip_address(), netmask: 0..128}
+  @type t :: %__MODULE__{address: :inet.ip_address(), netmask: nil | 0..128}
 
   defstruct address: nil, netmask: nil
 end

--- a/lib/postgrex/extensions/inet.ex
+++ b/lib/postgrex/extensions/inet.ex
@@ -7,9 +7,9 @@ defmodule Postgrex.Extensions.INET do
   def encode(_) do
     quote location: :keep do
       %Postgrex.INET{address: {a, b, c, d}, netmask: n} ->
-        <<8 :: int32, 2, n, 0, 4, a, b, c, d>>
+        <<8 :: int32, 2, n || 32, 0, 4, a, b, c, d>>
       %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: n} ->
-        <<20 :: int32, 3, n, 0, 16,
+        <<20 :: int32, 3, n || 128, 0, 16,
           a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
       other ->
         raise ArgumentError, Postgrex.Utils.encode_msg(other, Postgrex.INET)
@@ -19,9 +19,11 @@ defmodule Postgrex.Extensions.INET do
   def decode(_) do
     quote location: :keep do
       <<8 :: int32, 2, n, _cidr?, 4, a, b, c, d>> ->
+        n = if(n == 32, do: nil, else: n)
         %Postgrex.INET{address: {a, b, c, d}, netmask: n}
       <<20 :: int32, 3, n, _cidr?, 16,
         a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> ->
+          n = if(n == 128, do: nil, else: n)
         %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: n}
     end
   end

--- a/lib/postgrex/extensions/inet.ex
+++ b/lib/postgrex/extensions/inet.ex
@@ -2,20 +2,22 @@ defmodule Postgrex.Extensions.INET do
   @moduledoc false
 
   import Postgrex.BinaryUtils, warn: false
-  use Postgrex.BinaryExtension, [send: "cidr_send", send: "inet_send"]
+  use Postgrex.BinaryExtension, send: "cidr_send", send: "inet_send"
 
   def encode(_) do
     quote location: :keep do
       %Postgrex.INET{address: {a, b, c, d}, netmask: nil} ->
-        <<8 :: int32, 2, 32, 0, 4, a, b, c, d>>
+        <<8::int32, 2, 32, 0, 4, a, b, c, d>>
+
       %Postgrex.INET{address: {a, b, c, d}, netmask: n} ->
-        <<8 :: int32, 2, n, 1, 4, a, b, c, d>>
+        <<8::int32, 2, n, 1, 4, a, b, c, d>>
+
       %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: nil} ->
-        <<20 :: int32, 3, 128, 0, 16,
-          a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+        <<20::int32, 3, 128, 0, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+
       %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: n} ->
-        <<20 :: int32, 3, n, 1, 16,
-          a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+        <<20::int32, 3, n, 1, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+
       other ->
         raise ArgumentError, Postgrex.Utils.encode_msg(other, Postgrex.INET)
     end
@@ -23,11 +25,11 @@ defmodule Postgrex.Extensions.INET do
 
   def decode(_) do
     quote location: :keep do
-      <<8 :: int32, 2, n, cidr?, 4, a, b, c, d>> ->
+      <<8::int32, 2, n, cidr?, 4, a, b, c, d>> ->
         n = if(cidr? == 1 or n != 32, do: n, else: nil)
         %Postgrex.INET{address: {a, b, c, d}, netmask: n}
-      <<20 :: int32, 3, n, cidr?, 16,
-        a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> ->
+
+      <<20::int32, 3, n, cidr?, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> ->
         n = if(cidr? == 1 or n != 128, do: n, else: nil)
         %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: n}
     end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -290,15 +290,15 @@ defmodule QueryTest do
 
   @tag min_pg_version: "9.0"
   test "decode network types", context do
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
+    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
            query("SELECT '127.0.0.1/32'::inet", [])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 128}]] =
+    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
            query("SELECT '2001:abcd::/128'::inet", [])
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 8}]] =
            query("SELECT '127.0.0.1/8'::inet", [])
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
+    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
            query("SELECT '127.0.0.1/32'::cidr", [])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 128}]] =
+    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
            query("SELECT '2001:abcd::/128'::cidr", [])
     assert [[%Postgrex.INET{address: {192, 168, 0, 0}, netmask: 16}]] =
            query("SELECT '192.168.0.0/16'::cidr", [])
@@ -610,16 +610,16 @@ defmodule QueryTest do
 
   @tag min_pg_version: "9.0"
   test "encode network types", context do
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
-           query("SELECT $1::inet", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 128}]] =
-           query("SELECT $1::inet", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 128}])
+    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
+           query("SELECT $1::inet", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}])
+    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
+           query("SELECT $1::inet", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}])
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 8}]] =
            query("SELECT $1::inet", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 8}])
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
-           query("SELECT $1::cidr", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 128}]] =
-           query("SELECT $1::cidr", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 128}])
+    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
+           query("SELECT $1::cidr", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}])
+    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
+           query("SELECT $1::cidr", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}])
     assert [[%Postgrex.INET{address: {192, 168, 0, 0}, netmask: 16}]] =
            query("SELECT $1::cidr", [%Postgrex.INET{address: {192, 168, 0, 0}, netmask: 16}])
     assert [[%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}]] =

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -291,51 +291,64 @@ defmodule QueryTest do
   @tag min_pg_version: "9.0"
   test "decode network types", context do
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
-      query("SELECT '127.0.0.1'::inet", [])
+             query("SELECT '127.0.0.1'::inet", [])
+
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
-      query("SELECT '127.0.0.1/32'::inet", [])
+             query("SELECT '127.0.0.1/32'::inet", [])
+
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
-      query("SELECT '127.0.0.1/32'::inet::cidr", [])
+             query("SELECT '127.0.0.1/32'::inet::cidr", [])
+
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
-      query("SELECT '127.0.0.1/32'::cidr", [])
+             query("SELECT '127.0.0.1/32'::cidr", [])
+
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}]] =
-      query("SELECT '127.0.0.1/4'::inet", [])
+             query("SELECT '127.0.0.1/4'::inet", [])
+
     assert [[%Postgrex.INET{address: {112, 0, 0, 0}, netmask: 4}]] =
-      query("SELECT '127.0.0.1/4'::inet::cidr", [])
+             query("SELECT '127.0.0.1/4'::inet::cidr", [])
+
     assert %Postgrex.Error{
-              postgres: %{
-                code: :invalid_text_representation,
-                detail: "Value has bits set to right of mask.",
-                message: "invalid cidr value: \"127.0.0.1/4\"",
-              },
-              query: "SELECT '127.0.0.1/4'::cidr"
-            } = query("SELECT '127.0.0.1/4'::cidr", [])
+             postgres: %{
+               code: :invalid_text_representation,
+               detail: "Value has bits set to right of mask.",
+               message: "invalid cidr value: \"127.0.0.1/4\""
+             },
+             query: "SELECT '127.0.0.1/4'::cidr"
+           } = query("SELECT '127.0.0.1/4'::cidr", [])
+
     assert [[%Postgrex.INET{address: {112, 0, 0, 0}, netmask: 4}]] =
-      query("SELECT '112.0.0.0/4'::cidr", [])
+             query("SELECT '112.0.0.0/4'::cidr", [])
 
     assert [[%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: nil}]] =
-      query("SELECT '::1'::inet", [])
+             query("SELECT '::1'::inet", [])
+
     assert [[%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: nil}]] =
-      query("SELECT '::1/128'::inet", [])
+             query("SELECT '::1/128'::inet", [])
+
     assert [[%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}]] =
-      query("SELECT '::1/128'::inet::cidr", [])
+             query("SELECT '::1/128'::inet::cidr", [])
+
     assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}]] =
-      query("SELECT '2001:abcd::/8'::inet", [])
+             query("SELECT '2001:abcd::/8'::inet", [])
+
     assert [[%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}]] =
-      query("SELECT '2001:abcd::/8'::inet::cidr", [])
+             query("SELECT '2001:abcd::/8'::inet::cidr", [])
+
     assert %Postgrex.Error{
-              postgres: %{
-                code: :invalid_text_representation,
-                detail: "Value has bits set to right of mask.",
-                message: "invalid cidr value: \"2001:abcd::/8\"",
-              },
-              query: "SELECT '2001:abcd::/8'::cidr"
-            } = query("SELECT '2001:abcd::/8'::cidr", [])
+             postgres: %{
+               code: :invalid_text_representation,
+               detail: "Value has bits set to right of mask.",
+               message: "invalid cidr value: \"2001:abcd::/8\""
+             },
+             query: "SELECT '2001:abcd::/8'::cidr"
+           } = query("SELECT '2001:abcd::/8'::cidr", [])
+
     assert [[%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}]] =
-      query("SELECT '2000::/8'::cidr", [])
+             query("SELECT '2000::/8'::cidr", [])
 
     assert [[%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}]] =
-           query("SELECT '08:01:2b:05:07:09'::macaddr", [])
+             query("SELECT '08:01:2b:05:07:09'::macaddr", [])
   end
 
   test "decode oid and its aliases", context do
@@ -643,47 +656,79 @@ defmodule QueryTest do
   @tag min_pg_version: "9.0"
   test "encode network types", context do
     assert [["127.0.0.1/32"]] =
-      query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}])
+             query("SELECT $1::inet::text", [
+               %Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}
+             ])
+
     assert [["127.0.0.1/32"]] =
-      query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+             query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+
     assert [["127.0.0.1/32"]] =
-      query("SELECT $1::inet::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+             query("SELECT $1::inet::cidr::text", [
+               %Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}
+             ])
+
     assert [["127.0.0.1/32"]] =
-      query("SELECT $1::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+             query("SELECT $1::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+
     assert [["127.0.0.1/4"]] =
-      query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}])
+             query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}])
+
     assert %Postgrex.Error{
-              postgres: %{
-                code: :invalid_binary_representation,
-                detail: "Value has bits set to right of mask.",
-                message: "invalid external \"cidr\" value",
-              }
-            } = query("SELECT $1::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}])
+             postgres: %{
+               code: :invalid_binary_representation,
+               detail: "Value has bits set to right of mask.",
+               message: "invalid external \"cidr\" value"
+             }
+           } =
+             query("SELECT $1::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}])
+
     assert [["112.0.0.0/4"]] =
-      query("SELECT $1::cidr::text", [%Postgrex.INET{address: {112, 0, 0, 0}, netmask: 4}])
+             query("SELECT $1::cidr::text", [%Postgrex.INET{address: {112, 0, 0, 0}, netmask: 4}])
 
     assert [["::1/128"]] =
-      query("SELECT $1::inet::text", [%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: nil}])
+             query("SELECT $1::inet::text", [
+               %Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: nil}
+             ])
+
     assert [["::1/128"]] =
-      query("SELECT $1::inet::text", [%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}])
+             query("SELECT $1::inet::text", [
+               %Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}
+             ])
+
     assert [["::1/128"]] =
-      query("SELECT $1::inet::cidr::text", [%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}])
+             query("SELECT $1::inet::cidr::text", [
+               %Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}
+             ])
+
     assert [["2001:abcd::/8"]] =
-      query("SELECT $1::inet::text", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+             query("SELECT $1::inet::text", [
+               %Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}
+             ])
+
     assert [["2000::/8"]] =
-      query("SELECT $1::inet::cidr::text", [%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+             query("SELECT $1::inet::cidr::text", [
+               %Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}
+             ])
+
     assert %Postgrex.Error{
-              postgres: %{
-                code: :invalid_binary_representation,
-                detail: "Value has bits set to right of mask.",
-                message: "invalid external \"cidr\" value",
-              }
-            } = query("SELECT $1::cidr::text", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+             postgres: %{
+               code: :invalid_binary_representation,
+               detail: "Value has bits set to right of mask.",
+               message: "invalid external \"cidr\" value"
+             }
+           } =
+             query("SELECT $1::cidr::text", [
+               %Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}
+             ])
+
     assert [["2000::/8"]] =
-      query("SELECT $1::cidr::text", [%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+             query("SELECT $1::cidr::text", [
+               %Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}
+             ])
 
     assert [["08:01:2b:05:07:09"]] =
-      query("SELECT $1::macaddr::text", [%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}])
+             query("SELECT $1::macaddr::text", [%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}])
   end
 
   test "encode bit string", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -291,17 +291,49 @@ defmodule QueryTest do
   @tag min_pg_version: "9.0"
   test "decode network types", context do
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
-           query("SELECT '127.0.0.1/32'::inet", [])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
-           query("SELECT '2001:abcd::/128'::inet", [])
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 8}]] =
-           query("SELECT '127.0.0.1/8'::inet", [])
+      query("SELECT '127.0.0.1'::inet", [])
     assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
-           query("SELECT '127.0.0.1/32'::cidr", [])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
-           query("SELECT '2001:abcd::/128'::cidr", [])
-    assert [[%Postgrex.INET{address: {192, 168, 0, 0}, netmask: 16}]] =
-           query("SELECT '192.168.0.0/16'::cidr", [])
+      query("SELECT '127.0.0.1/32'::inet", [])
+    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
+      query("SELECT '127.0.0.1/32'::inet::cidr", [])
+    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}]] =
+      query("SELECT '127.0.0.1/32'::cidr", [])
+    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}]] =
+      query("SELECT '127.0.0.1/4'::inet", [])
+    assert [[%Postgrex.INET{address: {112, 0, 0, 0}, netmask: 4}]] =
+      query("SELECT '127.0.0.1/4'::inet::cidr", [])
+    assert %Postgrex.Error{
+              postgres: %{
+                code: :invalid_text_representation,
+                detail: "Value has bits set to right of mask.",
+                message: "invalid cidr value: \"127.0.0.1/4\"",
+              },
+              query: "SELECT '127.0.0.1/4'::cidr"
+            } = query("SELECT '127.0.0.1/4'::cidr", [])
+    assert [[%Postgrex.INET{address: {112, 0, 0, 0}, netmask: 4}]] =
+      query("SELECT '112.0.0.0/4'::cidr", [])
+
+    assert [[%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: nil}]] =
+      query("SELECT '::1'::inet", [])
+    assert [[%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: nil}]] =
+      query("SELECT '::1/128'::inet", [])
+    assert [[%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}]] =
+      query("SELECT '::1/128'::inet::cidr", [])
+    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}]] =
+      query("SELECT '2001:abcd::/8'::inet", [])
+    assert [[%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}]] =
+      query("SELECT '2001:abcd::/8'::inet::cidr", [])
+    assert %Postgrex.Error{
+              postgres: %{
+                code: :invalid_text_representation,
+                detail: "Value has bits set to right of mask.",
+                message: "invalid cidr value: \"2001:abcd::/8\"",
+              },
+              query: "SELECT '2001:abcd::/8'::cidr"
+            } = query("SELECT '2001:abcd::/8'::cidr", [])
+    assert [[%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}]] =
+      query("SELECT '2000::/8'::cidr", [])
+
     assert [[%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}]] =
            query("SELECT '08:01:2b:05:07:09'::macaddr", [])
   end
@@ -610,23 +642,48 @@ defmodule QueryTest do
 
   @tag min_pg_version: "9.0"
   test "encode network types", context do
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
-           query("SELECT $1::inet", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
-           query("SELECT $1::inet", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}])
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 8}]] =
-           query("SELECT $1::inet", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 8}])
-    assert [[%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}]] =
-           query("SELECT $1::cidr", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}])
-    assert [[%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}]] =
-           query("SELECT $1::cidr", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: nil}])
-    assert [[%Postgrex.INET{address: {192, 168, 0, 0}, netmask: 16}]] =
-           query("SELECT $1::cidr", [%Postgrex.INET{address: {192, 168, 0, 0}, netmask: 16}])
-    assert [[%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}]] =
-           query("SELECT $1::macaddr", [%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}])
+    assert [["127.0.0.1/32"]] =
+      query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}])
+    assert [["127.0.0.1/32"]] =
+      query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+    assert [["127.0.0.1/32"]] =
+      query("SELECT $1::inet::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+    assert [["127.0.0.1/32"]] =
+      query("SELECT $1::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}])
+    assert [["127.0.0.1/4"]] =
+      query("SELECT $1::inet::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}])
+    assert %Postgrex.Error{
+              postgres: %{
+                code: :invalid_binary_representation,
+                detail: "Value has bits set to right of mask.",
+                message: "invalid external \"cidr\" value",
+              }
+            } = query("SELECT $1::cidr::text", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 4}])
+    assert [["112.0.0.0/4"]] =
+      query("SELECT $1::cidr::text", [%Postgrex.INET{address: {112, 0, 0, 0}, netmask: 4}])
 
-    assert %Postgrex.Error{postgres: %{code: :invalid_binary_representation}} =
-           query("SELECT $1::cidr", [%Postgrex.INET{address: {127, 0, 0, 1}, netmask: 8}])
+    assert [["::1/128"]] =
+      query("SELECT $1::inet::text", [%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: nil}])
+    assert [["::1/128"]] =
+      query("SELECT $1::inet::text", [%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}])
+    assert [["::1/128"]] =
+      query("SELECT $1::inet::cidr::text", [%Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}])
+    assert [["2001:abcd::/8"]] =
+      query("SELECT $1::inet::text", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+    assert [["2000::/8"]] =
+      query("SELECT $1::inet::cidr::text", [%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+    assert %Postgrex.Error{
+              postgres: %{
+                code: :invalid_binary_representation,
+                detail: "Value has bits set to right of mask.",
+                message: "invalid external \"cidr\" value",
+              }
+            } = query("SELECT $1::cidr::text", [%Postgrex.INET{address: {8193, 43981, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+    assert [["2000::/8"]] =
+      query("SELECT $1::cidr::text", [%Postgrex.INET{address: {8192, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}])
+
+    assert [["08:01:2b:05:07:09"]] =
+      query("SELECT $1::macaddr::text", [%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}])
   end
 
   test "encode bit string", context do


### PR DESCRIPTION
Pull request to fix an issue mentioned in #383.