### PR TITLE
Reduce the amount of metadata and structs

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -121,8 +121,6 @@ defmodule Postgrex do
     * `:timeout` - Query request timeout (default: `#{@timeout}`);
     * `:decode_mapper` - Fun to map each row in the result to a term after
     decoding, (default: `fn x -> x end`);
-    * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection`
     * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
     query on error, otherwise set to `:transaction` (default: `:transaction`);
 
@@ -178,8 +176,6 @@ defmodule Postgrex do
     (default: `#{@pool_timeout}`)
     * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Prepare request timeout (default: `#{@timeout}`);
-    * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection`
     * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
     prepare on error, otherwise set to `:transaction` (default: `:transaction`);
 
@@ -232,8 +228,6 @@ defmodule Postgrex do
     * `:timeout` - Execute request timeout (default: `#{@timeout}`);
     * `:decode_mapper` - Fun to map each row in the result to a term after
     decoding, (default: `fn x -> x end`);
-    * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection`
     * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
     execute on error, otherwise set to `:transaction` (default: `:transaction`);
 
@@ -277,8 +271,6 @@ defmodule Postgrex do
     (default: `#{@pool_timeout}`)
     * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Close request timeout (default: `#{@timeout}`);
-    * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection`
     * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
     close on error, otherwise set to `:transaction` (default: `:transaction`);
 
@@ -329,16 +321,14 @@ defmodule Postgrex do
     (default: `#{@pool_timeout}`)
     * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
-    * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection`;
     * `:mode` - Set to `:savepoint` to use savepoints instead of an SQL
     transaction, otherwise set to `:transaction` (default: `:transaction`);
 
 
   The `:timeout` is for the duration of the transaction and all nested
   transactions and requests. This timeout overrides timeouts set by internal
-  transactions and requests. The `:pool` and `:mode` will be used for all
-  requests inside the transaction function.
+  transactions and requests. The `:mode` will be used for all requests inside
+  the transaction function.
 
   ## Example
 
@@ -374,8 +364,6 @@ defmodule Postgrex do
   ## Options
 
     * `:pool_timeout` - Call timeout (default: `#{@pool_timeout}`)
-    * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection`
 
   """
   @spec parameters(conn, Keyword.t) :: %{binary => binary}

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -194,7 +194,7 @@ defmodule Postgrex do
     opts =
       opts
       |> defaults()
-      |> Keyword.put(:prepare, true)
+      |> Keyword.put(:postgrex_prepare, true)
 
     DBConnection.prepare(conn, query, opts)
   end
@@ -208,7 +208,7 @@ defmodule Postgrex do
     opts =
       opts
       |> defaults()
-      |> Keyword.put(:prepare, true)
+      |> Keyword.put(:postgrex_prepare, true)
 
     DBConnection.prepare!(conn, %Query{name: name, statement: statement}, opts)
   end

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -141,12 +141,8 @@ defmodule Postgrex do
   @spec query(conn, iodata, list, Keyword.t) :: {:ok, Postgrex.Result.t} | {:error, Exception.t}
   def query(conn, statement, params, opts \\ []) do
     query = %Query{name: "", statement: statement}
-    opts =
-      opts
-      |> defaults()
-      |> Keyword.put(:function, :prepare_execute)
 
-    case DBConnection.prepare_execute(conn, query, params, opts) do
+    case DBConnection.prepare_execute(conn, query, params, defaults(opts)) do
       {:ok, _, result} ->
         {:ok, result}
       {:error, _} = error ->
@@ -161,12 +157,7 @@ defmodule Postgrex do
   @spec query!(conn, iodata, list, Keyword.t) :: Postgrex.Result.t
   def query!(conn, statement, params, opts \\ []) do
     query = %Query{name: "", statement: statement}
-    opts =
-      opts
-      |> defaults()
-      |> Keyword.put(:function, :prepare_execute)
-
-    {_, result} = DBConnection.prepare_execute!(conn, query, params, opts)
+    {_, result} = DBConnection.prepare_execute!(conn, query, params, defaults(opts))
     result
   end
 
@@ -199,10 +190,11 @@ defmodule Postgrex do
   @spec prepare(conn, iodata, iodata, Keyword.t) :: {:ok, Postgrex.Query.t} | {:error, Exception.t}
   def prepare(conn, name, statement, opts \\ []) do
     query = %Query{name: name, statement: statement}
+
     opts =
       opts
       |> defaults()
-      |> Keyword.put(:function, :prepare)
+      |> Keyword.put(:prepare, true)
 
     DBConnection.prepare(conn, query, opts)
   end
@@ -216,7 +208,7 @@ defmodule Postgrex do
     opts =
       opts
       |> defaults()
-      |> Keyword.put(:function, :prepare)
+      |> Keyword.put(:prepare, true)
 
     DBConnection.prepare!(conn, %Query{name: name, statement: statement}, opts)
   end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -196,7 +196,7 @@ defmodule Postgrex.Protocol do
   end
 
   def handle_prepare(%Query{name: ""} = query, opts, s) do
-    prepare = Keyword.get(opts, :prepare, false)
+    prepare = Keyword.get(opts, :postgrex_prepare, false)
     status = new_status(opts, prepare: prepare)
 
     case prepare do
@@ -211,7 +211,7 @@ defmodule Postgrex.Protocol do
   end
 
   def handle_prepare(%Query{} = query, opts, s) do
-    prepare = Keyword.get(opts, :prepare, false)
+    prepare = Keyword.get(opts, :postgrex_prepare, false)
     status = new_status(opts, prepare: prepare)
 
     case prepare do
@@ -242,7 +242,7 @@ defmodule Postgrex.Protocol do
           | {:disconnect, %RuntimeError{}, state}
           | {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_execute(%Query{} = query, params, opts, s) do
-    case Keyword.get(opts, :copy, false) do
+    case Keyword.get(opts, :postgrex_copy, false) do
       true -> handle_execute_copy(query, params, opts, s)
       false -> handle_execute_result(query, params, opts, s)
     end

--- a/lib/postgrex/stream.ex
+++ b/lib/postgrex/stream.ex
@@ -49,7 +49,7 @@ defimpl Collectable, for: Postgrex.Stream do
 
   def into(%Stream{conn: %DBConnection{}} = stream) do
     %Stream{conn: conn, query: query, params: params, options: opts} = stream
-    opts = Keyword.put(opts, :copy, true)
+    opts = Keyword.put(opts, :postgrex_copy, true)
 
     case query do
       %Query{} ->

--- a/lib/postgrex/stream.ex
+++ b/lib/postgrex/stream.ex
@@ -64,7 +64,6 @@ defimpl Collectable, for: Postgrex.Stream do
         {:ok, make_into(conn, stream, copy, opts)}
       query ->
         internal = %Stream{stream | query: %Query{name: "", statement: query}}
-        opts = Keyword.put(opts, :function, :prepare_into)
         {_, copy} = DBConnection.prepare_execute!(conn, internal, params, opts)
         {:ok, make_into(conn, stream, copy, opts)}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Postgrex.Mixfile do
       {:ex_doc, "~> 0.14", only: :docs},
       {:jason, "~> 1.0", only: :test},
       {:decimal, "~> 1.0"},
-      {:db_connection, "~> 2.0.0-dev", github: "elixir-ecto/db_connection", ref: "03b78e1"},
+      {:db_connection, "~> 2.0.0-dev", github: "elixir-ecto/db_connection", ref: "fbe3775"},
       {:connection, "~> 1.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "db_connection": {:git, "https://github.com/elixir-ecto/db_connection.git", "03b78e12d42764d8c7474a5def232d2343517396", [ref: "03b78e1"]},
+  "db_connection": {:git, "https://github.com/elixir-ecto/db_connection.git", "fbe3775534864e9ddbcdc4ca98e9ea3ea031704f", [ref: "fbe3775"]},
   "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -152,13 +152,6 @@ defmodule StreamTest do
     end)
   end
 
-  test "stream struct interpolates to statement", context do
-    query = prepare("", "BEGIN")
-    transaction(fn(conn) ->
-      assert "#{stream(query, [])}" == "BEGIN"
-    end)
-  end
-
   test "connection_id", context do
     query = prepare("", "SELECT pg_backend_pid()")
     {:ok, connection_id} = transaction(fn(conn) ->
@@ -376,7 +369,7 @@ defmodule StreamTest do
       assert Enum.into(["5\n"], stream) == stream
 
       assert_received %DBConnection.LogEntry{} = entry
-      assert (entry.query).query == query
+      assert entry.query == query
       assert {:ok, ^query, %Postgrex.Copy{query: ^query}} = entry.result
 
       assert_received %DBConnection.LogEntry{} = entry
@@ -389,6 +382,7 @@ defmodule StreamTest do
 
       assert %Postgrex.Result{rows: [[2], [3], [4], [5]]} =
         Postgrex.query!(conn, "SELECT * FROM uniques", [])
+
       Postgrex.rollback(conn, :done)
     end)
 
@@ -625,7 +619,7 @@ defmodule StreamTest do
       assert Enum.into(["2\n3\n"], stream) == stream
 
       assert_received %DBConnection.LogEntry{} = entry
-      assert (entry.query).query == query_in
+      assert entry.query == query_in
       assert {:ok, ^query_in, %Postgrex.Copy{query: ^query_in}} = entry.result
 
       assert_received %DBConnection.LogEntry{} = entry
@@ -650,7 +644,7 @@ defmodule StreamTest do
       assert Enum.into(["2\n3\n"], stream) == stream
 
       assert_received %DBConnection.LogEntry{} = entry
-      assert (entry.query).query == query_in
+      assert entry.query == query_in
       assert {:ok, ^query_in, %Postgrex.Copy{query: ^query_in}} = entry.result
 
       assert_received %DBConnection.LogEntry{} = entry
@@ -684,7 +678,7 @@ defmodule StreamTest do
       assert Enum.into(["2\n3\n"], stream) == stream
 
       assert_received %DBConnection.LogEntry{} = entry
-      assert (entry.query).query == query_in
+      assert entry.query == query_in
       assert {:ok, ^query_in, %Postgrex.Copy{query: ^query_in}} = entry.result
 
       assert_received %DBConnection.LogEntry{} = entry


### PR DESCRIPTION
This is a series of commits to simplify a bit the implementation:

  1. Instead of passing :function metadata, we just track what is important, which is the :prepare flag
  2. Do not pass the stream as query, instead pass the query itself and use the stream option
  3. Remove the copy structs in favor of tuples

