### PR TITLE
Mark code that uses improper lists as generated

### DIFF
--- a/lib/postgrex/extensions/bit_string.ex
+++ b/lib/postgrex/extensions/bit_string.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.BitString do
   def init(opts), do: Keyword.fetch!(opts, :decode_binary)
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       val when is_binary(val) ->
         [<<byte_size(val) + 4::int32, bit_size(val)::uint32>> | val]
 

--- a/lib/postgrex/extensions/box.ex
+++ b/lib/postgrex/extensions/box.ex
@@ -5,7 +5,7 @@ defmodule Postgrex.Extensions.Box do
   alias Postgrex.Extensions.Point
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       %Postgrex.Box{upper_right: p1, bottom_left: p2} ->
         encoded_p1 = Point.encode_point(p1, Postgrex.Box)
         encoded_p2 = Point.encode_point(p2, Postgrex.Box)

--- a/lib/postgrex/extensions/line_segment.ex
+++ b/lib/postgrex/extensions/line_segment.ex
@@ -5,7 +5,7 @@ defmodule Postgrex.Extensions.LineSegment do
   alias Postgrex.Extensions.Point
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       %Postgrex.LineSegment{point1: p1, point2: p2} ->
         encoded_p1 = Point.encode_point(p1, Postgrex.LineSegment)
         encoded_p2 = Point.encode_point(p2, Postgrex.LineSegment)

--- a/lib/postgrex/extensions/name.ex
+++ b/lib/postgrex/extensions/name.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.Name do
   def init(opts), do: Keyword.fetch!(opts, :decode_binary)
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       name when is_binary(name) and byte_size(name) < 64 ->
         [<<byte_size(name)::int32>> | name]
 

--- a/lib/postgrex/extensions/numeric.ex
+++ b/lib/postgrex/extensions/numeric.ex
@@ -4,7 +4,7 @@ defmodule Postgrex.Extensions.Numeric do
   use Postgrex.BinaryExtension, send: "numeric_send"
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       %Decimal{} = decimal ->
         data = unquote(__MODULE__).encode_numeric(decimal)
         [<<IO.iodata_length(data)::int32>> | data]

--- a/lib/postgrex/extensions/path.ex
+++ b/lib/postgrex/extensions/path.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.Path do
   alias Postgrex.Extensions.Point
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       %Postgrex.Path{open: o, points: ps} when is_list(ps) and is_boolean(o) ->
         open_byte = Path.open_to_byte(o)
         len = length(ps)

--- a/lib/postgrex/extensions/polygon.ex
+++ b/lib/postgrex/extensions/polygon.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.Polygon do
   alias Postgrex.Extensions.Point
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       %Postgrex.Polygon{vertices: vertices} when is_list(vertices) ->
         len = length(vertices)
 

--- a/lib/postgrex/extensions/raw.ex
+++ b/lib/postgrex/extensions/raw.ex
@@ -15,7 +15,7 @@ defmodule Postgrex.Extensions.Raw do
   def init(opts), do: Keyword.fetch!(opts, :decode_binary)
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       bin when is_binary(bin) ->
         [<<byte_size(bin)::int32>> | bin]
 

--- a/lib/postgrex/extensions/uuid.ex
+++ b/lib/postgrex/extensions/uuid.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.UUID do
   def init(opts), do: Keyword.fetch!(opts, :decode_binary)
 
   def encode(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       uuid when is_binary(uuid) and byte_size(uuid) == 16 ->
         [<<16::int32>> | uuid]
 

--- a/lib/postgrex/type_module.ex
+++ b/lib/postgrex/type_module.ex
@@ -333,7 +333,7 @@ defmodule Postgrex.TypeModule do
   end
 
   defp decode_rows(dispatch, rest, acc, rem, full, rows) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       def decode_rows(binary, types, rows) do
         decode_rows(binary, byte_size(binary), types, rows)
       end
@@ -464,7 +464,7 @@ defmodule Postgrex.TypeModule do
         decode_tuple_dispatch(extension, format, rest, oids, n, acc)
       end
 
-    quote do
+    quote generated: true do
       def decode_tuple(<<rest::binary>>, count, types) when is_integer(count) do
         decode_tuple(rest, count, types, 0, [])
       end


### PR DESCRIPTION
Addresses [#549](https://github.com/elixir-ecto/postgrex/issues/549) by marking code that creates improper lists as `generated: true`.

If it's preferable to explicitly opt-out of the specific Dialyzer warnings (using `@dialyzer`), that's an easy change.