### PR TITLE
WIP: Fix crash following mishandled result.

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -829,7 +829,7 @@ defmodule Postgrex.Protocol do
         bootstrap_fail(s, err, status, buffer)
 
       {:ok, msg, buffer} ->
-        s = handle_msg(s, status, msg)
+        {s, status} = handle_msg(s, status, msg)
         bootstrap_recv(s, status, type_infos, buffer)
 
       {:disconnect, err, s} ->
@@ -1578,7 +1578,7 @@ defmodule Postgrex.Protocol do
         bootstrap_fail(s, err, status, buffer)
 
       {:ok, msg, buffer} ->
-        s = handle_msg(s, status, msg)
+        {s, status} = handle_msg(s, status, msg)
         reload_recv(s, status, acc, buffer)
 
       {:disconnect, err, s} ->


### PR DESCRIPTION
`bootstrap_recv/4` and in turn `msg_recv/4` expect their first argument
to be a Map (usually a `%Postgrex.Protocol{}` struct), but this
case-clause assigns the entire two element tuple return from
`handle_msg/3` to `s` and then passes it onward.

```
** (FunctionClauseError) no function clause matching in Postgrex.Protocol.msg_recv/4
    (postgrex 0.15.8) lib/postgrex/protocol.ex:2837: Postgrex.Protocol.msg_recv({%Postgrex.Protocol{...
                                                       should not be a tuple --^^^
```

Although a bug has not yet occurred, a similar problem seems likely due
to same assignment and call-chain in `reload_recv/4` so it has also been
changed.

Closes #498