### PR TITLE
Fix invalid type error after failover

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1345,12 +1345,12 @@ defmodule Postgrex.Protocol do
   end
 
   defp recv_parse_describe(
-         %{types: proto_types} = s,
+         %{types: protocol_types} = s,
          status,
          %Query{ref: ref, types: query_types} = query,
          buffer
        )
-       when ref == nil or proto_types != query_types do
+       when ref == nil or protocol_types != query_types do
     with {:ok, s, buffer} <- recv_parse(s, status, buffer),
          {:ok, param_oids, result_oids, columns, s, buffer} <- recv_describe(s, status, buffer) do
       describe(s, query, param_oids, result_oids, columns, buffer)

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1815,10 +1815,6 @@ defmodule Postgrex.Protocol do
 
   ## execute
 
-  defp query_error(s, msg) do
-    {:error, Postgrex.QueryError.exception(msg), s}
-  end
-
   defp lock_error(s, fun) do
     msg = "connection is locked copying to or from the database and can not #{fun} transaction"
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -2116,16 +2116,12 @@ defmodule Postgrex.Protocol do
     lock_error(s, :bind, query)
   end
 
-  defp handle_bind(%Query{types: types} = query, params, res, opts, %{types: types} = s) do
+  defp handle_bind(query, params, res, opts, s) do
     if query_member?(s, query) do
       rebind(s, new_status(opts), query, params, res)
     else
       handle_prepare_bind(query, params, res, opts, s)
     end
-  end
-
-  defp handle_bind(%Query{} = query, _, _, _, s) do
-    query_error(s, "query #{inspect(query)} has invalid types for the connection")
   end
 
   defp handle_prepare_bind(%Query{name: ""} = query, params, res, opts, s) do

--- a/test/custom_extensions_test.exs
+++ b/test/custom_extensions_test.exs
@@ -137,16 +137,6 @@ defmodule CustomExtensionsTest do
            end) =~ "(RuntimeError) decode"
   end
 
-  test "raise when executing prepared query on connection with different types", context do
-    query = prepare("S42", "SELECT 42")
-
-    opts = [types: Postgrex.DefaultTypes] ++ context[:options]
-    {:ok, pid2} = Postgrex.start_link(opts)
-
-    {:error, %Postgrex.QueryError{message: message}} = Postgrex.execute(pid2, query, [])
-    assert message =~ ~r"invalid types for the connection"
-  end
-
   test "raise when streaming prepared query on connection with different types", context do
     query = prepare("S42", "SELECT 42")
 


### PR DESCRIPTION
This PR fixes https://github.com/elixir-ecto/postgrex/issues/550

The change to `recv_parse_describe` ensures that in case the Protocol & Query's `types` differ, the Query gets a new ref (to trigger an update to the Ecto cache) and gets the Protocol's `types` (both of these are done in `describe_result/4`).

Todo:
- [x] Maybe the same change should be done for the streaming of a prepared query?