### PR TITLE
Raise exception if encoding a date that is not in Calendar.ISO

### DIFF
--- a/lib/postgrex/extensions/date.ex
+++ b/lib/postgrex/extensions/date.ex
@@ -9,7 +9,7 @@ defmodule Postgrex.Extensions.Date do
 
   def encode(_) do
     quote location: :keep do
-      %Date{} = date ->
+      %Date{calendar: Calendar.ISO} = date ->
         unquote(__MODULE__).encode_elixir(date)
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Date)

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -106,6 +106,14 @@ defmodule Postgrex.Utils do
   @doc """
   Return encode error message.
   """
+  def encode_msg(%Date{calendar: calendar}= observed, _expected) when calendar != Calendar.ISO do
+    "Postgrex expected a %Date{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
+    "Postgrex (and Postgres) support dates in the `Calendar.ISO` calendar only."
+  end
+
+  @doc """
+  Return encode error message.
+  """
   def encode_msg(observed, expected) do
     "Postgrex expected #{to_desc(expected)}, got #{inspect observed}. " <>
     "Please make sure the value you are passing matches the definition in " <>

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -106,7 +106,7 @@ defmodule Postgrex.Utils do
   @doc """
   Return encode error message.
   """
-  def encode_msg(%Date{calendar: calendar}= observed, _expected) when calendar != Calendar.ISO do
+  def encode_msg(%Date{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
     "Postgrex expected a %Date{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
     "Postgrex (and Postgres) support dates in the `Calendar.ISO` calendar only."
   end

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -154,7 +154,15 @@ defmodule CalendarTest do
     assert [["0001-01-01"]] = query("SELECT $1::date::text", [~D[0001-01-01]])
     assert [["0001-02-03"]] = query("SELECT $1::date::text", [~D[0001-02-03]])
     assert [["2013-09-23"]] = query("SELECT $1::date::text", [~D[2013-09-23]])
-    assert [["1999-12-31"]] = query("SELECT $1::date::text", [~D[1999-12-31]])
+  end
+
+  test "encode non Calendar.ISO date", context do
+    defmodule OtherCalendar do
+    end
+
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %Date{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::date::text", [%{~D[1999-12-31] | calendar: OtherCalendar}])
+    end
   end
 
   test "encode timestamp", context do

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -154,6 +154,7 @@ defmodule CalendarTest do
     assert [["0001-01-01"]] = query("SELECT $1::date::text", [~D[0001-01-01]])
     assert [["0001-02-03"]] = query("SELECT $1::date::text", [~D[0001-02-03]])
     assert [["2013-09-23"]] = query("SELECT $1::date::text", [~D[2013-09-23]])
+    assert [["1999-12-31"]] = query("SELECT $1::date::text", [~D[1999-12-31]])
   end
 
   test "encode non Calendar.ISO date", context do


### PR DESCRIPTION
Postgrex currently assumes that a date to be encoded is in
the Calendar.ISO calendar (the default). However Elixir
supports different calendar types in the %Date{} struct.

Postgres does not support dates outside the Calendar.ISO
calendar for the Postgres standard date type.

This commit raises the standard DBConnection.EncodeError
error if a date in a different calendar is provided.