### PR TITLE
Use :supervisor as child_spec/1 return type

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -491,7 +491,7 @@ defmodule Postgrex do
   @doc """
   Returns a supervisor child specification for a DBConnection pool.
   """
-  @spec child_spec([start_option]) :: Supervisor.Spec.spec()
+  @spec child_spec([start_option]) :: :supervisor.child_spec()
   def child_spec(opts) do
     ensure_deps_started!(opts)
     opts = Postgrex.Utils.default_opts(opts)


### PR DESCRIPTION
Simple fix for #515 