### PR TITLE
Fix possible crash on getting default opts

### DIFF
--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -88,7 +88,8 @@ defmodule Postgrex.Utils do
     |> Keyword.put_new(:password, System.get_env("PGPASSWORD"))
     |> Keyword.put_new(:database, System.get_env("PGDATABASE"))
     |> Keyword.put_new(:hostname, System.get_env("PGHOST") || "localhost")
-    |> Keyword.update(:port, normalize_port(System.get_env("PGPORT")), &normalize_port/1)
+    |> Keyword.put_new(:port, System.get_env("PGPORT"))
+    |> Keyword.update!(:port, &normalize_port/1)
     |> Keyword.put_new(:types, Postgrex.DefaultTypes)
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
   end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -31,4 +31,12 @@ defmodule UtilsTest do
                Postgrex.Utils.parse_version("12beta1 (Debian 10.2-1.pgdg90+1)")
     end
   end
+
+  describe "default_opts/1" do
+    test "ignores garbage in PGPORT when port already present" do
+      System.put_env("PGPORT", "")
+      opts = Postgrex.Utils.default_opts(port: "6432")
+      assert Keyword.get(opts, :port) == 6432
+    end
+  end
 end


### PR DESCRIPTION
My application could not start because of empty PGPORT env variable. That behaviour was completely unexpected, because I provided ecto with port in application settings. So env variable wasn't going to be used anyway, but prevented application from starting.