### PR TITLE
Don't encode DateTime, NaiveDateTime or Time unless Calendar.ISO

### DIFF
--- a/lib/postgrex/extensions/date.ex
+++ b/lib/postgrex/extensions/date.ex
@@ -9,7 +9,7 @@ defmodule Postgrex.Extensions.Date do
 
   def encode(_) do
     quote location: :keep do
-      %Date{} = date ->
+      %Date{calendar: Calendar.ISO} = date ->
         unquote(__MODULE__).encode_elixir(date)
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Date)

--- a/lib/postgrex/extensions/time.ex
+++ b/lib/postgrex/extensions/time.ex
@@ -5,8 +5,9 @@ defmodule Postgrex.Extensions.Time do
 
   def encode(_) do
     quote location: :keep do
-      %Time{} = time ->
+      %Time{calendar: Calendar.ISO} = time ->
         unquote(__MODULE__).encode_elixir(time)
+
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Time)
     end

--- a/lib/postgrex/extensions/timestamp.ex
+++ b/lib/postgrex/extensions/timestamp.ex
@@ -8,10 +8,10 @@ defmodule Postgrex.Extensions.Timestamp do
 
   def encode(_) do
     quote location: :keep do
-      %NaiveDateTime{} = naive ->
+      %NaiveDateTime{calendar: Calendar.ISO} = naive ->
         unquote(__MODULE__).encode_elixir(naive)
 
-      %DateTime{} = dt ->
+      %DateTime{calendar: Calendar.ISO} = dt ->
         unquote(__MODULE__).encode_elixir(dt)
 
       other ->

--- a/lib/postgrex/extensions/timestamptz.ex
+++ b/lib/postgrex/extensions/timestamptz.ex
@@ -13,10 +13,12 @@ defmodule Postgrex.Extensions.TimestampTZ do
 
   def encode(_) do
     quote location: :keep do
-      %DateTime{} = datetime ->
-        unquote(__MODULE__).encode_elixir(datetime)
+      %DateTime{calendar: Calendar.ISO} = dt ->
+        unquote(__MODULE__).encode_elixir(dt)
+
       other ->
-        raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, DateTime)
+        raise DBConnection.EncodeError,
+              Postgrex.Utils.encode_msg(other, {DateTime, NaiveDateTime})
     end
   end
 

--- a/lib/postgrex/extensions/timetz.ex
+++ b/lib/postgrex/extensions/timetz.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Extensions.TimeTZ do
 
   def encode(_) do
     quote location: :keep do
-      %Time{} = time ->
+      %Time{calendar: Calendar.ISO} = time ->
         unquote(__MODULE__).encode_elixir(time)
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Time)

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -106,6 +106,14 @@ defmodule Postgrex.Utils do
   @doc """
   Return encode error message.
   """
+  def encode_msg(%Date{calendar: calendar}= observed, _expected) when calendar != Calendar.ISO do
+    "Postgrex expected a %Date{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
+    "Postgrex (and Postgres) support dates in the `Calendar.ISO` calendar only."
+  end
+
+  @doc """
+  Return encode error message.
+  """
   def encode_msg(observed, expected) do
     "Postgrex expected #{to_desc(expected)}, got #{inspect observed}. " <>
     "Please make sure the value you are passing matches the definition in " <>

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -114,6 +114,30 @@ defmodule Postgrex.Utils do
   @doc """
   Return encode error message.
   """
+  def encode_msg(%NaiveDateTime{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
+    "Postgrex expected a %NaiveDateTime{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
+    "Postgrex (and Postgres) support naive datetimes in the `Calendar.ISO` calendar only."
+  end
+
+  @doc """
+  Return encode error message.
+  """
+  def encode_msg(%DateTime{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
+    "Postgrex expected a %DateTime{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
+    "Postgrex (and Postgres) support datetimes in the `Calendar.ISO` calendar only."
+  end
+
+  @doc """
+  Return encode error message.
+  """
+  def encode_msg(%Time{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
+    "Postgrex expected a %Time{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
+    "Postgrex (and Postgres) support times in the `Calendar.ISO` calendar only."
+  end
+
+  @doc """
+  Return encode error message.
+  """
   def encode_msg(observed, expected) do
     "Postgrex expected #{to_desc(expected)}, got #{inspect observed}. " <>
     "Please make sure the value you are passing matches the definition in " <>

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -111,33 +111,21 @@ defmodule Postgrex.Utils do
     "Postgrex (and Postgres) support dates in the `Calendar.ISO` calendar only."
   end
 
-  @doc """
-  Return encode error message.
-  """
   def encode_msg(%NaiveDateTime{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
     "Postgrex expected a %NaiveDateTime{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
     "Postgrex (and Postgres) support naive datetimes in the `Calendar.ISO` calendar only."
   end
 
-  @doc """
-  Return encode error message.
-  """
   def encode_msg(%DateTime{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
     "Postgrex expected a %DateTime{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
     "Postgrex (and Postgres) support datetimes in the `Calendar.ISO` calendar only."
   end
 
-  @doc """
-  Return encode error message.
-  """
   def encode_msg(%Time{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
     "Postgrex expected a %Time{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
     "Postgrex (and Postgres) support times in the `Calendar.ISO` calendar only."
   end
 
-  @doc """
-  Return encode error message.
-  """
   def encode_msg(observed, expected) do
     "Postgrex expected #{to_desc(expected)}, got #{inspect observed}. " <>
     "Please make sure the value you are passing matches the definition in " <>

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -106,7 +106,7 @@ defmodule Postgrex.Utils do
   @doc """
   Return encode error message.
   """
-  def encode_msg(%Date{calendar: calendar}= observed, _expected) when calendar != Calendar.ISO do
+  def encode_msg(%Date{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
     "Postgrex expected a %Date{} in the `Calendar.ISO` calendar, got #{inspect observed}. " <>
     "Postgrex (and Postgres) support dates in the `Calendar.ISO` calendar only."
   end

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -154,7 +154,15 @@ defmodule CalendarTest do
     assert [["0001-01-01"]] = query("SELECT $1::date::text", [~D[0001-01-01]])
     assert [["0001-02-03"]] = query("SELECT $1::date::text", [~D[0001-02-03]])
     assert [["2013-09-23"]] = query("SELECT $1::date::text", [~D[2013-09-23]])
-    assert [["1999-12-31"]] = query("SELECT $1::date::text", [~D[1999-12-31]])
+  end
+
+  test "encode non Calendar.ISO date", context do
+    defmodule OtherCalendar do
+    end
+
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %Date{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::date::text", [%{~D[1999-12-31] | calendar: OtherCalendar}])
+    end
   end
 
   test "encode timestamp", context do

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -154,6 +154,7 @@ defmodule CalendarTest do
     assert [["0001-01-01"]] = query("SELECT $1::date::text", [~D[0001-01-01]])
     assert [["0001-02-03"]] = query("SELECT $1::date::text", [~D[0001-02-03]])
     assert [["2013-09-23"]] = query("SELECT $1::date::text", [~D[2013-09-23]])
+    assert [["1999-12-31"]] = query("SELECT $1::date::text", [~D[1999-12-31]])
   end
 
   test "encode non Calendar.ISO date", context do

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -157,12 +157,46 @@ defmodule CalendarTest do
     assert [["1999-12-31"]] = query("SELECT $1::date::text", [~D[1999-12-31]])
   end
 
-  test "encode non Calendar.ISO date", context do
+  test "encode non Calendar.ISO date, datetime and naive datetime", context do
     defmodule OtherCalendar do
     end
 
     assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %Date{} in the `Calendar.ISO` calendar/, fn ->
       assert [["1999-12-31"]] = query("SELECT $1::date::text", [%{~D[1999-12-31] | calendar: OtherCalendar}])
+    end
+
+    # Timestamp
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %NaiveDateTime{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::timestamp::text",
+        [%{~N[1999-12-31 11:00:00Z] | calendar: OtherCalendar}])
+    end
+
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %DateTime{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::timestamp::text",
+        [%{~U[2010-10-10 10:10:10Z] | calendar: OtherCalendar}])
+    end
+
+    # Timestampz
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %NaiveDateTime{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::timestamp with time zone::text",
+        [%{~N[1999-12-31 11:00:00Z] | calendar: OtherCalendar}])
+    end
+
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %DateTime{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::timestamp with time zone::text",
+        [%{~U[2010-10-10 10:10:10Z] | calendar: OtherCalendar}])
+    end
+
+    # Time
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %Time{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::time::text",
+      [%{~T[10:10:10] | calendar: OtherCalendar}])
+    end
+
+    # Time with zone
+    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %Time{} in the `Calendar.ISO` calendar/, fn ->
+      assert [["1999-12-31"]] = query("SELECT $1::timetz::text",
+      [%{~T[10:10:10] | calendar: OtherCalendar}])
     end
   end
 

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -171,20 +171,10 @@ defmodule CalendarTest do
         [%{~N[1999-12-31 11:00:00Z] | calendar: OtherCalendar}])
     end
 
-    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %DateTime{} in the `Calendar.ISO` calendar/, fn ->
-      assert [["1999-12-31"]] = query("SELECT $1::timestamp::text",
-        [%{~U[2010-10-10 10:10:10Z] | calendar: OtherCalendar}])
-    end
-
     # Timestampz
     assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %NaiveDateTime{} in the `Calendar.ISO` calendar/, fn ->
       assert [["1999-12-31"]] = query("SELECT $1::timestamp with time zone::text",
         [%{~N[1999-12-31 11:00:00Z] | calendar: OtherCalendar}])
-    end
-
-    assert_raise DBConnection.EncodeError, ~r/Postgrex expected a %DateTime{} in the `Calendar.ISO` calendar/, fn ->
-      assert [["1999-12-31"]] = query("SELECT $1::timestamp with time zone::text",
-        [%{~U[2010-10-10 10:10:10Z] | calendar: OtherCalendar}])
     end
 
     # Time


### PR DESCRIPTION
In line with the previous commit, ensures Postgrex only encodes values in the Calendar.ISO calendar.
