### PR TITLE
Disconnect on read-only transaction error

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -68,7 +68,7 @@ defmodule Postgrex do
     * `:types` - The types module to use, see `Postgrex.TypeModule`, this
       option is only required when using custom encoding or decoding (default:
       `Postgrex.DefaultTypes`);
-    * `:disconnect_on_errors` - List of error code atoms that when encountered
+    * `:disconnect_on_error_codes` - List of error code atoms that when encountered
       will disconnect the connection (default: `[]`);
 
   `Postgrex` uses the `DBConnection` framework and supports all `DBConnection`

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -68,6 +68,8 @@ defmodule Postgrex do
     * `:types` - The types module to use, see `Postgrex.TypeModule`, this
       option is only required when using custom encoding or decoding (default:
       `Postgrex.DefaultTypes`);
+    * `:disconnect_on_errors` - List of error code atoms that when encountered
+      will disconnect the connection (default: `[]`);
 
   `Postgrex` uses the `DBConnection` framework and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc.

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1694,6 +1694,8 @@ defmodule Postgrex.Protocol do
     end
   end
 
+  defp maybe_disconnect({:error, _, %{disconnect_on_error_codes: []}} = result), do: result
+
   defp maybe_disconnect({:error,
          %Postgrex.Error{postgres: %{code: code}} = error,
          %{disconnect_on_error_codes: codes} = state

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1694,13 +1694,15 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp maybe_disconnect({:error, %Postgrex.Error{postgres: %{code: code}} = error, state}) do
-    if code == :read_only_sql_transaction and state.disconnect_on_read_only_transaction_error do
-      {:disconnect, error, state}
-    else
-      {:error, error, state}
-    end
+  defp maybe_disconnect({
+         :error,
+         %Postgrex.Error{postgres: %{code: :read_only_sql_transaction}} = error,
+         %{disconnect_on_read_only_transaction_error: true} = state
+       }) do
+    {:disconnect, error, state}
   end
+
+  defp maybe_disconnect(other), do: other
 
   defp rebind_execute(s, %{mode: :transaction} = status, query, params) do
     # using a cached query is same as using it for the first time when don't

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -24,7 +24,7 @@ defmodule Postgrex.Protocol do
             postgres: :idle,
             transactions: :strict,
             buffer: nil,
-            disconnect_on_errors: []
+            disconnect_on_error_codes: []
 
   @type state :: %__MODULE__{
           sock: {module, any},
@@ -39,7 +39,7 @@ defmodule Postgrex.Protocol do
           postgres: DBConnection.status() | {DBConnection.status(), reference},
           transactions: :strict | :naive,
           buffer: nil | binary | :active_once,
-          disconnect_on_errors: [atom()]
+          disconnect_on_error_codes: [atom()]
         }
 
   @type notify :: (binary, binary -> any)
@@ -66,7 +66,7 @@ defmodule Postgrex.Protocol do
     sock_opts = [send_timeout: timeout] ++ (opts[:socket_options] || [])
     ssl? = opts[:ssl] || false
     types_mod = Keyword.fetch!(opts, :types)
-    disconnect_on_errors = opts[:disconnect_on_errors] || []
+    disconnect_on_error_codes = opts[:disconnect_on_error_codes] || []
 
     transactions =
       case opts[:transactions] || :naive do
@@ -84,7 +84,7 @@ defmodule Postgrex.Protocol do
       timeout: timeout,
       postgres: :idle,
       transactions: transactions,
-      disconnect_on_errors: disconnect_on_errors
+      disconnect_on_error_codes: disconnect_on_error_codes
     }
 
     types_key = if types_mod, do: {host, port, Keyword.fetch!(opts, :database)}
@@ -1696,7 +1696,7 @@ defmodule Postgrex.Protocol do
 
   defp maybe_disconnect({:error,
          %Postgrex.Error{postgres: %{code: code}} = error,
-         %{disconnect_on_errors: codes} = state
+         %{disconnect_on_error_codes: codes} = state
        } = result) do
     if code in codes do
       {:disconnect, error, state}

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -17,7 +17,8 @@ defmodule TransactionTest do
       idle: :active,
       backoff_type: :stop,
       prepare: context[:prepare] || :named,
-      max_restarts: 0
+      max_restarts: 0,
+      disconnect_on_read_only_transaction_error: context[:disconnect_on_read_only_transaction_error]
     ]
 
     {:ok, pid} = P.start_link(opts)
@@ -99,6 +100,7 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
+  @tag disconnect_on_read_only_transaction_error: true
   test "transaction read-only only error disconnects with prepare and execute", context do
     Process.flag(:trap_exit, true)
 
@@ -118,6 +120,7 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
+  @tag disconnect_on_read_only_transaction_error: true
   test "transaction read-only only error disconnects with prepare, execute, and close", context do
     Process.flag(:trap_exit, true)
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -18,7 +18,7 @@ defmodule TransactionTest do
       backoff_type: :stop,
       prepare: context[:prepare] || :named,
       max_restarts: 0,
-      disconnect_on_read_only_transaction_error: context[:disconnect_on_read_only_transaction_error]
+      disconnect_on_errors: context[:disconnect_on_errors] || []
     ]
 
     {:ok, pid} = P.start_link(opts)
@@ -100,7 +100,7 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
-  @tag disconnect_on_read_only_transaction_error: true
+  @tag disconnect_on_errors: [:read_only_sql_transaction]
   test "transaction read-only only error disconnects with prepare and execute", context do
     Process.flag(:trap_exit, true)
 
@@ -120,7 +120,7 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
-  @tag disconnect_on_read_only_transaction_error: true
+  @tag disconnect_on_errors: [:read_only_sql_transaction]
   test "transaction read-only only error disconnects with prepare, execute, and close", context do
     Process.flag(:trap_exit, true)
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -18,7 +18,7 @@ defmodule TransactionTest do
       backoff_type: :stop,
       prepare: context[:prepare] || :named,
       max_restarts: 0,
-      disconnect_on_errors: context[:disconnect_on_errors] || []
+      disconnect_on_error_codes: context[:disconnect_on_error_codes] || []
     ]
 
     {:ok, pid} = P.start_link(opts)
@@ -100,7 +100,7 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
-  @tag disconnect_on_errors: [:read_only_sql_transaction]
+  @tag disconnect_on_error_codes: [:read_only_sql_transaction]
   test "transaction read-only only error disconnects with prepare and execute", context do
     Process.flag(:trap_exit, true)
 
@@ -120,7 +120,7 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
-  @tag disconnect_on_errors: [:read_only_sql_transaction]
+  @tag disconnect_on_error_codes: [:read_only_sql_transaction]
   test "transaction read-only only error disconnects with prepare, execute, and close", context do
     Process.flag(:trap_exit, true)
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -110,12 +110,12 @@ defmodule TransactionTest do
       {:ok, query} = P.prepare(conn, "query_1", "insert into uniques values (1);", [])
 
       assert capture_log(fn ->
-        {:error, %Postgrex.Error{postgres: %{message: "cannot execute INSERT in a read-only transaction"}}} =
+        {:error, %Postgrex.Error{postgres: %{code: :read_only_sql_transaction}}} =
           P.execute(conn, query, [])
 
         pid = context[:pid]
         assert_receive {:EXIT, ^pid, :killed}
-      end) =~ "disconnected: ** (Postgrex.Error) ERROR 25006 (read_only_sql_transaction) cannot execute INSERT"
+      end) =~ "disconnected: ** (Postgrex.Error) ERROR 25006 (read_only_sql_transaction)"
     end)
   end
 
@@ -128,12 +128,12 @@ defmodule TransactionTest do
       P.query!(conn, "SET TRANSACTION READ ONLY", []).connection_id
 
       assert capture_log(fn ->
-        {:error, %Postgrex.Error{postgres: %{message: "cannot execute INSERT in a read-only transaction"}}} =
+        {:error, %Postgrex.Error{postgres: %{code: :read_only_sql_transaction}}} =
           P.query(conn, "insert into uniques values (1);", [])
 
         pid = context[:pid]
         assert_receive {:EXIT, ^pid, :killed}
-      end) =~ "disconnected: ** (Postgrex.Error) ERROR 25006 (read_only_sql_transaction) cannot execute INSERT"
+      end) =~ "disconnected: ** (Postgrex.Error) ERROR 25006 (read_only_sql_transaction)"
     end)
   end
 


### PR DESCRIPTION
Similar to https://github.com/xerions/mariaex/issues/180

Example: script below tries to constantly write and at some point we cause manual failover and expect the system to self-heal:

```elixir
# lib/aurora.ex
defmodule Aurora.Application do
  use Application

  def start(_, _) do
    opts = [
      # ...
      name: :aurora,
      disconnect_on_read_only_transaction_error: true
    ]

    children = [
      {Postgrex, opts}
    ]

    Supervisor.start_link(children, strategy: :one_for_one, name: Aurora.Supervisor)
  end
end
```

```elixir
# aurora.exs
Enum.each(1..1000, fn i ->
  :timer.sleep(1000)
  IO.write(to_string(DateTime.utc_now()))

  statement = "INSERT INTO integers (x) VALUES ($1)"


  case Postgrex.query(:aurora, statement, [i]) do
    {:ok, _result} ->
      IO.puts(" (ok)")


    {:error, %Postgrex.Error{postgres: %{code: :read_only_sql_transaction}} = exception} ->
      IO.puts(" (error)")
      IO.inspect(exception)

    {:error, exception} ->
      IO.puts(" (error)")
      IO.inspect(exception)
  end
end)
```

```
2018-10-09 15:32:39.785912Z (ok)
2018-10-09 15:32:41.017704Z (ok)
2018-10-09 15:32:42.235790Z (ok)
2018-10-09 15:32:43.443853Z (ok)
2018-10-09 15:32:44.657805Z (error)

17:32:46.545 [error] Postgrex.Protocol (#PID<0.198.0>) disconnected: ** (DBConnection.ConnectionError) tcp recv: closed
%DBConnection.ConnectionError{message: "tcp recv: closed"}

17:32:46.656 [error] Postgrex.Protocol #PID<0.198.0> could not cancel backend: tcp connect: connection refused - :econnrefused

17:32:47.157 [error] Postgrex.Protocol (#PID<0.198.0>) failed to connect: ** (DBConnection.ConnectionError) tcp connect (aurorabug-cluster.cluster-c6tmwgqa951y.eu-central-1.rds.amazonaws.com:5432): connection refused - :econnrefused
2018-10-09 15:32:47.546801Z (error)
%DBConnection.ConnectionError{
  message: "connection not available and request was dropped from queue after 2775ms"
}
2018-10-09 15:32:51.323003Z (error)
%DBConnection.ConnectionError{
  message: "connection not available and request was dropped from queue after 1999ms"
}
2018-10-09 15:32:54.322926Z (error)
%DBConnection.ConnectionError{
  message: "connection not available and request was dropped from queue after 1999ms"
}
2018-10-09 15:32:57.322953Z (error)
%DBConnection.ConnectionError{
  message: "connection not available and request was dropped from queue after 1999ms"
}

17:32:59.954 [error] Postgrex.Protocol (#PID<0.198.0>) failed to connect: ** (Postgrex.Error) FATAL 57P03 (cannot_connect_now) the database system is starting up
2018-10-09 15:33:00.322945Z (error)
%DBConnection.ConnectionError{
  message: "connection not available and request was dropped from queue after 1999ms"
}
2018-10-09 15:33:03.322770Z (ok)
2018-10-09 15:33:06.088702Z (ok)
2018-10-09 15:33:07.317767Z (ok)
2018-10-09 15:33:08.535858Z (ok)
```