### PR TITLE
Replace :crypto.hash/2 with :erlang.md5/1 for authentication

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -718,8 +718,8 @@ defmodule Postgrex.Protocol do
     user = Keyword.fetch!(opts, :username)
     pass = Keyword.fetch!(opts, :password)
 
-    digest = :crypto.hash(:md5, [pass, user]) |> Base.encode16(case: :lower)
-    digest = :crypto.hash(:md5, [digest, salt]) |> Base.encode16(case: :lower)
+    digest = :erlang.md5([pass, user]) |> Base.encode16(case: :lower)
+    digest = :erlang.md5([digest, salt]) |> Base.encode16(case: :lower)
     auth_send(s, msg_password(pass: ["md5", digest, 0]), status, buffer)
   end
 


### PR DESCRIPTION
When used in FIPS mode, :crypto.hash(:md5, iodata) refuses to do encryption. Authentication using md5 hashed password [is FIPS 140-2 compliant if connection is TLS encrypted](https://docs.oracle.com/cd/E36784_01/html/E54953/fips-notok-1.html). This PR changes use of :crypto.hash/2 function with :erlang.md5/1 as suggested by [erlang documentation](http://erlang.org/doc/apps/crypto/fips.html).

Closes #449 