### PR TITLE
Fix `start_options` `:ssl_opts`

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -34,7 +34,7 @@ defmodule Postgrex do
           | {:connect_timeout, timeout}
           | {:handshake_timeout, timeout}
           | {:ssl, boolean}
-          | {:ssl_opts, [:ssl.ssl_option()]}
+          | {:ssl_opts, [:ssl.tls_option()]}
           | {:socket_options, [:gen_tcp.connect_option()]}
           | {:prepare, :named | :unnamed}
           | {:transactions, :strict | :naive}


### PR DESCRIPTION
`:ssl.ssl_option/0` is no more and `:ssl.tls_option/0` is the think that should be used instead otherwise [it can be a little bit confusing to the newcomers](https://elixirforum.com/t/how-to-connect-to-postgrex-with-ssl-certificate/26255?u=hauleth).