### PR TITLE
Require elixir v11+

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Postgrex.Mixfile do
     [
       app: :postgrex,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.11",
       deps: deps(),
       name: "Postgrex",
       description: "PostgreSQL driver for Elixir",


### PR DESCRIPTION
Since https://github.com/elixir-ecto/postgrex/pull/547, Postgrex requires elixir v11 or superior.