### PR TITLE
Fix failing test / formatter error (13, 1.11.3, 23.2.5) 

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -883,10 +883,8 @@ defmodule Postgrex.Protocol do
 
   defp check_target_server_type_done(s, status, buffer), do: bootstrap(s, status, buffer)
 
-  defp check_target_server_type_fail(s, expected_server_type, actual_server_type) do
-    msg =
-      "the server type is not as expected. expected: #{expected_server_type}. actual: #{actual_server_type}"
-
+  defp check_target_server_type_fail(s, expected, actual) do
+    msg = "the server type is not as expected. expected: #{expected}. actual: #{actual}"
     err = %Postgrex.Error{message: msg}
     {:disconnect, err, s}
   end


### PR DESCRIPTION
~I think this may fix~ This fixes the test-failure currently being reported for the gh action `test (13, 1.11.3, 23.2.5)` on master...