### PR TITLE
[fix](deps) bump db_connection to 2.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Postgrex.Mixfile do
       {:ex_doc, "~> 0.20", only: :docs},
       {:jason, "~> 1.0", optional: true},
       {:decimal, "~> 1.5"},
-      {:db_connection, "~> 2.1"},
+      {:db_connection, "~> 2.2"},
       {:connection, "~> 1.0"}
     ]
   end


### PR DESCRIPTION
`ecto_sql` depends of `db_connection` ~> 2.2 as it requires the idle_time support [https://github.com/elixir-ecto/ecto_sql/commit/66f21fd7f687be5e76674ee56a74e8e01e626868].
A new release of `postgrex` might be necessary for inclusion into projects.