### PR TITLE
Add tests to the error handling when using multiple endpoints

### DIFF
--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -230,7 +230,7 @@ defmodule LoginTest do
 
              assert_start_and_killed(opts ++ context[:options])
            end) =~
-             ~r'\*\* \(Postgrex\.Error\) failed to establish connection to multiple endpoints\: DBConnection\.ConnectionError\: "tcp connect \(doesntexist\:5432\)\: non\-existing domain \- \:nxdomain", DBConnection\.ConnectionError\: "tcp connect \(localhost\:5555\)\: connection refused \- \:econnrefused"'
+             ~r'\*\* \(Postgrex\.Error\) failed to establish connection to multiple endpoints\:\n\n  \* doesntexist\:5432\: \(DBConnection\.ConnectionError\) tcp connect \(doesntexist\:5432\)\: non\-existing domain \- \:nxdomain\n  \* localhost\:5555\: \(DBConnection\.ConnectionError\) tcp connect \(localhost\:5555\)\: connection refused \- \:econnrefused'
   end
 
   test "outputs a single error message when only one endpoint is used", context do

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -208,7 +208,7 @@ defmodule LoginTest do
   test "server type 'secondary' against two primary instances", context do
     message =
       capture_log(fn ->
-       opts = [
+        opts = [
           endpoints: [{"localhost", 5432}, {"localhost", 5432}],
           target_server_type: :secondary
         ]
@@ -216,8 +216,11 @@ defmodule LoginTest do
         assert_start_and_killed(opts ++ context[:options])
       end)
 
-    assert message =~ "** (Postgrex.Error) failed to establish connection to multiple endpoints:\n\n"
-    assert message =~ "  * localhost:5432: (Postgrex.Error) the server type is not as expected. expected: secondary. actual: primary"
+    assert message =~
+             "** (Postgrex.Error) failed to establish connection to multiple endpoints:\n\n"
+
+    assert message =~
+             "  * localhost:5432: (Postgrex.Error) the server type is not as expected. expected: secondary. actual: primary"
   end
 
   test "outputs an error message per attempted endpoint when more than one endpoint is used",


### PR DESCRIPTION
This PR is a minor follow up to https://github.com/elixir-ecto/postgrex/pull/544. I thought it would be better to add those 2 tests to the error handling