### PR TITLE
Fix deprecated time unit warning

### DIFF
--- a/lib/postgrex/extensions/timestamptz.ex
+++ b/lib/postgrex/extensions/timestamptz.ex
@@ -30,7 +30,7 @@ defmodule Postgrex.Extensions.TimestampTZ do
   ## Helpers
 
   def encode_elixir(%DateTime{utc_offset: 0, std_offset: 0} = datetime) do
-    case DateTime.to_unix(datetime, :microseconds) do
+    case DateTime.to_unix(datetime, :microsecond) do
       microsecs when microsecs < @us_max ->
         <<8 :: int32, microsecs - @us_epoch :: int64>>
       _ ->
@@ -42,6 +42,6 @@ defmodule Postgrex.Extensions.TimestampTZ do
   end
 
   def microsecond_to_elixir(microsecs) do
-    DateTime.from_unix!(microsecs + @us_epoch, :microseconds)
+    DateTime.from_unix!(microsecs + @us_epoch, :microsecond)
   end
 end


### PR DESCRIPTION
Fixes:

```
warning: deprecated time unit: :microseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
  (elixir) lib/system.ex:898: System.warn/2
  (elixir) lib/system.ex:752: System.convert_time_unit/3
  (elixir) lib/calendar/datetime.ex:280: DateTime.to_unix/2
  (postgrex) lib/postgrex/extensions/timestamptz.ex:33: Postgrex.Extensions.TimestampTZ.encode_elixir/1
  (postgrex) lib/postgrex/type_module.ex:714: Postgrex.DefaultTypes.encode_params/3
```