### PR TITLE
Add support for 4-part versions (Enterprise DB)

### DIFF
--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -64,10 +64,11 @@ defmodule Postgrex.Utils do
     segments =
       version_string
       |> String.trim_trailing("devel")
-      |> String.split(".", parts: 3)
+      |> String.split(".", parts: 4)
       |> Enum.map(&String.to_integer/1)
 
     case segments do
+      [major, minor, patch, _] -> {major, minor, patch}
       [major, minor, patch] -> {major, minor, patch}
       [major, minor] -> {major, minor, 0}
       [major] -> {major, 0, 0}

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -11,5 +11,15 @@ defmodule UtilsTest do
       segments = Postgrex.Utils.parse_version("10.2 (Debian 10.2-1.pgdg90+1)")
       assert segments == {10, 2, 0}
     end
+
+    test "parses 3 part version strings" do
+      segments = Postgrex.Utils.parse_version("10.2.1 (Debian 10.2-1.pgdg90+1)")
+      assert segments == {10, 2, 1}
+    end
+
+    test "parses 4 part version strings" do
+      segments = Postgrex.Utils.parse_version("9.5.5.10 ___")
+      assert segments == {9, 5, 5}
+    end
   end
 end


### PR DESCRIPTION
Hi,

When using postgrex with Enterprise DB Postgres, Postgrex isn't able to parse the version since it contains 4 parts. (9.5.5.10 for instance).

This pull request fixes that issue by accepting 4 parts, ignoring the last part.
I couldn't find any documentation regarding that last number, I'm assuming it's a build number.