### PR TITLE
Add extra_ssl_opts to endpoints config

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -81,8 +81,8 @@ defmodule Postgrex do
     * `:endpoints` - A list of endpoints (host and port pairs, with an optional
       extra_opts keyword list);
       Postgrex will try each endpoint in order, one by one, until the connection succeeds;
-      The syntax is `[{host1,port1},{host2,port2},{host3,port3}]` or
-      [{host1,port1, [extra_opt1: value]},{host2,port2, [extra_opt2: value]}}];
+      The syntax is `[{host1, port1},{host2, port2},{host3, port3}]` or
+      `[{host1, port1, extra_opt1: value},{host2, port2, extra_opt2: value}}]`;
       This option takes precedence over `:hostname+:port`;
     * `:socket_dir` - Connect to PostgreSQL via UNIX sockets in the given directory;
       The socket name is derived based on the port. This is the preferred method
@@ -221,6 +221,7 @@ defmodule Postgrex do
       ]
 
   ### Failover with SSL support
+
   As specified in Erlang [:ssl.connect](https://erlang.org/doc/man/ssl.html#connect-3),
   host verification using `:public_key.pkix_verify_hostname_match_fun(:https)`
   requires that the ssl_opt `server_name_indication` is set, and for this reason,

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -79,7 +79,7 @@ defmodule Postgrex do
     * `:hostname` - Server hostname (default: PGHOST env variable, then localhost);
     * `:port` - Server port (default: PGPORT env variable, then 5432);
     * `:endpoints` - A list of endpoints (host and port pairs, with an optional
-      extra_ssl_opts keyword list);
+      extra_opts keyword list);
       Postgrex will try each endpoint in order, one by one, until the connection succeeds;
       The syntax is `[{host1,port1},{host2,port2},{host3,port3}]` or
       [{host1,port1, [extra_opt1: value]},{host2,port2, [extra_opt2: value]}}];
@@ -230,13 +230,13 @@ defmodule Postgrex do
         {
           "test-instance-1.xyz.eu-west-1.rds.amazonaws.com",
           5432,
-          [server_name_indication: String.to_charlist("test-instance-1.xyz.eu-west-1.rds.amazonaws.com")]
+          [ssl: [server_name_indication: String.to_charlist("test-instance-1.xyz.eu-west-1.rds.amazonaws.com")]]
         },
         (...),
         {
           "test-instance-2.xyz.eu-west-1.rds.amazonaws.com",
           5432,
-          [server_name_indication: String.to_charlist("test-instance-2.xyz.eu-west-1.rds.amazonaws.com")]
+          [ssl: [server_name_indication: String.to_charlist("test-instance-2.xyz.eu-west-1.rds.amazonaws.com")]]
         }
       ]
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -122,11 +122,9 @@ defmodule Postgrex.Protocol do
           :error ->
             case Keyword.fetch(opts, :endpoints) do
               {:ok, endpoints} when is_list(endpoints) ->
-                Enum.map(endpoints, fn endpoint ->
-                  case endpoint do
-                    {hostname, port} -> {to_charlist(hostname), port, []}
-                    {hostname, port, extra_opts} -> {to_charlist(hostname), port, extra_opts}
-                  end
+                Enum.map(endpoints, fn
+                  {hostname, port} -> {to_charlist(hostname), port, []}
+                  {hostname, port, extra_opts} -> {to_charlist(hostname), port, extra_opts}
                 end)
 
               {:ok, _} ->

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -112,12 +112,12 @@ defmodule Postgrex.Protocol do
 
     case Keyword.fetch(opts, :socket) do
       {:ok, file} ->
-        [{{:local, file}, 0}]
+        [{{:local, file}, 0, []}]
 
       :error ->
         case Keyword.fetch(opts, :socket_dir) do
           {:ok, dir} ->
-            [{{:local, "#{dir}/.s.PGSQL.#{port}"}, 0}]
+            [{{:local, "#{dir}/.s.PGSQL.#{port}"}, 0, []}]
 
           :error ->
             case Keyword.fetch(opts, :endpoints) do
@@ -133,7 +133,7 @@ defmodule Postgrex.Protocol do
               :error ->
                 case Keyword.fetch(opts, :hostname) do
                   {:ok, hostname} ->
-                    [{to_charlist(hostname), port}]
+                    [{to_charlist(hostname), port, []}]
 
                   :error ->
                     raise ArgumentError,

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -82,6 +82,13 @@ defmodule LoginTest do
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
+  @tag :ssl
+  test "ssl with extra_ssl_opts in endpoints", context do
+    opts = [ssl: true, endpoints: [{"localhost", 5555, [verify_peer: :none]}]]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
   test "env var defaults", context do
     assert {:ok, pid} = P.start_link(context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
@@ -195,6 +202,12 @@ defmodule LoginTest do
 
   test "endpoints with two choices, the first will not accept a connection", context do
     opts = [endpoints: [{"localhost", 5555}, {"localhost", 5432}]]
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
+  test "endpoints with extra_ssl_opts", context do
+    opts = [endpoints: [{"localhost", 5555, [depth: 3]}, {"localhost", 5432, [depth: 3]}]]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -83,10 +83,18 @@ defmodule LoginTest do
   end
 
   @tag :ssl
-  test "ssl with extra_ssl_opts in endpoints", context do
-    opts = [ssl: true, endpoints: [{"localhost", 5555, [verify_peer: :none]}]]
+  test "ssl with extra_ssl_opts in endpoints succeeds", context do
+    opts = [ssl: true, endpoints: [{"localhost", 5555, [ssl: [verify_peer: :none]]}]]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
+  @tag :ssl
+  test "ssl with extra_ssl_opts in endpoints fails due to bad ssl_opt", context do
+    assert capture_log(fn ->
+            opts = [ssl: true, endpoints: [{"localhost", 5555, [ssl: [verify_peer: :foobar]]}]]
+            assert_start_and_killed(opts ++ context[:options])
+           end)
   end
 
   test "env var defaults", context do
@@ -206,8 +214,8 @@ defmodule LoginTest do
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
-  test "endpoints with extra_ssl_opts", context do
-    opts = [endpoints: [{"localhost", 5555, [depth: 3]}, {"localhost", 5432, [depth: 3]}]]
+  test "endpoints with extra_opts", context do
+    opts = [endpoints: [{"localhost", 5555, [ssl: [depth: 3]]}, {"localhost", 5432, [depth: 3]}]]
     assert {:ok, pid} = P.start_link(opts ++ context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -92,8 +92,8 @@ defmodule LoginTest do
   @tag :ssl
   test "ssl with extra_ssl_opts in endpoints fails due to bad ssl_opt", context do
     assert capture_log(fn ->
-            opts = [ssl: true, endpoints: [{"localhost", 5555, [ssl: [verify_peer: :foobar]]}]]
-            assert_start_and_killed(opts ++ context[:options])
+             opts = [ssl: true, endpoints: [{"localhost", 5555, [ssl: [verify_peer: :foobar]]}]]
+             assert_start_and_killed(opts ++ context[:options])
            end)
   end
 


### PR DESCRIPTION
This commit adds an optional third element in the `endpoints` config to be able to specify extra_ssl_options such as `server_name_indication` when using more than one host in the `endpoints` key.

More details are in https://github.com/elixir-ecto/postgrex/issues/571