### PR TITLE
Add support for microseconds in Postgrex.Interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ iex> Postgrex.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'hey
     time(tz)        %Time{hour: 0, minute: 37, second: 14} **
     timestamp       %NaiveDateTime{year: 2013, month: 10, day: 12, hour: 0, minute: 37, second: 14}
     timestamptz     %DateTime{year: 2013, month: 10, day: 12, hour: 0, minute: 37, second: 14, time_zone: "Etc/UTC"} **
-    interval        %Postgrex.Interval{months: 14, days: 40, secs: 10920}
+    interval        %Postgrex.Interval{months: 14, days: 40, secs: 10920, microsecs: 315}
     array           [1, 2, 3]
     composite type  {42, "title", "content"}
     range           %Postgrex.Range{lower: 1, upper: 5}

--- a/lib/postgrex/builtins.ex
+++ b/lib/postgrex/builtins.ex
@@ -7,12 +7,13 @@ defmodule Postgrex.Interval do
     * `months`
     * `days`
     * `secs`
+    * `microsecs`
 
   """
 
-  @type t :: %__MODULE__{months: integer, days: integer, secs: integer}
+  @type t :: %__MODULE__{months: integer, days: integer, secs: integer, microsecs: integer}
 
-  defstruct months: 0, days: 0, secs: 0
+  defstruct months: 0, days: 0, secs: 0, microsecs: 0
 end
 
 defmodule Postgrex.Range do

--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -5,8 +5,8 @@ defmodule Postgrex.Extensions.Interval do
 
   def encode(_) do
     quote location: :keep do
-      %Postgrex.Interval{months: months, days: days, secs: secs} ->
-        microsecs = secs * 1_000_000
+      %Postgrex.Interval{months: months, days: days, secs: secs, microsecs: microsecs} ->
+        microsecs = secs * 1_000_000 + microsecs
         <<16::int32, microsecs::int64, days::int32, months::int32>>
 
       other ->
@@ -18,7 +18,8 @@ defmodule Postgrex.Extensions.Interval do
     quote location: :keep do
       <<16::int32, microsecs::int64, days::int32, months::int32>> ->
         secs = div(microsecs, 1_000_000)
-        %Postgrex.Interval{months: months, days: days, secs: secs}
+        microsecs = rem(microsecs, 1_000_000)
+        %Postgrex.Interval{months: months, days: days, secs: secs, microsecs: microsecs}
     end
   end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -105,19 +105,26 @@ defmodule QueryTest do
   end
 
   test "decode interval", context do
-    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 0}]] = query("SELECT interval '0'", [])
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 0, microsecs: 0}]] =
+             query("SELECT interval '0'", [])
 
-    assert [[%Postgrex.Interval{months: 100, days: 0, secs: 0}]] =
+    assert [[%Postgrex.Interval{months: 100, days: 0, secs: 0, microsecs: 0}]] =
              query("SELECT interval '100 months'", [])
 
-    assert [[%Postgrex.Interval{months: 0, days: 100, secs: 0}]] =
+    assert [[%Postgrex.Interval{months: 0, days: 100, secs: 0, microsecs: 0}]] =
              query("SELECT interval '100 days'", [])
 
-    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 100}]] =
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 100, microsecs: 0}]] =
              query("SELECT interval '100 secs'", [])
 
-    assert [[%Postgrex.Interval{months: 14, days: 40, secs: 10920}]] =
+    assert [[%Postgrex.Interval{months: 14, days: 40, secs: 10920, microsecs: 0}]] =
              query("SELECT interval '1 year 2 months 40 days 3 hours 2 minutes'", [])
+
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 53, microsecs: 204_800}]] =
+             query("SELECT interval '53 secs 204800 microseconds'", [])
+
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 10, microsecs: 240_000}]] =
+             query("SELECT interval '10240000 microseconds'", [])
   end
 
   test "decode point", context do
@@ -733,20 +740,35 @@ defmodule QueryTest do
   end
 
   test "encode interval", context do
-    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 0}]] =
-             query("SELECT $1::interval", [%Postgrex.Interval{months: 0, days: 0, secs: 0}])
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 0, microsecs: 0}]] =
+             query("SELECT $1::interval", [
+               %Postgrex.Interval{months: 0, days: 0, secs: 0, microsecs: 0}
+             ])
 
-    assert [[%Postgrex.Interval{months: 100, days: 0, secs: 0}]] =
-             query("SELECT $1::interval", [%Postgrex.Interval{months: 100, days: 0, secs: 0}])
+    assert [[%Postgrex.Interval{months: 100, days: 0, secs: 0, microsecs: 0}]] =
+             query("SELECT $1::interval", [
+               %Postgrex.Interval{months: 100, days: 0, secs: 0, microsecs: 0}
+             ])
 
-    assert [[%Postgrex.Interval{months: 0, days: 100, secs: 0}]] =
-             query("SELECT $1::interval", [%Postgrex.Interval{months: 0, days: 100, secs: 0}])
+    assert [[%Postgrex.Interval{months: 0, days: 100, secs: 0, microsecs: 0}]] =
+             query("SELECT $1::interval", [
+               %Postgrex.Interval{months: 0, days: 100, secs: 0, microsecs: 0}
+             ])
 
-    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 100}]] =
-             query("SELECT $1::interval", [%Postgrex.Interval{months: 0, days: 0, secs: 100}])
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 100, microsecs: 0}]] =
+             query("SELECT $1::interval", [
+               %Postgrex.Interval{months: 0, days: 0, secs: 100, microsecs: 0}
+             ])
 
-    assert [[%Postgrex.Interval{months: 14, days: 40, secs: 10920}]] =
-             query("SELECT $1::interval", [%Postgrex.Interval{months: 14, days: 40, secs: 10920}])
+    assert [[%Postgrex.Interval{months: 14, days: 40, secs: 10920, microsecs: 0}]] =
+             query("SELECT $1::interval", [
+               %Postgrex.Interval{months: 14, days: 40, secs: 10920, microsecs: 0}
+             ])
+
+    assert [[%Postgrex.Interval{months: 14, days: 40, secs: 10921, microsecs: 24000}]] =
+             query("SELECT $1::interval", [
+               %Postgrex.Interval{months: 14, days: 40, secs: 10920, microsecs: 1_024_000}
+             ])
   end
 
   test "encode arrays", context do


### PR DESCRIPTION
Implements [#475 ](https://github.com/elixir-ecto/postgrex/issues/475)

Changes:
- `microsecs` field added to `Postgrex.Interval`
- `Postgrex.Extensions.Interval.encode/1` extended
- `Postgrex.Extensions.Interval.decode/1` extended
- tests
- docs update