### PR TITLE
More compatible empty list encoding

### DIFF
--- a/lib/postgrex/extensions/array.ex
+++ b/lib/postgrex/extensions/array.ex
@@ -41,6 +41,14 @@ defmodule Postgrex.Extensions.Array do
 
   ## Helpers
 
+  # Special case for empty lists. This treats an empty list as an empty 1 d
+  # imensional array. While libpq will decode an payload encoded for a 0-dim
+  # array, CockroachDB will not. Also, this is how libpq actually encodes 0-dim
+  # arrays.
+  def encode([], elem_oid, _encoder) do
+    <<20::int32, 1::int32, 0::int32, elem_oid::uint32, 0::int32, 1::int32>>
+  end
+
   def encode(list, elem_oid, encoder) do
     {data, ndims, lengths} = encode(list, 0, [], encoder)
     lengths = for len <- Enum.reverse(lengths), do: <<len::int32, 1::int32>>

--- a/lib/postgrex/extensions/array.ex
+++ b/lib/postgrex/extensions/array.ex
@@ -41,10 +41,9 @@ defmodule Postgrex.Extensions.Array do
 
   ## Helpers
 
-  # Special case for empty lists. This treats an empty list as an empty 1 d
-  # imensional array. While libpq will decode an payload encoded for a 0-dim
-  # array, CockroachDB will not. Also, this is how libpq actually encodes 0-dim
-  # arrays.
+  # Special case for empty lists. This treats an empty list as an empty 1-dim array.
+  # While libpq will decode an payload encoded for a 0-dim array, CockroachDB will not.
+  # Also, this is how libpq actually encodes 0-dim arrays.
   def encode([], elem_oid, _encoder) do
     <<20::int32, 1::int32, 0::int32, elem_oid::uint32, 0::int32, 1::int32>>
   end


### PR DESCRIPTION
libpq supports decoding 0 dimensional arrays, but it encodes them as
empty 1 dimensional arrays. It's therefore unclear how they should be
encoded. Unfortunately, CockroachDB only supports decoding empty 1
dimensional arrays.

Fixes #491 