### PR TITLE
Replication: return results from simple queries + add more simple queries

### DIFF
--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -418,7 +418,7 @@ defmodule Postgrex.Replication do
   end
 
   @doc """
-  Returns timeline history file for the specified timeline ID.
+  Returns the timeline history file for the specified timeline ID.
 
   Once replication has begun, no other commands can be given and this
   function will return `{:error, :replication_started}`.

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -292,7 +292,7 @@ defmodule Postgrex.Replication do
     * `:timeout` - Call timeout.
       Defaults to `5000`.
 
-  To better understand the meaning of those options,
+  To better understand the meaning of this command,
   [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec create_slot(server, String.t(), atom(), Keyword.t()) ::
@@ -320,7 +320,7 @@ defmodule Postgrex.Replication do
     * `:timeout` - Call timeout.
       Defaults to `5000`.
 
-  To better understand the meaning of those options,
+  To better understand the meaning of this command,
   [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec drop_slot(server, String.t(), Keyword.t()) ::
@@ -359,7 +359,7 @@ defmodule Postgrex.Replication do
     * `:timeout` - Call timeout.
       Defaults to `5000`.
 
-  To better understand the meaning of those options,
+  To better understand the meaning of this command,
   [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec start_replication(server, String.t(), Keyword.t()) ::
@@ -381,7 +381,7 @@ defmodule Postgrex.Replication do
     * `:timeout` - Call timeout.
       Defaults to `5000`.
 
-  To better understand the meaning of those options,
+  To better understand the meaning of this command,
   [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec show(server, String.t(), Keyword.t()) ::
@@ -405,7 +405,7 @@ defmodule Postgrex.Replication do
     * `:timeout` - Call timeout.
       Defaults to `5000`.
 
-  To better understand the meaning of those options,
+  To better understand the meaning of this command,
   [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec identify_system(server, Keyword.t()) ::
@@ -428,7 +428,7 @@ defmodule Postgrex.Replication do
     * `:timeout` - Call timeout.
       Defaults to `5000`.
 
-  To better understand the meaning of those options,
+  To better understand the meaning of this command,
   [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec timeline_history(server, String.t(), Keyword.t()) ::

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -388,7 +388,7 @@ defmodule Postgrex.Replication do
           {:ok, Postgrex.Result.t()}
           | {:error, Postgrex.Error.t()}
           | {:error, :replication_started}
-  def show(pid, name, opts \\ []) do
+  def show(pid, name, opts \\ []) when is_binary(name) do
     opts = [name: name] ++ opts
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
     call(pid, {:show, opts}, timeout)
@@ -435,7 +435,7 @@ defmodule Postgrex.Replication do
           {:ok, Postgrex.Result.t()}
           | {:error, Postgrex.Error.t()}
           | {:error, :replication_started}
-  def timeline_history(pid, timeline_id, opts \\ []) do
+  def timeline_history(pid, timeline_id, opts \\ []) when is_binary(timeline_id) do
     opts = [timeline_id: timeline_id] ++ opts
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
     call(pid, {:timeline_history, opts}, timeout)

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -364,7 +364,7 @@ defmodule Postgrex.Replication do
   end
 
   @doc """
-  Requests the server to send the current setting of a run-time parameter.
+  Returns the current setting of a run-time parameter.
 
   Once replication has begun, no other commands can be given and this
   function will return `{:error, :replication_started}`.

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -317,9 +317,9 @@ defmodule Postgrex.Types do
   end
 
   @doc false
-  @spec decode_simple_row(binary, [oid], state) :: {:ok, list()}
-  def decode_simple_row(binary, oids, {mod, _} = state) do
-    apply(mod, :decode_simple_row, [binary, oids, state])
+  @spec decode_simple(binary, state) :: [String.t()]
+  def decode_simple(binary, {mod, _}) do
+    apply(mod, :decode_simple, [binary])
   end
 
   @doc false

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -318,7 +318,6 @@ defmodule Postgrex.Types do
 
   @doc false
   @spec decode_simple_row(binary, [oid], state) :: {:ok, list()}
-        when row: var
   def decode_simple_row(binary, oids, {mod, _} = state) do
     apply(mod, :decode_simple_row, [binary, oids, state])
   end

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -317,6 +317,13 @@ defmodule Postgrex.Types do
   end
 
   @doc false
+  @spec decode_simple_row(binary, [oid], state) :: {:ok, list()}
+        when row: var
+  def decode_simple_row(binary, oids, {mod, _} = state) do
+    apply(mod, :decode_simple_row, [binary, oids, state])
+  end
+
+  @doc false
   @spec fetch(oid, state) ::
           {:ok, {:binary | :text, type}} | {:error, TypeInfo.t() | nil, module}
   def fetch(oid, {mod, table}) do

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -94,9 +94,24 @@ defmodule ReplicationTest do
                    @timeout
   end
 
+  test "show returns values", context do
+    {:ok, %Postgrex.Result{} = result} = PR.show(context.repl, "SERVER_VERSION")
+    assert result.num_rows == 1
+    refute is_nil(result.columns)
+    refute is_nil(result.rows)
+  end
+
+  test "create slot returns results", context do
+    %{slot: slot, plugin: plugin} = @repl_opts
+    {:ok, %Postgrex.Result{} = result} = PR.create_slot(context.repl, slot, plugin)
+    refute is_nil(result.columns)
+    refute is_nil(result.rows)
+    refute is_nil(result.num_rows)
+  end
+
   test "can't create same slot twice", context do
     %{slot: slot, plugin: plugin} = @repl_opts
-    :ok = PR.create_slot(context.repl, slot, plugin)
+    {:ok, %Postgrex.Result{}} = PR.create_slot(context.repl, slot, plugin)
     {:error, %Postgrex.Error{} = error} = PR.create_slot(context.repl, slot, plugin)
     assert Exception.message(error) =~ "replication slot \"postgrex_example\" already exists"
   end
@@ -124,7 +139,7 @@ defmodule ReplicationTest do
 
   defp start_replication(repl) do
     %{slot: slot, plugin: plugin, plugin_opts: plugin_opts} = @repl_opts
-    :ok = PR.create_slot(repl, slot, plugin)
+    {:ok, %Postgrex.Result{}} = PR.create_slot(repl, slot, plugin)
     :ok = PR.start_replication(repl, slot, plugin_opts: plugin_opts)
   end
 end

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -94,13 +94,6 @@ defmodule ReplicationTest do
                    @timeout
   end
 
-  test "show returns values", context do
-    {:ok, %Postgrex.Result{} = result} = PR.show(context.repl, "SERVER_VERSION")
-    assert result.num_rows == 1
-    refute is_nil(result.columns)
-    refute is_nil(result.rows)
-  end
-
   test "create slot returns results", context do
     %{slot: slot, plugin: plugin} = @repl_opts
     {:ok, %Postgrex.Result{} = result} = PR.create_slot(context.repl, slot, plugin)
@@ -135,6 +128,20 @@ defmodule ReplicationTest do
     repl1 = start_supervised!({Repl, {self(), @opts}}, id: :repl1)
     {:error, %Postgrex.Error{} = error} = PR.drop_slot(repl1, slot, wait: false)
     assert Exception.message(error) =~ "replication slot \"postgrex_example\" is active for PID"
+  end
+
+  test "identify system returns values", context do
+    {:ok, %Postgrex.Result{} = result} = PR.identify_system(context.repl)
+    assert result.num_rows == 1
+    refute is_nil(result.columns)
+    refute is_nil(result.rows)
+  end
+
+  test "show returns values", context do
+    {:ok, %Postgrex.Result{} = result} = PR.show(context.repl, "SERVER_VERSION")
+    assert result.num_rows == 1
+    refute is_nil(result.columns)
+    refute is_nil(result.rows)
   end
 
   defp start_replication(repl) do

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -97,9 +97,9 @@ defmodule ReplicationTest do
   test "create slot returns results", context do
     %{slot: slot, plugin: plugin} = @repl_opts
     {:ok, %Postgrex.Result{} = result} = PR.create_slot(context.repl, slot, plugin)
-    refute is_nil(result.columns)
-    refute is_nil(result.rows)
-    refute is_nil(result.num_rows)
+    assert result.num_rows == 1
+    assert result.columns == ["slot_name", "consistent_point", "snapshot_name", "output_plugin"]
+    assert [[_, _, _, _]] = result.rows
   end
 
   test "can't create same slot twice", context do
@@ -133,15 +133,15 @@ defmodule ReplicationTest do
   test "identify system returns values", context do
     {:ok, %Postgrex.Result{} = result} = PR.identify_system(context.repl)
     assert result.num_rows == 1
-    refute is_nil(result.columns)
-    refute is_nil(result.rows)
+    assert result.columns == ["systemid", "timeline", "xlogpos", "dbname"]
+    assert [[_, _, _, _]] = result.rows
   end
 
   test "show returns values", context do
     {:ok, %Postgrex.Result{} = result} = PR.show(context.repl, "SERVER_VERSION")
     assert result.num_rows == 1
-    refute is_nil(result.columns)
-    refute is_nil(result.rows)
+    assert result.columns == ["server_version"]
+    assert [[_]] = result.rows
   end
 
   defp start_replication(repl) do

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -109,7 +109,7 @@ defmodule ReplicationTest do
     assert Exception.message(error) =~ "replication slot \"postgrex_example\" already exists"
   end
 
-  test "can't drop a lot that doesn't exist", context do
+  test "can't drop a slot that doesn't exist", context do
     %{slot: slot} = @repl_opts
     {:error, %Postgrex.Error{} = error} = PR.drop_slot(context.repl, slot)
     assert Exception.message(error) =~ "replication slot \"postgrex_example\" does not exist"


### PR DESCRIPTION
This PR does the following:
- adds the ability to decode the rows returned by the simple queries executed on a replication connection
- returns the results from the existing simple queries, such as `create_slot` and `drop_slot` 
- adds the new commands `show`, `identify_server`, `timeline_history` and returns their results

