### PR TITLE
Ensure that connections are established to the right type of instances

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -72,19 +72,25 @@ defmodule Postgrex do
   Start the connection process and connect to postgres.
 
   ## Options
+  
+  Postgrex provides multiple ways to connect to the server, listed in order of
+  precedence below:
 
     * `:hostname` - Server hostname (default: PGHOST env variable, then localhost);
+    * `:port` - Server port (default: PGPORT env variable, then 5432);
     * `:endpoints` - A list of endpoints (host and port pairs); Postgrex will try
       each endpoint in order, one by one, until the connection succeeds; The syntax
       is `[{host1,port1},{host2,port2},{host3,port3}]`; This option takes precedence
-      over `:hostname`;
+      over `:hostname+:port`;
     * `:socket_dir` - Connect to PostgreSQL via UNIX sockets in the given directory;
       The socket name is derived based on the port. This is the preferred method
       for configuring sockets and it takes precedence over the hostname. If you are
       connecting to a socket outside of the PostgreSQL convention, use `:socket` instead;
     * `:socket` - Connect to PostgreSQL via UNIX sockets in the given path.
       This option takes precedence over the `:hostname`, `:endpoints` and `:socket_dir`;
-    * `:port` - Server port (default: PGPORT env variable, then 5432);
+
+  Once a server is specified, you can configure the connection with the following:
+
     * `:database` - Database (default: PGDATABASE env variable; otherwise required);
     * `:username` - Username (default: PGUSER env variable, then USER env var);
     * `:password` - User password (default: PGPASSWORD env variable);
@@ -101,6 +107,21 @@ defmodule Postgrex do
       from the ssl docs;
     * `:socket_options` - Options to be given to the underlying socket
       (applies to both TCP and UNIX sockets);
+    * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
+      Defaults to 1000ms;
+    * `:target_server_type` - Allows opening connections to only a server with the required state.
+      The allowed values are `:any`, `:primary` and `:secondary` (default: `:any`);
+    * `:disconnect_on_error_codes` - List of error code atoms that when encountered
+      will disconnect the connection. This is useful when using Postgrex against systems that
+      support failover, which when it occurs will emit certain error codes
+      e.g. `:read_only_sql_transaction` (default: `[]`);
+    * `:show_sensitive_data_on_connection_error` - By default, `Postgrex`
+      hides all information during connection errors to avoid leaking credentials
+      or other sensitive information. You can set this option if you wish to
+      see complete errors and stacktraces during connection errors;
+
+  The following options controls the pool and other Postgrex features:
+  
     * `:prepare` - How to prepare queries, either `:named` to use named queries
     or `:unnamed` to force unnamed queries (default: `:named`);
     * `:transactions` - Set to `:strict` to error on unexpected transaction
@@ -112,18 +133,6 @@ defmodule Postgrex do
     * `:types` - The types module to use, see `Postgrex.TypeModule`, this
       option is only required when using custom encoding or decoding (default:
       `Postgrex.DefaultTypes`);
-    * `:disconnect_on_error_codes` - List of error code atoms that when encountered
-      will disconnect the connection. This is useful when using Postgrex against systems that
-      support failover, which when it occurs will emit certain error codes
-      e.g. `:read_only_sql_transaction` (default: `[]`);
-    * `:show_sensitive_data_on_connection_error` - By default, `Postgrex`
-      hides all information during connection errors to avoid leaking credentials
-      or other sensitive information. You can set this option if you wish to
-      see complete errors and stacktraces during connection errors;
-    * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
-      Defaults to 1000ms;
-    * `:target_server_type` - Allows opening connections to only a server with the required state.
-      The allowed values are `:any`, `:primary` and `:secondary` (default: `:any`);
 
   `Postgrex` uses the `DBConnection` library and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc. See `DBConnection.start_link/2`

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -114,9 +114,11 @@ defmodule Postgrex do
     * `:show_sensitive_data_on_connection_error` - By default, `Postgrex`
       hides all information during connection errors to avoid leaking credentials
       or other sensitive information. You can set this option if you wish to
-      see complete errors and stacktraces during connection errors
+      see complete errors and stacktraces during connection errors;
     * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
-      Defaults to 1000ms.
+      Defaults to 1000ms;
+    * `:target_server_type` - Allows opening connections to only a server with the required state.
+      The allowed values are `:any`, `:primary` and `:secondary` (default: `:any`);
 
   `Postgrex` uses the `DBConnection` library and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc. See `DBConnection.start_link/2`

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -109,8 +109,10 @@ defmodule Postgrex do
       (applies to both TCP and UNIX sockets);
     * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
       Defaults to 1000ms;
-    * `:target_server_type` - Allows opening connections to only a server with the required state.
-      The allowed values are `:any`, `:primary` and `:secondary` (default: `:any`);
+    * `:target_server_type` - Allows opening connections to a server in the given
+      replica mode. The allowed values are `:any`, `:primary` and `:secondary`
+      (default: `:any`). If this option is used together with `endpoints`, we will
+      traverse all endpoints until we find an endpoint matching the server type;
     * `:disconnect_on_error_codes` - List of error code atoms that when encountered
       will disconnect the connection. This is useful when using Postgrex against systems that
       support failover, which when it occurs will emit certain error codes

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -195,10 +195,10 @@ defmodule Postgrex do
   in the `endpoints` list:
 
       endpoints: [
-          {"test-instance-1.xyz.eu-west-1.rds.amazonaws.com", 5432},
-          {"test-instance-2.xyz.eu-west-1.rds.amazonaws.com", 5432},
-          (...),
-          {"test-instance-N.xyz.eu-west-1.rds.amazonaws.com", 5432},
+        {"test-instance-1.xyz.eu-west-1.rds.amazonaws.com", 5432},
+        {"test-instance-2.xyz.eu-west-1.rds.amazonaws.com", 5432},
+        (...),
+        {"test-instance-N.xyz.eu-west-1.rds.amazonaws.com", 5432}
       ]
   """
   @spec start_link([start_option]) :: {:ok, pid} | {:error, Postgrex.Error.t() | term}

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -35,6 +35,7 @@ defmodule Postgrex do
 
   @type start_option ::
           {:hostname, String.t()}
+          | {:endpoints, [tuple()]}
           | {:socket_dir, Path.t()}
           | {:socket, Path.t()}
           | {:port, :inet.port_number()}
@@ -73,12 +74,16 @@ defmodule Postgrex do
   ## Options
 
     * `:hostname` - Server hostname (default: PGHOST env variable, then localhost);
+    * `:endpoints` - A list of endpoints (host and port pairs); Postgrex will try
+      each endpoint in order, one by one, until the connection succeeds; The syntax
+      is `[{host1,port1},{host2,port2},{host3,port3}]`; This option takes precedence
+      over `:hostname`;
     * `:socket_dir` - Connect to PostgreSQL via UNIX sockets in the given directory;
       The socket name is derived based on the port. This is the preferred method
       for configuring sockets and it takes precedence over the hostname. If you are
       connecting to a socket outside of the PostgreSQL convention, use `:socket` instead;
     * `:socket` - Connect to PostgreSQL via UNIX sockets in the given path.
-      This option takes precedence over the `:hostname` and `:socket_dir`;
+      This option takes precedence over the `:hostname`, `:endpoints` and `:socket_dir`;
     * `:port` - Server port (default: PGPORT env variable, then 5432);
     * `:database` - Database (default: PGDATABASE env variable; otherwise required);
     * `:username` - Username (default: PGUSER env variable, then USER env var);

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -168,7 +168,7 @@ defmodule Postgrex do
   Some services, such as AWS Aurora, support failovers. The 2 options
   `endpoints` and `target_server_type` can be used together to achieve a faster fail-over.
 
-  Example with an AWS Aurora cluster named test with 2 instances. Using the
+  Imagine an AWS Aurora cluster named "test" with 2 instances. Use the
   following options minimize downtime by ensuring that Postgrex connects to
   the new primary instance as soon as possible.
 

--- a/lib/postgrex/extension.ex
+++ b/lib/postgrex/extension.ex
@@ -83,7 +83,7 @@ defmodule Postgrex.Extension do
   Prelude defines properties and values that are attached to the body of
   the types module.
   """
-  @callback prelude(state) :: Macro.t
+  @callback prelude(state) :: Macro.t()
 
   @doc """
   Specifies the types the extension matches, see `Postgrex.TypeInfo` for

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -146,7 +146,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp connect_endpoints(host, port, sock_opts, timeout, s, %{remaining_endpoints: remaining_endpoints} = status) do
-    case connect_and_proceed(host, port, sock_opts, timeout, s, status) do
+    case connect_and_handshake(host, port, sock_opts, timeout, s, status) do
       {:ok, _} = ret ->
         ret
 
@@ -159,7 +159,7 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp connect_and_proceed(host, port, sock_opts, timeout, s, status) do
+  defp connect_and_handshake(host, port, sock_opts, timeout, s, status) do
     case connect(host, port, sock_opts, timeout, s) do
       {:ok, s} ->
         handshake(s, status)

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -768,10 +768,10 @@ defmodule Postgrex.Protocol do
   ## check_target_server_type
 
   defp check_target_server_type(s, %{target_server_type: :any} = status, buffer),
-       do: check_target_server_type_done(s, status, buffer)
+    do: check_target_server_type_done(s, status, buffer)
 
   defp check_target_server_type(s, status, buffer),
-       do: check_target_server_type_send(s, status, buffer)
+    do: check_target_server_type_send(s, status, buffer)
 
   defp check_target_server_type_send(s, status, buffer) do
     msg = msg_query(statement: "show transaction_read_only")
@@ -792,11 +792,13 @@ defmodule Postgrex.Protocol do
         check_target_server_type_recv(s, status, buffer)
 
       {:ok, msg_data_row(values: values), buffer} ->
-        <<len::uint32, string_value::binary(len)>> = values
-        actual_server_type = case string_value do
-          "off" -> :primary
-          "on" -> :secondary
-        end
+        <<len::uint32, read_only_value::binary(len)>> = values
+
+        actual_server_type =
+          case read_only_value do
+            "off" -> :primary
+            "on" -> :secondary
+          end
 
         case {expected_server_type, actual_server_type} do
           {:any, _} -> check_target_server_type_recv(s, status, buffer)

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -149,14 +149,15 @@ defmodule Postgrex.Protocol do
 
   defp try_connect(host, port, sock_opts, timeout, s, %{remaining_endpoints: remaining_endpoints} = status) do
     case connect_and_proceed(host, port, sock_opts, timeout, s, status) do
-      {:ok, _} = ret -> ret
+      {:ok, _} = ret ->
+        ret
 
       {:error, _} when not is_nil(remaining_endpoints) and length(remaining_endpoints) > 0 ->
         {{host, port}, remaining_endpoints} = List.pop_at(remaining_endpoints, 0)
         try_connect(host, port, sock_opts, timeout, s, %{status | remaining_endpoints: remaining_endpoints})
 
       {:error, _} = error ->
-          error
+        error
     end
   end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -826,7 +826,7 @@ defmodule Postgrex.Protocol do
   defp check_target_server_type_done(s, status, buffer), do: bootstrap(s, status, buffer)
 
   defp check_target_server_type_fail(s, expected_server_type, actual_server_type) do
-    msg = "the server type is not as expected: expected: #{expected_server_type}. actual: #{actual_server_type}"
+    msg = "the server type is not as expected. expected: #{expected_server_type}. actual: #{actual_server_type}"
     err = %Postgrex.Error{message: msg}
     {:disconnect, err, s}
   end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -106,7 +106,7 @@ defmodule Postgrex.Protocol do
       remaining_endpoints: remaining_endpoints_to_attempt
     }
 
-    try_connect(host, port, sock_opts ++ @sock_opts, connect_timeout, s, status)
+    connect_endpoints(host, port, sock_opts ++ @sock_opts, connect_timeout, s, status)
   end
 
   defp host_and_port_params(opts) do
@@ -147,14 +147,14 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp try_connect(host, port, sock_opts, timeout, s, %{remaining_endpoints: remaining_endpoints} = status) do
+  defp connect_endpoints(host, port, sock_opts, timeout, s, %{remaining_endpoints: remaining_endpoints} = status) do
     case connect_and_proceed(host, port, sock_opts, timeout, s, status) do
       {:ok, _} = ret ->
         ret
 
       {:error, _} when not is_nil(remaining_endpoints) and length(remaining_endpoints) > 0 ->
         {{host, port}, remaining_endpoints} = List.pop_at(remaining_endpoints, 0)
-        try_connect(host, port, sock_opts, timeout, s, %{status | remaining_endpoints: remaining_endpoints})
+        connect_endpoints(host, port, sock_opts, timeout, s, %{status | remaining_endpoints: remaining_endpoints})
 
       {:error, _} = error ->
         error

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -149,9 +149,8 @@ defmodule Postgrex.Protocol do
   end
 
   defp try_connect(host, port, sock_opts, timeout, s, %{remaining_endpoints: remaining_endpoints} = status) do
-    case connect(host, port, sock_opts, timeout, s) do
-      {:ok, s} ->
-        handshake(s, status)
+    case connect_and_handshake(host, port, sock_opts, timeout, s, status) do
+      {:ok, _} = ret -> ret
 
       {:error, _} when not is_nil(remaining_endpoints) and length(remaining_endpoints) > 0 ->
         {{host, port}, remaining_endpoints} = List.pop_at(remaining_endpoints, 0)
@@ -159,6 +158,16 @@ defmodule Postgrex.Protocol do
 
       {:error, _} = error ->
           error
+    end
+  end
+
+  defp connect_and_handshake(host, port, sock_opts, timeout, s, status) do
+    case connect(host, port, sock_opts, timeout, s) do
+      {:ok, s} ->
+        handshake(s, status)
+
+      {:error, _} = error ->
+        error
     end
   end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -820,6 +820,10 @@ defmodule Postgrex.Protocol do
         err = Postgrex.Error.exception(postgres: fields)
         check_target_server_type_error(s, err, status, buffer)
 
+      {:ok, msg, buffer} ->
+        {s, status} = handle_msg(s, status, msg)
+        check_target_server_type_recv(s, status, buffer)
+
       {:disconnect, err, s} ->
         check_target_server_type_error(s, err, status)
     end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -141,9 +141,21 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp connect_endpoints(sock_opts, timeout, s, status, err \\ {:error, %Postgrex.Error{message: "endpoints shouldn't be an empty list"}})
+  defp connect_endpoints(
+         sock_opts,
+         timeout,
+         s,
+         status,
+         err \\ {:error, %Postgrex.Error{message: "endpoints shouldn't be an empty list"}}
+       )
 
-  defp connect_endpoints(sock_opts, timeout, s, %{opts: opts, remaining_endpoints: remaining_endpoints, types_mod: types_mod} = status, _err)
+  defp connect_endpoints(
+         sock_opts,
+         timeout,
+         s,
+         %{opts: opts, remaining_endpoints: remaining_endpoints, types_mod: types_mod} = status,
+         _err
+       )
        when remaining_endpoints != [] do
     [{host, port} | remaining_endpoints] = remaining_endpoints
     types_key = if types_mod, do: {host, port, Keyword.fetch!(opts, :database)}
@@ -818,7 +830,11 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp check_target_server_type_recv(s, %{target_server_type: expected_server_type} = status, buffer) do
+  defp check_target_server_type_recv(
+         s,
+         %{target_server_type: expected_server_type} = status,
+         buffer
+       ) do
     case msg_recv(s, :infinity, buffer) do
       {:ok, msg_row_desc(fields: fields), buffer} ->
         {[@text_type_oid], ["transaction_read_only"]} = columns(fields)

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -24,7 +24,8 @@ defmodule Postgrex.Protocol do
             postgres: :idle,
             transactions: :strict,
             buffer: nil,
-            disconnect_on_error_codes: []
+            disconnect_on_error_codes: [],
+            target_server_type: :any
 
   @type state :: %__MODULE__{
           sock: {module, any},
@@ -39,7 +40,8 @@ defmodule Postgrex.Protocol do
           postgres: DBConnection.status() | {DBConnection.status(), reference},
           transactions: :strict | :naive,
           buffer: nil | binary | :active_once,
-          disconnect_on_error_codes: [atom()]
+          disconnect_on_error_codes: [atom()],
+          target_server_type: :any | :primary | :secondary,
         }
 
   @type notify :: (binary, binary -> any)
@@ -69,6 +71,7 @@ defmodule Postgrex.Protocol do
     ssl? = opts[:ssl] || false
     types_mod = Keyword.fetch!(opts, :types)
     disconnect_on_error_codes = opts[:disconnect_on_error_codes] || []
+    target_server_type = opts[:target_server_type] || :any
 
     transactions =
       case opts[:transactions] || :naive do
@@ -749,7 +752,7 @@ defmodule Postgrex.Protocol do
         init_recv(%{s | connection_id: pid, connection_key: key}, status, buffer)
 
       {:ok, msg_ready(), buffer} ->
-        bootstrap(s, status, buffer)
+        check_target_server_type(s, status, buffer)
 
       {:ok, msg_error(fields: fields), buffer} ->
         disconnect(s, Postgrex.Error.exception(postgres: fields), buffer)
@@ -761,6 +764,12 @@ defmodule Postgrex.Protocol do
       {:disconnect, _, _} = dis ->
         dis
     end
+  end
+
+  ## check_target_server_type
+
+  defp check_target_server_type(s, status, buffer) do
+
   end
 
   ## bootstrap

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -187,6 +187,32 @@ defmodule LoginTest do
              ~r"\*\* \(Postgrex.Error\) the server type is not as expected. expected: secondary. actual: primary"
   end
 
+  test "endpoints with one choice", context do
+    opts = [endpoints: [{"localhost", 5432}]]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
+  test "endpoints with two choices, the first will not accept a connection", context do
+    opts = [endpoints: [{"localhost", 5555}, {"localhost", 5432}]]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
+  test "server type 'primary' against two primary instances", context do
+    opts = [endpoints: [{"localhost", 5432}, {"localhost", 5432}], target_server_type: :primary]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
+  test "server type 'secondary' against two primary instances", context do
+    assert capture_log(fn ->
+             opts = [endpoints: [{"localhost", 5432}, {"localhost", 5432}], target_server_type: :secondary]
+             assert_start_and_killed(opts ++ context[:options])
+           end) =~
+             ~r"\*\* \(Postgrex.Error\) the server type is not as expected. expected: secondary. actual: primary"
+  end
+
   test "translates provided port number to integer" do
     assert 123 == P.Utils.default_opts(port: "123")[:port]
   end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -167,6 +167,26 @@ defmodule LoginTest do
     assert_receive {:ok, %Postgrex.Result{}}
   end
 
+  test "server type 'any' against a primary instance", context do
+    opts = [target_server_type: :any]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
+  test "server type 'primary against a primary instance", context do
+    opts = [target_server_type: :primary]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
+  test "server type 'secondary' against a primary instance", context do
+    assert capture_log(fn ->
+             opts = [target_server_type: :secondary]
+             assert_start_and_killed(opts ++ context[:options])
+           end) =~
+             ~r"\*\* \(Postgrex.Error\) the server type is not as expected. expected: secondary. actual: primary"
+  end
+
   test "translates provided port number to integer" do
     assert 123 == P.Utils.default_opts(port: "123")[:port]
   end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -207,7 +207,11 @@ defmodule LoginTest do
 
   test "server type 'secondary' against two primary instances", context do
     assert capture_log(fn ->
-             opts = [endpoints: [{"localhost", 5432}, {"localhost", 5432}], target_server_type: :secondary]
+             opts = [
+               endpoints: [{"localhost", 5432}, {"localhost", 5432}],
+               target_server_type: :secondary
+             ]
+
              assert_start_and_killed(opts ++ context[:options])
            end) =~
              ~r"\*\* \(Postgrex.Error\) the server type is not as expected. expected: secondary. actual: primary"


### PR DESCRIPTION
Add a parameter called `target_server_type` inspired by the `targetServerType` parameter in the [Postgres JDBC driver](https://jdbc.postgresql.org/documentation/head/connect.html). This option improves DB fail-overs by ensuring that we are reconnecting to the right instance. It is also mentioned in the AWS [DB fail-over best practices document](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.BestPractices.html#AuroraPostgreSQL.BestPractices.FastFailover).

Based on my testing, from the point of view of the client application, a DB fail-over on AWS Aurora Postgres evolves like this:

1. Let's start with our client app being connected to the primary instance. It is therefore able to do read and write operations on the database.
2. When the fail-over starts, the primary instance (let's call it instance-1) will stop all its TCP connections to the client.
3. The client will try to reestablish a connection. The DB instance (instance-1) will then refuse to open a TCP connection (`tcp connect: connection refused - :econnrefused`)
4. The client will retry to reestablish a connection. The DB instance (instance-1) will then accept the TCP connection but refuse the DB connection (`FATAL 57P03 (cannot_connect_now) the database system is starting up`)
5. The client will continue to retry until the DB instance (instance-1) is ready. Then the client is able to establish a connection and the connection is added to the connection pool.
6. That connection is checked out from the pool and a query is executed using that connection but the query fails because the connection is between the client and the -now- secondary instance. Lucky `disconnect_on_error_codes` kicks in and the connection is reset and removed from the pool.
7. Finally, the AWS DNS switch kicks in and the read/write cluster endpoint now redirect toward instance-2 - the new primary instance. Any connection attempted after this point will be made to the new primary instance which is ready to handle connections by this point.

This PR allows Postgrex to better fail-fast during fail-overs. If the client is unable to connection to the right type of instance, it will fail instead of silently being placed in the pool and fail on the next write operation.
The downside is that it leads to a growing time between each connection attempt (because of the exponential back-off in `DBConnection.ConnectionPool`). The solution to that problem would be to use a more aggressive "backoff_max" setting.


With the following options:
{:ok, pid} = Postgrex.start_link(hostname: "test.cluster-XXX.eu-west-1.rds.amazonaws.com", username: "postgres",  password: "XXXXX",  database: "postgres", show_sensitive_data_on_connection_error: true, target_server_type: :primary, backoff_max: 2_000)

We get this behavior:
```
21:17:54.367 [error] Postgrex.Protocol (#PID<0.207.0>) disconnected: ** (DBConnection.ConnectionError) tcp recv: closed

21:17:54.406 [error] Postgrex.Protocol #PID<0.207.0> could not cancel backend: tcp connect: connection refused - :econnrefused

21:17:54.481 [error] Postgrex.Protocol (#PID<0.207.0>) failed to connect: ** (DBConnection.ConnectionError) tcp connect (test.cluster-XXX.eu-west-1.rds.amazonaws.com:5432): connection refused - :econnrefused

21:17:57.318 [error] Postgrex.Protocol (#PID<0.207.0>) failed to connect: ** (Postgrex.Error) FATAL 57P03 (cannot_connect_now) the database system is starting up

21:17:59.176 [error] Postgrex.Protocol (#PID<0.207.0>) failed to connect: ** (Postgrex.Error) the server type is not as expected. expected: primary. actual: secondary

21:18:01.053 [error] Postgrex.Protocol (#PID<0.207.0>) failed to connect: ** (Postgrex.Error) the server type is not as expected. expected: primary. actual: secondary

21:18:02.875 [error] Postgrex.Protocol (#PID<0.207.0>) failed to connect: ** (Postgrex.Error) the server type is not as expected. expected: primary. actual: secondary

21:18:04.846 [error] Postgrex.Protocol (#PID<0.207.0>) failed to connect: ** (Postgrex.Error) the server type is not as expected. expected: primary. actual: secondary

(no more errors afterwards which means the next connection attempt was successful)
```

Which means a total downtime of 12 seconds. The downtime would have been the same without target_server_type but with a lot more unnecessary connections made to the database.

The way `target_server_type` is implemented is by issuing show `transaction_read_only` on the instance and checking the result (`false` means that the instance is `primary` and vise versa). It is the same way the parameter is implemented in the JDBC driver (https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java#L848). This method is also mentioned in the [Postgres documentation](https://www.postgresql.org/docs/12/hot-standby.html).

Final notes:
* I'm open for suggestions on how to better test the feature (tests are lacking at the moment because the test suite is made against one single instance). 
* The DB fail-over could be improved even more in the future by supporting a list of hosts that should be tried, one by one, in order, when trying to establish a new connection.