### PR TITLE
Add explicit cast for CockroachDB v19.1

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -70,7 +70,7 @@ defmodule Postgrex.Types do
           # equiv to `WHERE t.oid NOT IN (SELECT unnest(ARRAY[#{Enum.join(oids, ",")}]))`
           # `unnest` is not supported in redshift or postgres version prior to 8.4
           """
-          WHERE t.oid NOT IN (
+          WHERE t.oid::INT NOT IN (
             SELECT (ARRAY[#{Enum.join(oids, ",")}])[i]
             FROM generate_series(1, #{length(oids)}) AS i
           )


### PR DESCRIPTION
The latest version of CockroachDB comes with full support for correlated subqueries which was an issue before. Now the only stoper is one sql fragment where an explicity cast is currently needed.

See: https://github.com/cockroachdb/cockroach/issues/14554