### PR TITLE
Fix non-working example

### DIFF
--- a/lib/postgrex/extension.ex
+++ b/lib/postgrex/extension.ex
@@ -61,7 +61,11 @@ defmodule Postgrex.Extension do
 
   This example could be used in a custom types module:
 
-      Postgrex.Types.define(MyApp.Types, [{MyApp.LTree, :copy}])
+      Postgrex.Types.define(MyApp.Types, [MyApp.LTree])
+      
+  Or pass in opts for the extension that will be passed to the `init/1` callback:
+  
+      Postgrex.Types.define(MyApp.Types, [{MyApp.LTree, [decode_copy: :copy]}])
 
   """
 


### PR DESCRIPTION
Example would fail with:

```
** (FunctionClauseError) no function clause matching in Keyword.get/3

    The following arguments were given to Keyword.get/3:

        # 1
        :copy

        # 2
        :decode_copy

        # 3
        :copy

    Attempted function clauses (showing 1 out of 1):

        def get(keywords, key, default) when is_list(keywords) and is_atom(key)

    (elixir) lib/keyword.ex:195: Keyword.get/3
    lib/postgrex/type_module.ex:878: Postgrex.TypeModule.configure/1
    (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
    lib/postgrex/type_module.ex:11: Postgrex.TypeModule.define/3
    lib/postgrex/test.ex:51: (file)
```
as `:copy` was passed to the `init/1` callback instead of a keyword list. 

Changed the example to show both passing in a module with and without opts.