### PR TITLE
Replace ArgumentError/RuntimeError by Postgrex.QueryError

### DIFF
--- a/lib/postgrex/error.ex
+++ b/lib/postgrex/error.ex
@@ -54,3 +54,7 @@ defmodule Postgrex.Error do
   defp build_detail(%{detail: detail}) when is_binary(detail), do: ["\n\n" | detail]
   defp build_detail(_), do: []
 end
+
+defmodule Postgrex.QueryError do
+  defexception [:message]
+end

--- a/lib/postgrex/type_module.ex
+++ b/lib/postgrex/type_module.ex
@@ -441,8 +441,7 @@ defmodule Postgrex.TypeModule do
                   "be decoded inside an anonymous record"
             raise RuntimeError, msg
           {:error, %TypeInfo{type: pg_type}, _mod} ->
-            msg = "type `#{pg_type}` can not be handled by the configured " <>
-                  "extensions"
+            msg = "type `#{pg_type}` can not be handled by the configured extensions"
             raise RuntimeError, msg
           {:error, nil, _mod} ->
             msg = "oid `#{oid}` was not bootstrapped and lacks type information"

--- a/test/custom_extensions_test.exs
+++ b/test/custom_extensions_test.exs
@@ -136,7 +136,7 @@ defmodule CustomExtensionsTest do
     opts = [types: Postgrex.DefaultTypes] ++ context[:options]
     {:ok, pid2} = Postgrex.start_link(opts)
 
-    {:error, %ArgumentError{message: message}} = Postgrex.execute(pid2, query, [])
+    {:error, %Postgrex.QueryError{message: message}} = Postgrex.execute(pid2, query, [])
     assert message =~ ~r"invalid types for the connection"
   end
 
@@ -147,7 +147,7 @@ defmodule CustomExtensionsTest do
     {:ok, pid2} = Postgrex.start_link(opts)
 
     Postgrex.transaction(pid2, fn(conn) ->
-      assert_raise ArgumentError, ~r"invalid types for the connection",
+      assert_raise Postgrex.QueryError, ~r"invalid types for the connection",
         fn() -> stream(query, []) |> Enum.take(1) end
     end)
   end
@@ -159,7 +159,7 @@ defmodule CustomExtensionsTest do
     {:ok, pid2} = Postgrex.start_link(opts)
 
     Postgrex.transaction(pid2, fn(conn) ->
-      assert_raise ArgumentError, ~r"invalid types for the connection",
+      assert_raise Postgrex.QueryError, ~r"invalid types for the connection",
         fn() -> Enum.into(["1\n"], stream(query, [])) end
     end)
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1051,7 +1051,7 @@ defmodule QueryTest do
     message = "postgresql protocol can not handle 65536 parameters, the maximum is 65535"
 
     assert capture_log(fn ->
-      %RuntimeError{message: ^message} = query(query, params)
+      %Postgrex.QueryError{message: ^message} = query(query, params)
       pid = context[:pid]
       assert_receive {:EXIT, ^pid, :killed}
     end) =~ message


### PR DESCRIPTION
Postgrex.QueryError is better semantically. Another case
was also replaced by DBConnection.ConnectionError.