### PR TITLE
Fix doc: PostgreSQL, not Postgres / typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Postgrex v0.15+ requires Elixir v1.6+.
 
 * Backwards incompatible changes
   * Invoke `encode_to_iodata!` instead of `encode!` in JSON encoder
-  * Remove Postgrex.CIDR and use Postgrex.INET to encode both inet/cidr (as Postgres may perform implicit/explicit casting at any time)
+  * Remove Postgrex.CIDR and use Postgrex.INET to encode both inet/cidr (as PostgreSQL may perform implicit/explicit casting at any time)
   * Postgrex.Time, Postgrex.Date and Postgrex.Timestamp were deprecated and now have been effectively removed
   * `Postgrex.execute/4` now always returns the prepared query
   * `:pool_timeout` is removed in favor of `:queue_target` and `:queue_interval`. See `DBConnection.start_link/2` for more information
@@ -240,7 +240,7 @@ Postgrex v0.15+ requires Elixir v1.6+.
   * Add extensions
   * Encode/decode ranges generically
   * Add bounds when encoding integer types to error instead of overflowing the integer
-  * Log unhandled Postgres errors (when it cant be replied to anyone)
+  * Log unhandled PostgreSQL errors (when it cant be replied to anyone)
   * Add support for enum types
   * Add support for citext type
   * Add microseconds to times and timestamps
@@ -251,7 +251,7 @@ Postgrex v0.15+ requires Elixir v1.6+.
   * Remove encoder, decoder and formatter functions, use extensions instead
   * Use structs for dates, times, timestamps, interval and ranges
   * Change the default timeout for all operations to 5000ms
-  * Show Postgres error codes as their names instead
+  * Show PostgreSQL error codes as their names instead
 
 ## v0.7.0 (2015-01-20)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ mix deps.clean postgrex --build
 
 Extensions are used to extend Postgrex' built-in type encoding/decoding.
 
-Here is a [JSON extension](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex/extensions/json.ex) that supports encoding/decoding Elixir maps to the Postgres' JSON type.
+Here is a [JSON extension](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex/extensions/json.ex) that supports encoding/decoding Elixir maps to the PostgreSQL JSON type.
 
 Extensions can be specified and configured when building custom type modules:
 
@@ -153,11 +153,11 @@ host    all             postgrex_cleartext_pw   127.0.0.1/32    password
 host    all             postgrex_scram_pw       127.0.0.1/32    scram-sha-256
 ```
 
-The server needs to be restarted for the changes to take effect. Additionally you need to setup a Postgres user with the same username as the local user and give it trust or ident in your hba file. Or you can export $PGUSER and $PGPASSWORD before running tests.
+The server needs to be restarted for the changes to take effect. Additionally you need to setup a PostgreSQL user with the same username as the local user and give it trust or ident in your hba file. Or you can export $PGUSER and $PGPASSWORD before running tests.
 
 ### Testing hstore on 9.0
 
-Postgres versions 9.0 does not have the `CREATE EXTENSION` commands. This means we have to locate the postgres installation and run the `hstore.sql` in `contrib` to install `hstore`. Below is an example command to test 9.0 on OS X with homebrew installed postgres:
+PostgreSQL versions 9.0 does not have the `CREATE EXTENSION` commands. This means we have to locate the postgres installation and run the `hstore.sql` in `contrib` to install `hstore`. Below is an example command to test 9.0 on OS X with homebrew installed postgres:
 
 ```
 $ PGVERSION=9.0 PGPATH=/usr/local/share/postgresql9/ mix test

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -2,11 +2,11 @@ defmodule Postgrex do
   @moduledoc """
   PostgreSQL driver for Elixir.
 
-  This module handles the connection to Postgres, providing support
+  This module handles the connection to PostgreSQL, providing support
   for queries, transactions, connection backoff, logging, pooling and
   more.
 
-  Note that the notifications API (pub/sub) supported by Postgres is
+  Note that the notifications API (pub/sub) supported by PostgreSQL is
   handled by `Postgrex.Notifications`. Hence, to use this feature,
   you need to start a separate (notifications) connection.
   """
@@ -61,11 +61,11 @@ defmodule Postgrex do
   ## Options
 
     * `:hostname` - Server hostname (default: PGHOST env variable, then localhost);
-    * `:socket_dir` - Connect to Postgres via UNIX sockets in the given directory;
+    * `:socket_dir` - Connect to PostgreSQL via UNIX sockets in the given directory;
       The socket name is derived based on the port. This is the preferred method
       for configuring sockets and it takes precedence over the hostname. If you are
-      connecting to a socket outside of the Postgres convention, use `:socket` instead;
-    * `:socket` - Connect to Postgres via UNIX sockets in the given path.
+      connecting to a socket outside of the PostgreSQL convention, use `:socket` instead;
+    * `:socket` - Connect to PostgreSQL via UNIX sockets in the given path.
       This option takes precedence over the `:hostname` and `:socket_dir`;
     * `:port` - Server port (default: PGPORT env variable, then 5432);
     * `:database` - Database (default: PGDATABASE env variable; otherwise required);

--- a/lib/postgrex/builtins.ex
+++ b/lib/postgrex/builtins.ex
@@ -1,6 +1,6 @@
 defmodule Postgrex.Interval do
   @moduledoc """
-  Struct for PostgreSQL interval.
+  Struct for PostgreSQL `interval`.
 
   ## Fields
 
@@ -17,7 +17,7 @@ end
 
 defmodule Postgrex.Range do
   @moduledoc """
-  Struct for PostgreSQL range.
+  Struct for PostgreSQL `range`.
 
   ## Fields
 
@@ -40,7 +40,7 @@ end
 
 defmodule Postgrex.INET do
   @moduledoc """
-  Struct for PostgreSQL inet/cidr.
+  Struct for PostgreSQL `inet` / `cidr`.
 
   ## Fields
 
@@ -56,7 +56,7 @@ end
 
 defmodule Postgrex.MACADDR do
   @moduledoc """
-  Struct for PostgreSQL macaddr.
+  Struct for PostgreSQL `macaddr`.
 
   ## Fields
 
@@ -73,7 +73,7 @@ end
 
 defmodule Postgrex.Point do
   @moduledoc """
-  Struct for PostgreSQL point.
+  Struct for PostgreSQL `point`.
 
   ## Fields
 
@@ -89,7 +89,7 @@ end
 
 defmodule Postgrex.Polygon do
   @moduledoc """
-  Struct for PostgreSQL polygon.
+  Struct for PostgreSQL `polygon`.
 
   ## Fields
 
@@ -104,7 +104,7 @@ end
 
 defmodule Postgrex.Line do
   @moduledoc """
-  Struct for PostgreSQL line.
+  Struct for PostgreSQL `line`.
 
   Note, lines are stored in PostgreSQL in the form `{a, b, c}`, which
   parameterizes a line as `a*x + b*y + c = 0`.
@@ -124,7 +124,7 @@ end
 
 defmodule Postgrex.LineSegment do
   @moduledoc """
-  Struct for PostgreSQL line segment.
+  Struct for PostgreSQL `lseg`.
 
   ## Fields
 
@@ -140,7 +140,7 @@ end
 
 defmodule Postgrex.Box do
   @moduledoc """
-  Struct for PostgreSQL rectangular box.
+  Struct for PostgreSQL `box`.
 
   ## Fields
 
@@ -159,7 +159,7 @@ end
 
 defmodule Postgrex.Path do
   @moduledoc """
-  Struct for PostgreSQL path.
+  Struct for PostgreSQL `path`.
 
   ## Fields
 
@@ -175,7 +175,7 @@ end
 
 defmodule Postgrex.Circle do
   @moduledoc """
-  Struct for PostgreSQL circle.
+  Struct for PostgreSQL `circle`.
 
   ## Fields
 
@@ -190,7 +190,7 @@ end
 
 defmodule Postgrex.Lexeme do
   @moduledoc """
-  Struct for PostgreSQL lexeme (A tsvector type is composed of multiple lexemes)
+  Struct for PostgreSQL `lexeme`.
 
   ## Fields
 

--- a/lib/postgrex/builtins.ex
+++ b/lib/postgrex/builtins.ex
@@ -1,6 +1,6 @@
 defmodule Postgrex.Interval do
   @moduledoc """
-  Struct for Postgres interval.
+  Struct for PostgreSQL interval.
 
   ## Fields
 
@@ -17,7 +17,7 @@ end
 
 defmodule Postgrex.Range do
   @moduledoc """
-  Struct for Postgres range.
+  Struct for PostgreSQL range.
 
   ## Fields
 
@@ -40,7 +40,7 @@ end
 
 defmodule Postgrex.INET do
   @moduledoc """
-  Struct for Postgres inet/cidr.
+  Struct for PostgreSQL inet/cidr.
 
   ## Fields
 
@@ -56,7 +56,7 @@ end
 
 defmodule Postgrex.MACADDR do
   @moduledoc """
-  Struct for Postgres macaddr.
+  Struct for PostgreSQL macaddr.
 
   ## Fields
 
@@ -73,7 +73,7 @@ end
 
 defmodule Postgrex.Point do
   @moduledoc """
-  Struct for Postgres point.
+  Struct for PostgreSQL point.
 
   ## Fields
 
@@ -89,7 +89,7 @@ end
 
 defmodule Postgrex.Polygon do
   @moduledoc """
-  Struct for Postgres polygon.
+  Struct for PostgreSQL polygon.
 
   ## Fields
 
@@ -104,9 +104,9 @@ end
 
 defmodule Postgrex.Line do
   @moduledoc """
-  Struct for Postgres line.
+  Struct for PostgreSQL line.
 
-  Note, lines are stored in Postgres in the form `{a, b, c}`, which
+  Note, lines are stored in PostgreSQL in the form `{a, b, c}`, which
   parameterizes a line as `a*x + b*y + c = 0`.
 
   ## Fields
@@ -124,7 +124,7 @@ end
 
 defmodule Postgrex.LineSegment do
   @moduledoc """
-  Struct for Postgres line segment.
+  Struct for PostgreSQL line segment.
 
   ## Fields
 
@@ -140,7 +140,7 @@ end
 
 defmodule Postgrex.Box do
   @moduledoc """
-  Struct for Postgres rectangular box.
+  Struct for PostgreSQL rectangular box.
 
   ## Fields
 
@@ -159,7 +159,7 @@ end
 
 defmodule Postgrex.Path do
   @moduledoc """
-  Struct for Postgres path.
+  Struct for PostgreSQL path.
 
   ## Fields
 
@@ -175,7 +175,7 @@ end
 
 defmodule Postgrex.Circle do
   @moduledoc """
-  Struct for Postgres circle.
+  Struct for PostgreSQL circle.
 
   ## Fields
 
@@ -190,7 +190,7 @@ end
 
 defmodule Postgrex.Lexeme do
   @moduledoc """
-  Struct for Postgres Lexeme (A Tsvector type is composed of multiple lexemes)
+  Struct for PostgreSQL lexeme (A tsvector type is composed of multiple lexemes)
 
   ## Fields
 

--- a/lib/postgrex/error_code.ex
+++ b/lib/postgrex/error_code.ex
@@ -26,7 +26,7 @@ defmodule Postgrex.ErrorCode do
   end
 
   @doc ~S"""
-  Translates a Postgres error code into a name
+  Translates a PostgreSQL error code into a name
 
   Examples:
       iex> code_to_name("23505")
@@ -43,7 +43,7 @@ defmodule Postgrex.ErrorCode do
   def code_to_name(_), do: nil
 
   @doc ~S"""
-  Translates a Postgres error name into a list of possible codes.
+  Translates a PostgreSQL error name into a list of possible codes.
   Most error names have only a single code, but there are exceptions.
 
   Examples:

--- a/lib/postgrex/extension.ex
+++ b/lib/postgrex/extension.ex
@@ -1,6 +1,6 @@
 defmodule Postgrex.Extension do
   @moduledoc """
-  An extension knows how to encode and decode Postgres types to and
+  An extension knows how to encode and decode PostgreSQL types to and
   from Elixir values.
 
   Custom extensions can be enabled via `Postgrex.Types.define/3`.

--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -1,6 +1,6 @@
 defmodule Postgrex.Notifications do
   @moduledoc ~S"""
-  API for notifications (pub/sub) in Postgres.
+  API for notifications (pub/sub) in PostgreSQL.
 
   In order to use it, first you need to start the notification process.
   In your supervision tree:
@@ -12,7 +12,7 @@ defmodule Postgrex.Notifications do
       {:ok, listen_ref} = Postgrex.Notifications.listen(MyApp.Notifications, "channel")
 
   Now every time a message is broadcast on said channel, for example via
-  Postgres command line:
+  PostgreSQL command line:
 
       NOTIFY "channel", "Oh hai!";
 

--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -22,7 +22,7 @@ defmodule Postgrex.Notifications do
 
   ## A note on casing
 
-  While PostgreSQL seems to behave as case insensittive, it actually has a very
+  While PostgreSQL seems to behave as case-insensitive, it actually has a very
   perculiar behaviour on casing. When you write:
 
       SELECT * FROM POSTS

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -2775,7 +2775,7 @@ defmodule Postgrex.Protocol do
   defp decode_tag(<<h, t::binary>>, acc) when h in ?A..?Z,
     do: decode_tag(t, <<acc::binary, h + 32>>)
 
-  # Valid SQL statements in Postgresql are only
+  # Valid SQL statements in PostgreSQL are only
   # uppercase A..Z and space. Therefore any other
   # character prompts a return of the accumulator
   # ignoring anything from the invalid character

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Result do
     * `rows` - The result set. A list of lists, each inner list corresponding to a
       row, each element in the inner list corresponds to a column;
     * `num_rows` - The number of fetched or affected rows;
-    * `connection_id` - The OS pid of the Postgres backend that executed the query;
+    * `connection_id` - The OS pid of the PostgreSQL backend that executed the query;
     * `messages` - A list of maps of messages, such as hints and notices, sent by the
       the driver during the execution of the query
   """

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -1,13 +1,13 @@
 defmodule Postgrex.Types do
   @moduledoc """
-  Encodes and decodes between Postgres' protocol and Elixir values.
+  Encodes and decodes between PostgreSQL protocol and Elixir values.
   """
 
   alias Postgrex.TypeInfo
   import Postgrex.BinaryUtils
 
   @typedoc """
-  Postgres internal identifier that maps to a type. See
+  PostgreSQL internal identifier that maps to a type. See
   http://www.postgresql.org/docs/9.4/static/datatype-oid.html.
   """
   @type oid :: pos_integer

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -110,24 +110,24 @@ defmodule Postgrex.Utils do
   """
   def encode_msg(%Date{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
     "Postgrex expected a %Date{} in the `Calendar.ISO` calendar, got #{inspect(observed)}. " <>
-      "Postgrex (and Postgres) support dates in the `Calendar.ISO` calendar only."
+      "Postgrex (and PostgreSQL) support dates in the `Calendar.ISO` calendar only."
   end
 
   def encode_msg(%NaiveDateTime{calendar: calendar} = observed, _expected)
       when calendar != Calendar.ISO do
     "Postgrex expected a %NaiveDateTime{} in the `Calendar.ISO` calendar, got #{inspect(observed)}. " <>
-      "Postgrex (and Postgres) support naive datetimes in the `Calendar.ISO` calendar only."
+      "Postgrex (and PostgreSQL) support naive datetimes in the `Calendar.ISO` calendar only."
   end
 
   def encode_msg(%DateTime{calendar: calendar} = observed, _expected)
       when calendar != Calendar.ISO do
     "Postgrex expected a %DateTime{} in the `Calendar.ISO` calendar, got #{inspect(observed)}. " <>
-      "Postgrex (and Postgres) support datetimes in the `Calendar.ISO` calendar only."
+      "Postgrex (and PostgreSQL) support datetimes in the `Calendar.ISO` calendar only."
   end
 
   def encode_msg(%Time{calendar: calendar} = observed, _expected) when calendar != Calendar.ISO do
     "Postgrex expected a %Time{} in the `Calendar.ISO` calendar, got #{inspect(observed)}. " <>
-      "Postgrex (and Postgres) support times in the `Calendar.ISO` calendar only."
+      "Postgrex (and PostgreSQL) support times in the `Calendar.ISO` calendar only."
   end
 
   def encode_msg(observed, expected) do


### PR DESCRIPTION
I found that postgrex uses both PostgreSQL and Postgres.

Although Postgres is "widely accepted as nickname or alias" [manual](https://www.postgresql.org/docs/current/history.html), it would be better to stick with the official name here.

... or just change all PostgreSQL to Postgres :)

Also included small typo fix.