### PR TITLE
 Guard against atom table overflow for non-standard SQL commands

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -2653,8 +2653,19 @@ defmodule Postgrex.Protocol do
   defp decode_tag(<<h, t::binary>>, acc) when h in ?A..?Z,
     do: decode_tag(t, <<acc::binary, h + 32>>)
 
-  defp decode_tag(<<h, t::binary>>, acc),
-    do: decode_tag(t, <<acc::binary, h>>)
+  # Valid SQL statements in Postgresql are only
+  # uppercase A..Z and space. Therefore any other
+  # character prompts a return of the accumulator
+  # ignoring anything from the invalid character
+  # and any trailing space.
+  defp decode_tag(<<_h, _t::binary>>, acc) do
+    tag =
+      acc
+      |> String.trim_trailing("_")
+      |> String.to_atom
+
+    {tag, nil}
+  end
 
   # It is ok to use infinity timeout here if in client process as timer is
   # running.


### PR DESCRIPTION
In `Postgrex.Protocol` the [command is converted to an atom](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex/protocol.ex#L2650) with `String.to_atom/1`.

For Postgres wire-compatible databases like [agensgraph](http://bitnine.net/documentations/quick-guide-1-3.html#overview), commands may be returned that have dynamically generated command names such as `:"graph_write_(insert_vertex_0,_insert_edge_1)"` which could result in blowing up the atom table.

Since Postgres commands always consist of [only A..Z and `0x20`](https://www.postgresql.org/docs/11/static/sql-commands.html) this commit terminates the tag scan whenever a character outside this range is detected which will at least limit the number of potential atoms created without compromising the performance of the standard Posgresql command returns.

Tests are passing with 4 exceptions related to the connection setup on the Postgrex CI environment which are not easily replicated on my dev machine.