### PR TITLE
Support negative years for date, timestamp and timestampz types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
             lint: lint
           - pg: 13
             pair:
-              elixir: 1.6.6
-              otp: 19.3.6.13
+              elixir: 1.11.4
+              otp: 21.3
     env:
       MIX_ENV: test
     steps:

--- a/lib/postgrex/extensions/date.ex
+++ b/lib/postgrex/extensions/date.ex
@@ -11,7 +11,7 @@ defmodule Postgrex.Extensions.Date do
   @max_days Date.to_gregorian_days(~D[9999-12-31])
 
   # Elixir supports earlier dates but this is the
-  # earliest supported in Postfresql
+  # earliest supported in Postgresql.
   @min_days Date.to_gregorian_days(~D[-4713-01-01])
 
   def encode(_) do

--- a/lib/postgrex/extensions/date.ex
+++ b/lib/postgrex/extensions/date.ex
@@ -3,9 +3,16 @@ defmodule Postgrex.Extensions.Date do
   import Postgrex.BinaryUtils, warn: false
   use Postgrex.BinaryExtension, send: "date_send"
 
-  @gd_epoch :calendar.date_to_gregorian_days({2000, 1, 1})
+  @gd_epoch Date.to_gregorian_days(~D[2000-01-01])
   @max_year 9999
-  @max_days 3_652_424
+
+  # Latest date supported by Elixir. Postgresql
+  # supports later dates.
+  @max_days Date.to_gregorian_days(~D[9999-12-31])
+
+  # Elixir supports earlier dates but this is the
+  # earliest supported in Postfresql
+  @min_days Date.to_gregorian_days(~D[-4713-01-01])
 
   def encode(_) do
     quote location: :keep do
@@ -26,9 +33,8 @@ defmodule Postgrex.Extensions.Date do
 
   ## Helpers
 
-  def encode_elixir(%Date{year: year, month: month, day: day}) when year <= @max_year do
-    date = {year, month, day}
-    <<4::int32, :calendar.date_to_gregorian_days(date) - @gd_epoch::int32>>
+  def encode_elixir(%Date{year: year} = date) when year <= @max_year do
+    <<4::int32, Date.to_gregorian_days(date) - @gd_epoch::int32>>
   end
 
   def encode_elixir(%Date{} = date) do
@@ -38,13 +44,11 @@ defmodule Postgrex.Extensions.Date do
   def day_to_elixir(days) do
     days = days + @gd_epoch
 
-    if days in 0..@max_days do
-      days
-      |> :calendar.gregorian_days_to_date()
-      |> Date.from_erl!()
+    if days in @min_days..@max_days do
+      Date.from_gregorian_days(days)
     else
       raise ArgumentError,
-            "Postgrex can only decode dates with days between 0 and #{@max_days}, " <>
+            "Postgrex can only decode dates with days between #{@min_days} and #{@max_days}, " <>
               "got: #{inspect(days)}"
     end
   end

--- a/lib/postgrex/extensions/timestamp.ex
+++ b/lib/postgrex/extensions/timestamp.ex
@@ -34,16 +34,19 @@ defmodule Postgrex.Extensions.Timestamp do
 
   ## Helpers
 
-  def encode_elixir(%_{
-        year: year,
-        hour: hour,
-        minute: min,
-        second: sec,
-        microsecond: {usec, _}
-      } = date_time)
-      when year <= @max_year and year >= @min_year and hour in 0..23 and min in 0..59 and sec in 0..59 and
+  def encode_elixir(
+        %_{
+          year: year,
+          hour: hour,
+          minute: min,
+          second: sec,
+          microsecond: {usec, _}
+        } = date_time
+      )
+      when year <= @max_year and year >= @min_year and hour in 0..23 and min in 0..59 and
+             sec in 0..59 and
              usec in 0..999_999 do
-    {gregorian_seconds, usec} =  NaiveDateTime.to_gregorian_seconds(date_time)
+    {gregorian_seconds, usec} = NaiveDateTime.to_gregorian_seconds(date_time)
     secs = gregorian_seconds - @gs_epoch
     <<8::int32, secs * 1_000_000 + usec::int64>>
   end

--- a/lib/postgrex/extensions/timestamptz.ex
+++ b/lib/postgrex/extensions/timestamptz.ex
@@ -3,14 +3,16 @@ defmodule Postgrex.Extensions.TimestampTZ do
   import Postgrex.BinaryUtils, warn: false
   use Postgrex.BinaryExtension, send: "timestamptz_send"
 
-  @gs_epoch :calendar.datetime_to_gregorian_seconds({{2000, 1, 1}, {0, 0, 0}})
-  @max_year 294_276
+  @gs_epoch NaiveDateTime.to_gregorian_seconds(~N[2000-01-01 00:00:00.0]) |> elem(0)
 
-  @gs_unix_epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
+  @gs_unix_epoch NaiveDateTime.to_gregorian_seconds(~N[1970-01-01 00:00:00.0]) |> elem(0)
   @us_epoch (@gs_epoch - @gs_unix_epoch) * 1_000_000
-  @gs_max :calendar.datetime_to_gregorian_seconds({{@max_year + 1, 1, 1}, {0, 0, 0}}) -
-            @gs_unix_epoch
+
+  @gs_max elem(NaiveDateTime.to_gregorian_seconds(~N[9999-01-01 00:00:00.0]), 0) - @gs_unix_epoch
   @us_max @gs_max * 1_000_000
+
+  @gs_min elem(NaiveDateTime.to_gregorian_seconds(~N[-4713-01-01 00:00:00.0]), 0) - @gs_unix_epoch
+  @us_min @gs_min * 1_000_000
 
   @plus_infinity 9_223_372_036_854_775_807
   @minus_infinity -9_223_372_036_854_775_808
@@ -39,11 +41,11 @@ defmodule Postgrex.Extensions.TimestampTZ do
 
   def encode_elixir(%DateTime{utc_offset: 0, std_offset: 0} = datetime) do
     case DateTime.to_unix(datetime, :microsecond) do
-      microsecs when microsecs < @us_max ->
+      microsecs when microsecs in @us_min..@us_max ->
         <<8::int32, microsecs - @us_epoch::int64>>
 
       _ ->
-        raise ArgumentError, "#{inspect(datetime)} is beyond the maximum year 294276"
+        raise ArgumentError, "#{inspect(datetime)} is not in the year range -4713..9999"
     end
   end
 
@@ -67,11 +69,8 @@ defmodule Postgrex.Extensions.TimestampTZ do
     raise ArgumentError, """
     got \"#{type}\" from PostgreSQL. If you want to support infinity timestamps \
     in your application, you can enable them by defining your own types:
-
         Postgrex.Types.define(MyApp.PostgrexTypes, [], allow_infinite_timestamps: true)
-
     And then configuring your database to use it:
-
         types: MyApp.PostgrexTypes
     """
   end


### PR DESCRIPTION
Supports negative years for the types date, timestamp,
timestampz. A side effect is that the `:calendar` module
is no longer used.

**This implementation support only Elixir 1.11 and 1.12** because
of its use of `NaiveDateTime.to_gregorian_seconds/1`. I looked
at using the private `rata die` functions but that would require
reimplementation of quite a lot of code - or making some private
functions public.

* Support years down to -4713 in date, timestamp and
timestampz type since that is the minimum year supported
by Postgresql

* Support years up to 9999 in timestampz (which is less
than that supported by [Postgresql](https://www.postgresql.org/docs/9.1/datatype-datetime.html))
but is the maximum supported by `Calendar.ISO`.

* Add tests for negative dates, timestamps and timestampz