### PR TITLE
Fix reraise usage in DBConnection.Query.encode/3 for Postgrex.Copy

### DIFF
--- a/lib/postgrex/stream.ex
+++ b/lib/postgrex/stream.ex
@@ -101,7 +101,8 @@ defimpl DBConnection.Query, for: Postgrex.Copy do
     rescue
       ArgumentError ->
         reraise ArgumentError,
-                "expected iodata to copy to database, got: " <> inspect(data)
+                [message: "expected iodata to copy to database, got: " <> inspect(data)],
+                __STACKTRACE__
     else
       iodata ->
         {:copy_data, iodata}


### PR DESCRIPTION
reraise/2 takes stacktrace as second argument,
reraise/3 accepts optional arguments for the exception