### PR TITLE
Enable PG 11 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - PGVERSION=9.5
     - PGVERSION=9.6
     - PGVERSION=10
+    - PGVERSION=11
 matrix:
   include:
     - elixir: 1.7


### PR DESCRIPTION
### Motivation

Recently I got in a discussion at work if we should use pg 11 or a older version because of no explicit support of `postgrex`. So would be nice to enable PG 11 on travis to guarantee that everything is working.

### Proposed solution

Include `PGVERSION=11` on `.travis.yml`