### PR TITLE
[#558] Support xid8 type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Enhancements
+  * Support `xid8` type introduced in PostgreSQL 13
+
 ## v0.15.9 (2021-04-24)
 
 * Enhancements

--- a/lib/postgrex/binary_utils.ex
+++ b/lib/postgrex/binary_utils.ex
@@ -13,12 +13,16 @@ defmodule Postgrex.BinaryUtils do
     quote do: signed - 16
   end
 
-  defmacro uint16 do
-    quote do: unsigned - 16
+  defmacro uint64 do
+    quote do: unsigned - 64
   end
 
   defmacro uint32 do
     quote do: unsigned - 32
+  end
+
+  defmacro uint16 do
+    quote do: unsigned - 16
   end
 
   defmacro int8 do

--- a/lib/postgrex/extensions/xid8.ex
+++ b/lib/postgrex/extensions/xid8.ex
@@ -1,0 +1,25 @@
+defmodule Postgrex.Extensions.Xid8 do
+  @moduledoc false
+  import Postgrex.BinaryUtils, warn: false
+  use Postgrex.BinaryExtension, send: "xid8send"
+
+  @xid8_range 0..18_446_744_073_709_551_615
+
+  def encode(_) do
+    range = Macro.escape(@xid8_range)
+
+    quote location: :keep do
+      int when is_integer(int) and int in unquote(range) ->
+        <<8::int32, int::uint64>>
+
+      other ->
+        raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, unquote(range))
+    end
+  end
+
+  def decode(_) do
+    quote location: :keep do
+      <<8::int32, int::uint64>> -> int
+    end
+  end
+end

--- a/lib/postgrex/extensions/xid8.ex
+++ b/lib/postgrex/extensions/xid8.ex
@@ -9,7 +9,7 @@ defmodule Postgrex.Extensions.Xid8 do
     range = Macro.escape(@xid8_range)
 
     quote location: :keep do
-      int when is_integer(int) and int in unquote(range) ->
+      int when int in unquote(range) ->
         <<8::int32, int::uint64>>
 
       other ->

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -38,7 +38,8 @@ defmodule Postgrex.Utils do
     Postgrex.Extensions.TSVector,
     Postgrex.Extensions.UUID,
     Postgrex.Extensions.VoidBinary,
-    Postgrex.Extensions.VoidText
+    Postgrex.Extensions.VoidText,
+    Postgrex.Extensions.Xid8
   ]
 
   @doc """


### PR DESCRIPTION
Fixes #558 

This patch adds support for the `xid8` type introduced in PostgreSQL 13.