### PR TITLE
Improve error handling when using multiple endpoints

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -178,7 +178,7 @@ defmodule Postgrex.Protocol do
       end)
       |> Enum.join(", ")
 
-    {:error, %Postgrex.Error{message: "[#{concat_messages}]"}}
+    {:error, %Postgrex.Error{message: "failed to establish connection to multiple endpoints: #{concat_messages}"}}
   end
 
   defp connect_and_handshake(host, port, sock_opts, timeout, s, status) do

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -175,7 +175,7 @@ defmodule Postgrex.Protocol do
       errors
       |> Enum.reverse()
       |> Enum.map(fn %error_module{} = error ->
-        "#{error_module}: \"#{Exception.message(error)}\""
+        "#{inspect(error_module)}: \"#{Exception.message(error)}\""
       end)
       |> Enum.join(", ")
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -157,7 +157,14 @@ defmodule Postgrex.Protocol do
         ret
 
       {:error, err} ->
-        connect_endpoints(remaining_endpoints, sock_opts, timeout, s, status, previous_errors ++ [err])
+        connect_endpoints(
+          remaining_endpoints,
+          sock_opts,
+          timeout,
+          s,
+          status,
+          previous_errors ++ [err]
+        )
     end
   end
 
@@ -166,7 +173,9 @@ defmodule Postgrex.Protocol do
   defp connect_endpoints([], _, _, _, _, errors) when is_list(errors) do
     concat_messages =
       errors
-      |> Enum.map(fn %error_module{} = error -> "#{error_module}: \"#{Exception.message(error)}\"" end)
+      |> Enum.map(fn %error_module{} = error ->
+        "#{error_module}: \"#{Exception.message(error)}\""
+      end)
       |> Enum.join(", ")
 
     {:error, %Postgrex.Error{message: "[#{concat_messages}]"}}

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -163,7 +163,7 @@ defmodule Postgrex.Protocol do
           timeout,
           s,
           status,
-          previous_errors ++ [err]
+          [err | previous_errors]
         )
     end
   end
@@ -173,12 +173,16 @@ defmodule Postgrex.Protocol do
   defp connect_endpoints([], _, _, _, _, errors) when is_list(errors) do
     concat_messages =
       errors
+      |> Enum.reverse()
       |> Enum.map(fn %error_module{} = error ->
         "#{error_module}: \"#{Exception.message(error)}\""
       end)
       |> Enum.join(", ")
 
-    {:error, %Postgrex.Error{message: "failed to establish connection to multiple endpoints: #{concat_messages}"}}
+    {:error,
+     %Postgrex.Error{
+       message: "failed to establish connection to multiple endpoints: #{concat_messages}"
+     }}
   end
 
   defp connect_and_handshake(host, port, sock_opts, timeout, s, status) do

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -214,7 +214,7 @@ defmodule LoginTest do
 
              assert_start_and_killed(opts ++ context[:options])
            end) =~
-             ~r'\*\* \(Postgrex\.Error\) failed to establish connection to multiple endpoints: Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary", Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary"'
+             ~r'\*\* \(Postgrex\.Error\) failed to establish connection to multiple endpoints: Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary", Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary"'
   end
 
   test "translates provided port number to integer" do

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -214,7 +214,7 @@ defmodule LoginTest do
 
              assert_start_and_killed(opts ++ context[:options])
            end) =~
-             ~r"\*\* \(Postgrex.Error\) the server type is not as expected. expected: secondary. actual: primary"
+             ~r'\*\* \(Postgrex\.Error\) \[Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary", Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary"\]'
   end
 
   test "translates provided port number to integer" do

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -214,7 +214,7 @@ defmodule LoginTest do
 
              assert_start_and_killed(opts ++ context[:options])
            end) =~
-             ~r'\*\* \(Postgrex\.Error\) \[Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary", Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary"\]'
+             ~r'\*\* \(Postgrex\.Error\) failed to establish connection to multiple endpoints: Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary", Elixir\.Postgrex\.Error\: "the server type is not as expected\. expected\: secondary\. actual\: primary"'
   end
 
   test "translates provided port number to integer" do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/postgrex/issues/542

If Postgrex tries to connect to more than one database instance and if the connection fails for all of them, one global exception is raised and its message is a concatenation of all the exceptions message (one exception per connection failed). 

This PR doesn't alter the behavior of the library if connection is attempted to only one instance (using either the `hostname` & `port` config options, the UNIX socket option or the `endpoints` option with only one {hostname,port} tuple).