### PR TITLE
Allow dynamic connection configuration for notifications

### DIFF
--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -90,7 +90,7 @@ defmodule Postgrex.Notifications do
 
   The options that this function accepts are the same as those accepted by
   `Postgrex.start_link/1`, as well as the extra options `:sync_connect`,
-  `:auto_reconnect`, `:reconnect_backoff` and `:configure`.
+  `:auto_reconnect`, `:reconnect_backoff`, and `:configure`.
 
   ## Options
 
@@ -219,7 +219,7 @@ defmodule Postgrex.Notifications do
   def connect(_, s) do
     opts =
       case Keyword.get(s.opts, :configure) do
-        {module, fun, args} -> apply(module, fun, [Keyword.merge(s.opts, args)])
+        {module, fun, args} -> apply(module, fun, [s.opts | args])
         fun when is_function(fun, 1) -> fun.(s.opts)
         nil -> s.opts
       end

--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -90,7 +90,7 @@ defmodule Postgrex.Notifications do
 
   The options that this function accepts are the same as those accepted by
   `Postgrex.start_link/1`, as well as the extra options `:sync_connect`,
-  `:auto_reconnect`, and `:reconnect_backoff`.
+  `:auto_reconnect`, `:reconnect_backoff` and `:configure`.
 
   ## Options
 
@@ -107,6 +107,12 @@ defmodule Postgrex.Notifications do
 
     * `:idle_interval` - while also accepted on `Postgrex.start_link/1`, it has
       a default of `5000ms` in `Postgrex.Notifications` (instead of 1000ms).
+
+    * `:configure` - A function to run before every connect attempt to
+      dynamically configure the options, either a 1-arity fun,
+      `{module, function, args}` with options prepended to `args` or
+      `nil` where only returned options are passed to connect callback
+      (default: `nil`)
   """
   @spec start_link(Keyword.t()) :: {:ok, pid} | {:error, Postgrex.Error.t() | term}
   def start_link(opts) do
@@ -212,9 +218,10 @@ defmodule Postgrex.Notifications do
 
   def connect(_, s) do
     opts =
-      case s.opts[:configure] do
+      case Keyword.get(s.opts, :configure) do
+        {module, fun, args} -> apply(module, fun, [Keyword.merge(s.opts, args)])
+        fun when is_function(fun, 1) -> fun.(s.opts)
         nil -> s.opts
-        {module, fun, args} -> apply(module, fun, [s.opts | args])
       end
 
     case Protocol.connect([types: nil] ++ opts) do

--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -108,11 +108,9 @@ defmodule Postgrex.Notifications do
     * `:idle_interval` - while also accepted on `Postgrex.start_link/1`, it has
       a default of `5000ms` in `Postgrex.Notifications` (instead of 1000ms).
 
-    * `:configure` - A function to run before every connect attempt to
-      dynamically configure the options, either a 1-arity fun,
-      `{module, function, args}` with options prepended to `args` or
-      `nil` where only returned options are passed to connect callback
-      (default: `nil`)
+    * `:configure` - A function to run before every connect attempt to dynamically
+      configure the options as a `{module, function, args}`, where the current
+      options will prepended to `args`. Defaults to `nil`.
   """
   @spec start_link(Keyword.t()) :: {:ok, pid} | {:error, Postgrex.Error.t() | term}
   def start_link(opts) do

--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -211,7 +211,13 @@ defmodule Postgrex.Notifications do
   end
 
   def connect(_, s) do
-    case Protocol.connect([types: nil] ++ s.opts) do
+    opts =
+      case s.opts[:configure] do
+        nil -> s.opts
+        {module, fun, args} -> apply(module, fun, [s.opts | args])
+      end
+
+    case Protocol.connect([types: nil] ++ opts) do
       {:ok, protocol} ->
         s = %{s | listener_channels: %{}, connected: true, protocol: protocol}
         Enum.reduce_while(s.listeners, {:ok, s, s.idle_interval}, &reestablish_listener/2)

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -156,4 +156,29 @@ defmodule NotificationTest do
       assert Task.await(async)
     end
   end
+
+  test "dynamic configuration with named function" do
+    {:ok, _} =
+      PN.start_link(
+        configure: {NotificationTest, :configure, baz: :frobnicate},
+        foo: :bar
+      )
+  end
+
+  test "dynamic configuration with anonymous function" do
+    {:ok, _} =
+      PN.start_link(
+        configure: fn opts ->
+          assert :bar = Keyword.get(opts, :foo)
+          Keyword.merge(opts, @opts)
+        end,
+        foo: :bar
+      )
+  end
+
+  def configure(opts) do
+    assert :bar = Keyword.get(opts, :foo)
+    assert :frobnicate = Keyword.get(opts, :baz)
+    Keyword.merge(opts, @opts)
+  end
 end

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -160,7 +160,7 @@ defmodule NotificationTest do
   test "dynamic configuration with named function" do
     {:ok, _} =
       PN.start_link(
-        configure: {NotificationTest, :configure, baz: :frobnicate},
+        configure: {NotificationTest, :configure, [:bar, :baz]},
         foo: :bar
       )
   end
@@ -176,9 +176,8 @@ defmodule NotificationTest do
       )
   end
 
-  def configure(opts) do
+  def configure(opts, :bar, :baz) do
     assert :bar = Keyword.get(opts, :foo)
-    assert :frobnicate = Keyword.get(opts, :baz)
     Keyword.merge(opts, @opts)
   end
 end

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -160,24 +160,33 @@ defmodule NotificationTest do
   test "dynamic configuration with named function" do
     {:ok, _} =
       PN.start_link(
-        configure: {NotificationTest, :configure, [:bar, :baz]},
+        database: "nobody_knows_it",
+        configure: {NotificationTest, :configure, [self(), :bar, :baz]},
         foo: :bar
       )
+
+    assert_received :configured
   end
 
   test "dynamic configuration with anonymous function" do
     {:ok, _} =
       PN.start_link(
+        database: "nobody_knows_it",
         configure: fn opts ->
           assert :bar = Keyword.get(opts, :foo)
+          send(opts[:parent], :configured)
           Keyword.merge(opts, @opts)
         end,
-        foo: :bar
+        foo: :bar,
+        parent: self()
       )
+
+    assert_received :configured
   end
 
-  def configure(opts, :bar, :baz) do
+  def configure(opts, parent, :bar, :baz) do
     assert :bar = Keyword.get(opts, :foo)
+    send(parent, :configured)
     Keyword.merge(opts, @opts)
   end
 end


### PR DESCRIPTION
When using Ecto, which uses `db_connection`, it's possible to provide dynamic connection configuration for every connection attempt via the `configure` option:

> A function to run before every connect attempt to dynamically configure the options, either a 1-arity fun, `{module, function, args}` with options prepended to `args` or `nil` where only returned options are passed to connect callback (default: `nil`) 

This is useful, for example, because it allows for using [temporary database credentials](https://www.vaultproject.io/docs/secrets/databases/postgresql.html#usage).

The same doesn't work for notifications however, apparently because they don't use the connection pool. This change would allow this.

I've omitted tests so far because I'm not sure this is the right place to fix it. What do you think?
