### PR TITLE
Fix unexpected messages on handshake

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -96,6 +96,7 @@ defmodule Postgrex.Protocol do
       types_key: types_key,
       types_lock: nil,
       prepare: prepare,
+      messages: [],
       ssl: ssl?
     }
 


### PR DESCRIPTION
Fixes #445

* psql (11.1)
* Elixir 1.7.4
* Erlang/OTP 21 [erts-10.2] [source] [64-bit]
* OSX 10.14

To reproduce the issue set `client_min_messages = debug5` in **postgresql.conf**. Postgrex fails:

```
{:ok, pid} = Postgrex.start_link(hostname: "localhost", username: "postgres", password: "postgres", database: "postgres", sync_connect: true)

{:ok, #PID<0.219.0>}

13:07:14.672 [error] GenServer #PID<0.221.0> terminating
** (RuntimeError) connect raised KeyError exception: key :messages not found.The exception details are hidden, as they may contain sensitive data such as database credentials. You may set :show_sensitive_data_on_connection_error to true if you wish to see all of the details
    (stdlib) :maps.get/2
    (elixir) lib/map.ex:267: Map.update!/3
    (postgrex) lib/postgrex/protocol.ex:2815: Postgrex.Protocol.handle_msg/3
    (postgrex) lib/postgrex/protocol.ex:755: Postgrex.Protocol.init_recv/3
    (postgrex) lib/postgrex/protocol.ex:576: Postgrex.Protocol.handshake/2
    (db_connection) lib/db_connection/connection.ex:66: DBConnection.Connection.connect/2
    (connection) lib/connection.ex:622: Connection.enter_connect/5
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: nil
State: Postgrex.Protocol
```