### PR TITLE
replication functions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.11.4-otp-23
+erlang 23.3.4.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.11.4-otp-23
-erlang 23.3.4.4

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -302,9 +302,9 @@ defmodule Postgrex.Replication do
 
   ## Options
 
-    * `:wait` - When `true`, waits for an active slot to become inactive before
-      dropping it. When `false`, raises an error when an attemping to drop an active slot.
-      Defaults to `true`.
+    * `:wait` - When `true`, blocks while the slot is being used by a connection.
+      When `false`, returns an error if the slot is being used by a connection.
+      Defaults to `false`.
 
     * `:timeout` - Call timeout.
       Defaults to `5000`.

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -249,7 +249,6 @@ defmodule Postgrex.Replication do
 
     * `:reconnect_backoff` - time (in ms) between reconnection attempts when
       `auto_reconnect` is enabled. Defaults to `500`.
-
   """
   @spec start_link(module(), term(), Keyword.t()) ::
           {:ok, pid} | {:error, Postgrex.Error.t() | term}
@@ -261,33 +260,31 @@ defmodule Postgrex.Replication do
   end
 
   @doc """
-    Creates a logical replication slot with the given name and output plugin.
-    By default, PostgreSQL includes the `pgoutput` plugin.
+  Creates a logical replication slot with the given name and output plugin.
+  By default, PostgreSQL includes the `pgoutput` plugin.
 
-    Once replication has begun, no other commands can be given and this
-    function will return `{:error, :replication_started}`.
+  Once replication has begun, no other commands can be given and this
+  function will return `{:error, :replication_started}`.
 
-    ## Options
+  ## Options
 
-  * `:temporary` - When `true`, the slot will automatically drop when a session
-    finishes. When `false`, the slot will persist outside of the session.
-    Note that `false`  can lead to an unwanted build-up of WAL segments
-    that eventually kill your primary instance. Prior to PostgreSQL 13, replication
-    slots stop WAL segments from being removed until they are read by a consumer.
-    Since PostgreSQL 13, the system parameter `max_slot_wal_keep_size` can be used
-    to prevent this. [See PostgreSQL docs](https://www.postgresql.org/docs/current/runtime-config-replication.html)
-    Defaults to `true`.
+    * `:temporary` - When `true`, the slot will automatically drop when a session
+      finishes. When `false`, the slot will persist outside of the session.
+      Note that `false`  can lead to an unwanted build-up of WAL segments
+      that eventually kill your primary instance. Prior to PostgreSQL 13, replication
+      slots stop WAL segments from being removed until they are read by a consumer.
+      Since PostgreSQL 13, the system parameter `max_slot_wal_keep_size` can be used
+      to prevent this. [See PostgreSQL docs](https://www.postgresql.org/docs/current/runtime-config-replication.html)
+      Defaults to `true`.
 
-  * `:snapshot` - The type of logical snapshot for the slot. Must be one of
-    `:export`, `:noexport`, or `:use`.
-    Defaults to `:export`.
+    * `:snapshot` - The type of logical snapshot for the slot. Must be one of
+      `:export`, `:noexport`, or `:use`.
+      Defaults to `:export`.
 
-  * `:timeout` - Call timeout
-    Defaults to `5000`.
+    * `:timeout` - Call timeout
+      Defaults to `5000`.
 
-  To better understand the meaning of those options, [see PostgreSQL
-  replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
-
+  To better understand the meaning of those options, [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec create_slot(server, String.t(), atom(), Keyword.t()) ::
           :ok | {:error, Postgrex.Error.t()} | {:error, :replication_started}
@@ -298,23 +295,21 @@ defmodule Postgrex.Replication do
   end
 
   @doc """
-    Drops logical replication slot with the given name.
+  Drops logical replication slot with the given name.
 
-    Once replication has begun, no other commands can be given and this
-    function will return `{:error, :replication_started}`.
+  Once replication has begun, no other commands can be given and this
+  function will return `{:error, :replication_started}`.
 
-    ## Options
+  ## Options
 
-  * `:wait` - If true, waits for an active slot to become inactive before
-    dropping it. If false, raises an error when an attemping to drop an active slot.
-    Defaults to `true`.
+    * `:wait` - If true, waits for an active slot to become inactive before
+      dropping it. If false, raises an error when an attemping to drop an active slot.
+      Defaults to `true`.
 
-  * `:timeout` - Call timeout
-    Defaults to `5000`.
+    * `:timeout` - Call timeout
+      Defaults to `5000`.
 
-  To better understand the meaning of those options, [see PostgreSQL
-  replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
-
+  To better understand the meaning of those options, [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec drop_slot(server, String.t(), Keyword.t()) ::
           :ok | {:error, Postgrex.Error.t()} | {:error, :replication_started}
@@ -325,28 +320,26 @@ defmodule Postgrex.Replication do
   end
 
   @doc """
-    Starts logical replication on the given slot. If the slot's plugin requires
-    additional options, make sure to specify them using the `plugin_opts` option.
+  Starts logical replication on the given slot. If the slot's plugin requires
+  additional options, make sure to specify them using the `plugin_opts` option.
 
-    Once replication has begun, no other commands can be given and this
-    function will return `{:error, :replication_started}`.
+  Once replication has begun, no other commands can be given and this
+  function will return `{:error, :replication_started}`.
 
-    ## Options
+  ## Options
 
-  * `:plugin_opts` - It must be a keyword list and is used to configure
-    the output plugin assigned to the given slot.
+    * `:plugin_opts` - It must be a keyword list and is used to configure
+      the output plugin assigned to the given slot.
 
-  * `:start_pos` - The LSN value to start replication from. Must be
-    formatted as a string of two hexadecimal numbers of up to 8 digits
-    each, separated by a slash. e.g. `1/F73E0220`.
-    Defaults to `0/0`.
+    * `:start_pos` - The LSN value to start replication from. Must be
+      formatted as a string of two hexadecimal numbers of up to 8 digits
+      each, separated by a slash. e.g. `1/F73E0220`.
+      Defaults to `0/0`.
 
-  * `:timeout` - Call timeout
-    Defaults to `5000`.
+    * `:timeout` - Call timeout
+      Defaults to `5000`.
 
-  To better understand the meaning of those options, [see PostgreSQL
-  replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
-
+  To better understand the meaning of those options, [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec start_replication(server, String.t(), Keyword.t()) ::
           :ok | {:error, Postgrex.Error.t()} | {:error, :replication_started}

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -142,7 +142,7 @@ defmodule Postgrex.Replication do
   defstruct protocol: nil,
             state: nil,
             auto_reconnect: false,
-            reconnect_backoff: 500
+            reconnect_backoff: 500,
             replication_started: false,
             replication_opts: nil
 

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -152,7 +152,6 @@ defmodule Postgrex.Replication do
   @type state :: term
   @type copy :: binary
   @timeout 5000
-  @temporary true
   @commands [:create_slot, :drop_slot, :start_replication]
 
   @doc """
@@ -531,7 +530,7 @@ defmodule Postgrex.Replication do
   ## Queries
   defp(command(:create_slot, opts)) do
     slot = Keyword.fetch!(opts, :slot)
-    temporary? = Keyword.get(opts, :temporary, @temporary)
+    temporary? = Keyword.get(opts, :temporary, true)
     plugin = Keyword.fetch!(opts, :plugin)
     snapshot = Keyword.get(opts, :snapshot, :export)
 
@@ -546,7 +545,7 @@ defmodule Postgrex.Replication do
 
   defp command(:drop_slot, opts) do
     slot = Keyword.fetch!(opts, :slot)
-    wait? = Keyword.get(opts, :wait, true)
+    wait? = Keyword.get(opts, :wait, false)
 
     [
       "DROP_REPLICATION_SLOT ",

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -330,8 +330,8 @@ defmodule Postgrex.Replication do
   additional options, make sure to specify them using the `plugin_opts` option.
 
   If the connection was started with `auto_reconnect` set to `true`, then
-  replication will automatically be restarted with the replication options passed
-  into this function. You must ensure your system will not be affected by receiving
+  replication will automatically restart with the options passed into this
+  function. You must ensure your system will not be affected by receiving
   duplicate WAL updates. Note that temporary slots cannot be restarted due to the
   fact that they automatically drop upon disconnect.
 

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -281,7 +281,7 @@ defmodule Postgrex.Replication do
       `:export`, `:noexport`, or `:use`.
       Defaults to `:export`.
 
-    * `:timeout` - Call timeout
+    * `:timeout` - Call timeout.
       Defaults to `5000`.
 
   To better understand the meaning of those options, [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
@@ -306,7 +306,7 @@ defmodule Postgrex.Replication do
       dropping it. If false, raises an error when an attemping to drop an active slot.
       Defaults to `true`.
 
-    * `:timeout` - Call timeout
+    * `:timeout` - Call timeout.
       Defaults to `5000`.
 
   To better understand the meaning of those options, [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
@@ -336,7 +336,7 @@ defmodule Postgrex.Replication do
       each, separated by a slash. e.g. `1/F73E0220`.
       Defaults to `0/0`.
 
-    * `:timeout` - Call timeout
+    * `:timeout` - Call timeout.
       Defaults to `5000`.
 
   To better understand the meaning of those options, [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -142,8 +142,7 @@ defmodule Postgrex.Replication do
   defstruct protocol: nil,
             state: nil,
             auto_reconnect: false,
-            reconnect_backoff: 500,
-            slot_opts: nil,
+            reconnect_backoff: 500
             replication_started: false,
             replication_opts: nil
 

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -302,8 +302,8 @@ defmodule Postgrex.Replication do
 
   ## Options
 
-    * `:wait` - If true, waits for an active slot to become inactive before
-      dropping it. If false, raises an error when an attemping to drop an active slot.
+    * `:wait` - When `true`, waits for an active slot to become inactive before
+      dropping it. When `false`, raises an error when an attemping to drop an active slot.
       Defaults to `true`.
 
     * `:timeout` - Call timeout.

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -3,9 +3,8 @@ defmodule Postgrex.Replication do
   A process that receives and sends PostgreSQL replication messages.
 
   > Note: this module is experimental and provides limited functionality.
-  > In particular, it only currently handles temporary logical replication
-  > with a WAL starting point specified by the server. We are glad to
-  > discuss and receive pull requests that extends the scope of the module.
+  > We are glad to discuss and receive pull requests that extends the
+  > scope of the module.
 
   ## Logical replication
 
@@ -62,16 +61,8 @@ defmodule Postgrex.Replication do
         use Postgrex.Replication
 
         def start_link(opts) do
-          # Setup temporary logical replication with the pgoutput plugin.
-          # proto_version must be 1 in recent pgoutput versions and
-          # the publication name is also required.
-          #
-          # Finally, also automatically reconnect if we lose connection.
+          # Automatically reconnect if we lose connection.
           extra_opts = [
-            slot: "postgrex",
-            logical: {:pgoutput, proto_version: 1, publication_names: "example"},
-            temporary: true,
-            snapshot: :noexport,
             auto_reconnect: true
           ]
 
@@ -104,13 +95,16 @@ defmodule Postgrex.Replication do
         defp current_time(), do: System.os_time(:microsecond) - @epoch
       end
 
-      {:ok, _pid} =
+      {:ok, pid} =
         Repl.start_link(
           host: "localhost",
           database: "demo_dev",
           username: "postgres",
         )
-
+      Postgrex.Replication.create_slot(pid, "postgrex", :pgoutput)
+      Postgrex.Replication.start_replication(pid, "postgrex",
+        plugin_opts: [proto_version: 1, publication_names: "postgrex_example"]
+      )
       Process.sleep(:infinity)
 
   ## `use` options
@@ -148,13 +142,16 @@ defmodule Postgrex.Replication do
   defstruct protocol: nil,
             state: nil,
             auto_reconnect: false,
-            reconnect_backoff: 500
+            reconnect_backoff: 500,
+            replication_started: false
 
   ## PUBLIC API ##
 
   @type server :: GenServer.server()
   @type state :: term
   @type copy :: binary
+  @timeout 5000
+  @commands [:create_slot, :drop_slot, :start_replication]
 
   @doc """
   Callback for process initialization.
@@ -236,32 +233,9 @@ defmodule Postgrex.Replication do
   The options that this function accepts are the same as those
   accepted by `Postgrex.start_link/1`, except for `:idle_interval`.
 
-  It also accepts extra options for connection and replication
-  management, documented in the sections below. Also note this
-  function also automatically set `:replication` to `"database"`
+  It also accepts extra options for connection management, documented below.
+  Also note this function also automatically set `:replication` to `"database"`
   as part of the connection `:parameters` if none is set yet.
-
-  ### Replication options
-
-    * `:logical` - required. It must be a tuple `{plugin, options}`
-      to configure logical replication with the given plugin and
-      options. By default, PostgreSQL includes the `pgoutput` plugin.
-
-    * `:slot` - required. The name of the replication slot.
-
-    * `:temporary` - required and must be set to `true`.
-
-    * `:start_pos` - optional. The LSN value to start replication from.
-      Must be formatted as a string of two hexadecimal numbers of up to
-      8 digits each, separated by a slash. e.g. `1/F73E0220`.
-      Defaults to `0/0`.
-
-    * `:snapshot` - optional. The type of logical snapshot for the
-      slot. Must be one of `:export`, `:noexport`, or `:use`.
-      Defaults to `:export`.
-
-  To better understand the meaning of those options, [see PostgreSQL
-  replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
 
   ### Connection options
 
@@ -284,6 +258,102 @@ defmodule Postgrex.Replication do
     opts = Keyword.put_new(opts, :sync_connect, true)
     connection_opts = Postgrex.Utils.default_opts(opts)
     Connection.start_link(__MODULE__, {module, arg, connection_opts}, server_opts)
+  end
+
+  @doc """
+    Creates a logical replication slot with the given name and output plugin.
+    By default, PostgreSQL includes the `pgoutput` plugin.
+
+    Once replication has begun, no other commands can be given and this
+    function will return `{:error, :replication_started}`.
+
+    ## Options
+
+  * `:temporary` - When `true`, the slot will automatically drop when a session
+    finishes. When `false`, the slot will persist outside of the session.
+    Note that `false`  can lead to an unwanted build-up of WAL segments
+    that eventually kill your primary instance. Prior to PostgreSQL 13, replication
+    slots stop WAL segments from being removed until they are read by a consumer.
+    Since PostgreSQL 13, the system parameter `max_slot_wal_keep_size` can be used
+    to prevent this. [See PostgreSQL docs](https://www.postgresql.org/docs/current/runtime-config-replication.html)
+    Defaults to `true`.
+
+  * `:snapshot` - The type of logical snapshot for the slot. Must be one of
+    `:export`, `:noexport`, or `:use`.
+    Defaults to `:export`.
+
+  * `:timeout` - Call timeout
+    Defaults to `5000`.
+
+  To better understand the meaning of those options, [see PostgreSQL
+  replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
+
+  """
+  @spec create_slot(server, String.t(), atom(), Keyword.t()) ::
+          :ok | {:error, Postgrex.Error.t()} | {:error, :replication_started}
+  def create_slot(pid, slot_name, plugin, opts \\ []) do
+    opts = [slot: slot_name, plugin: plugin] ++ opts
+    {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
+    call(pid, {:create_slot, opts}, timeout)
+  end
+
+  @doc """
+    Drops logical replication slot with the given name.
+
+    Once replication has begun, no other commands can be given and this
+    function will return `{:error, :replication_started}`.
+
+    ## Options
+
+  * `:wait` - If true, waits for an active slot to become inactive before
+    dropping it. If false, raises an error when an attemping to drop an active slot.
+    Defaults to `true`.
+
+  * `:timeout` - Call timeout
+    Defaults to `5000`.
+
+  To better understand the meaning of those options, [see PostgreSQL
+  replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
+
+  """
+  @spec drop_slot(server, String.t(), Keyword.t()) ::
+          :ok | {:error, Postgrex.Error.t()} | {:error, :replication_started}
+  def drop_slot(pid, slot_name, opts \\ []) do
+    opts = [slot: slot_name] ++ opts
+    {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
+    call(pid, {:drop_slot, opts}, timeout)
+  end
+
+  @doc """
+    Starts logical replication on the given slot. If the slot's plugin requires
+    additional options, make sure to specify them using the `plugin_opts` option.
+
+    Once replication has begun, no other commands can be given and this
+    function will return `{:error, :replication_started}`.
+
+    ## Options
+
+  * `:plugin_opts` - It must be a keyword list and is used to configure
+    the output plugin assigned to the given slot.
+
+  * `:start_pos` - The LSN value to start replication from. Must be
+    formatted as a string of two hexadecimal numbers of up to 8 digits
+    each, separated by a slash. e.g. `1/F73E0220`.
+    Defaults to `0/0`.
+
+  * `:timeout` - Call timeout
+    Defaults to `5000`.
+
+  To better understand the meaning of those options, [see PostgreSQL
+  replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
+
+  """
+  @spec start_replication(server, String.t(), Keyword.t()) ::
+          :ok | {:error, Postgrex.Error.t()} | {:error, :replication_started}
+  def start_replication(pid, slot_name, opts \\ []) do
+    opts = [slot: slot_name] ++ opts
+    {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
+    call(pid, {:start_replication, opts}, timeout)
   end
 
   ## CALLBACKS ##
@@ -325,23 +395,9 @@ defmodule Postgrex.Replication do
 
   @doc false
   def connect(_, s) do
-    opts = opts()
-
-    case Protocol.connect([types: nil] ++ opts()) do
+    case Protocol.connect(opts()) do
       {:ok, protocol} ->
-        s = %{s | protocol: protocol}
-        {create, start} = commands(opts)
-
-        with {:ok, %Postgrex.Result{}, protocol} <- Protocol.handle_simple(create, protocol),
-             {:ok, protocol} <- Protocol.handle_replication(start, protocol),
-             {:ok, protocol} <- Protocol.checkin(protocol) do
-          {:ok, %{s | protocol: protocol}}
-        else
-          # If we can't start replication, we assume that auto_reconnect can't
-          # solve it either, so we just raise the error as a readable message.
-          {_error, reason, _protocol} ->
-            raise reason
-        end
+        {:ok, %{s | protocol: protocol}}
 
       {:error, reason} ->
         if s.auto_reconnect do
@@ -349,6 +405,49 @@ defmodule Postgrex.Replication do
         else
           {:stop, reason, s}
         end
+    end
+  end
+
+  @doc false
+  def handle_call({:start_replication, _opts}, _from, %{replication_started: true} = s),
+    do: {:reply, {:error, :replication_started}, s}
+
+  @doc false
+  def handle_call({:start_replication, opts}, _from, s) do
+    %{protocol: protocol} = s
+    statement = command(:start_replication, opts)
+
+    with {:ok, protocol} <- Protocol.handle_replication(statement, protocol),
+         {:ok, protocol} <- Protocol.checkin(protocol) do
+      {:reply, :ok, %{s | protocol: protocol, replication_started: true}}
+    else
+      {:error, reason, protocol} ->
+        {:reply, {:error, reason}, %{s | protocol: protocol}}
+
+      {:disconnect, reason, protocol} ->
+        reconnect_or_stop(:disconnect, reason, protocol, s)
+    end
+  end
+
+  @doc false
+  def handle_call({name, _opts}, _from, %{replication_started: true} = s)
+      when name in @commands,
+      do: {:reply, {:error, :replication_started}, s}
+
+  @doc false
+  def handle_call({name, opts}, _from, s) when name in @commands do
+    %{protocol: protocol} = s
+    statement = command(name, opts)
+
+    case Protocol.handle_simple(statement, protocol) do
+      {:ok, %Postgrex.Result{}, protocol} ->
+        {:reply, :ok, %{s | protocol: protocol}}
+
+      {:error, reason, protocol} ->
+        {:reply, {:error, reason}, %{s | protocol: protocol}}
+
+      {:disconnect, reason, protocol} ->
+        reconnect_or_stop(:disconnect, reason, protocol, s)
     end
   end
 
@@ -413,30 +512,44 @@ defmodule Postgrex.Replication do
 
   ## Queries
 
-  defp commands(opts) do
+  defp command(:create_slot, opts) do
     slot = Keyword.fetch!(opts, :slot)
-    true = Keyword.fetch!(opts, :temporary)
-    {plugin, options} = Keyword.fetch!(opts, :logical)
-    start_pos = Keyword.get(opts, :start_pos, "0/0")
+    temporary? = Keyword.get(opts, :temporary, true)
+    plugin = Keyword.fetch!(opts, :plugin)
     snapshot = Keyword.get(opts, :snapshot, :export)
 
-    create = [
+    [
       "CREATE_REPLICATION_SLOT ",
       slot,
-      " TEMPORARY LOGICAL ",
+      (temporary? && " TEMPORARY LOGICAL ") || " LOGICAL ",
       Atom.to_string(plugin),
       snapshot(snapshot)
     ]
+  end
 
-    start = [
+  defp command(:drop_slot, opts) do
+    slot = Keyword.fetch!(opts, :slot)
+    wait? = Keyword.get(opts, :wait, true)
+
+    [
+      "DROP_REPLICATION_SLOT ",
+      slot,
+      (wait? && " WAIT") || ""
+    ]
+  end
+
+  defp command(:start_replication, opts) do
+    slot = Keyword.fetch!(opts, :slot)
+    options = Keyword.get(opts, :plugin_opts, [])
+    start_pos = Keyword.get(opts, :start_pos, "0/0")
+
+    [
       "START_REPLICATION SLOT ",
       slot,
       " LOGICAL ",
       start_pos,
       escape_options(options)
     ]
-
-    {create, start}
   end
 
   defp snapshot(:noexport), do: " NOEXPORT_SNAPSHOT"

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -114,6 +114,14 @@ defmodule ReplicationTest do
     assert {:error, :replication_started} == PR.start_replication(context.repl, "slot")
   end
 
+  test "drop_slot with wait = false returns an error when being used by a connection", context do
+    %{slot: slot} = @repl_opts
+    start_replication(context.repl)
+    repl1 = start_supervised!({Repl, {self(), @opts}}, id: :repl1)
+    {:error, %Postgrex.Error{} = error} = PR.drop_slot(repl1, slot, wait: false)
+    assert Exception.message(error) =~ "replication slot \"postgrex_example\" is active for PID"
+  end
+
   defp start_replication(repl) do
     %{slot: slot, plugin: plugin, plugin_opts: plugin_opts} = @repl_opts
     :ok = PR.create_slot(repl, slot, plugin)

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -1,6 +1,5 @@
 defmodule ReplicationTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
   alias Postgrex, as: P
   alias Postgrex.Replication, as: PR
 
@@ -54,15 +53,14 @@ defmodule ReplicationTest do
     max_restarts: 0
   ]
 
-  @repl_opts [
+  @repl_opts %{
     slot: "postgrex_example",
-    logical: {:pgoutput, proto_version: 1, publication_names: "postgrex_example"},
-    temporary: true,
-    snapshot: :noexport
-  ]
+    plugin: :pgoutput,
+    plugin_opts: [proto_version: 1, publication_names: "postgrex_example"]
+  }
 
   setup do
-    repl = start_supervised!({Repl, {self(), @repl_opts ++ @opts}})
+    repl = start_supervised!({Repl, {self(), @opts}})
     {:ok, repl: repl}
   end
 
@@ -75,11 +73,13 @@ defmodule ReplicationTest do
     assert_receive :pong
   end
 
-  test "handle_data" do
+  test "handle_data", context do
+    start_replication(context.repl)
     assert_receive <<?k, _::64, _::64, _>>, @timeout
   end
 
-  test "receives pgoutput" do
+  test "receives pgoutput", context do
+    start_replication(context.repl)
     pid = start_supervised!({P, @opts})
     P.query!(pid, "CREATE TABLE repl_test (id int, text text)", [])
     P.query!(pid, "INSERT INTO repl_test VALUES ($1, $2)", [42, "fortytwo"])
@@ -94,22 +94,29 @@ defmodule ReplicationTest do
                    @timeout
   end
 
-  test "raises on bad config with sync_connect: true" do
-    Process.flag(:trap_exit, true)
-    {:error, {%Postgrex.Error{} = error, _}} = Repl.start_link({self(), @repl_opts ++ @opts})
+  test "can't create same slot twice", context do
+    %{slot: slot, plugin: plugin} = @repl_opts
+    :ok = PR.create_slot(context.repl, slot, plugin)
+    {:error, %Postgrex.Error{} = error} = PR.create_slot(context.repl, slot, plugin)
     assert Exception.message(error) =~ "replication slot \"postgrex_example\" already exists"
   end
 
-  test "raises on bad config with sync_connect: false" do
-    Process.flag(:trap_exit, true)
-    opts = [sync_connect: false] ++ @repl_opts ++ @opts
-    msg = "replication slot \"postgrex_example\" already exists"
+  test "can't drop a lot that doesn't exist", context do
+    %{slot: slot} = @repl_opts
+    {:error, %Postgrex.Error{} = error} = PR.drop_slot(context.repl, slot)
+    assert Exception.message(error) =~ "replication slot \"postgrex_example\" does not exist"
+  end
 
-    assert capture_log(fn ->
-             {:ok, pid} = Repl.start_link({self(), opts})
-             ref = Process.monitor(pid)
-             assert_receive {:DOWN, ^ref, _, _, {%Postgrex.Error{} = error, _}}
-             assert Exception.message(error) =~ msg
-           end) =~ msg
+  test "can't run other commands after replication has started", context do
+    start_replication(context.repl)
+    assert {:error, :replication_started} == PR.create_slot(context.repl, "slot", :plugin)
+    assert {:error, :replication_started} == PR.drop_slot(context.repl, "slot")
+    assert {:error, :replication_started} == PR.start_replication(context.repl, "slot")
+  end
+
+  defp start_replication(repl) do
+    %{slot: slot, plugin: plugin, plugin_opts: plugin_opts} = @repl_opts
+    :ok = PR.create_slot(repl, slot, plugin)
+    :ok = PR.start_replication(repl, slot, plugin_opts: plugin_opts)
   end
 end


### PR DESCRIPTION
Related to https://github.com/elixir-ecto/postgrex/issues/578.

This PR alters `Postgrex.Replication` so that the initialization function doesn't start the replication process, but instead delegates those actions to different functions that can be used after the connection starts. 

3 functions have been added: `create_slot/4`, `drop_slot/3` and `start_replication/3`.

After replication has started, no other commands can be given to the connection so that the messages don't jumble.