### PR TITLE
LSN conversion

### DIFF
--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -133,9 +133,9 @@ defmodule Postgrex.Replication do
   `GenServer`. Read more about them in the `GenServer` docs.
   """
 
-  use Bitwise
   use Connection
   require Logger
+  import Bitwise
 
   alias Postgrex.Protocol
 
@@ -447,62 +447,62 @@ defmodule Postgrex.Replication do
   @doc """
   Returns the string representation of an LSN value, given its integer representation.
 
+  It returns `:error` if the provided integer falls outside the range for a valid
+  unsigned 64-bit integer.
+
+  ## Log Sequence Numbers
+
   PostgreSQL uses two representations for the Log Sequence Number (LSN):
 
     * An unsigned 64-bit integer. Used internally by PostgreSQL and sent in the XLogData
     replication messages.
 
-    * A string of two hexadecimal numbers of up to 8 digits each, separated
+    * A string of two hexadecimal numbers of up to eight digits each, separated
     by a slash. e.g. `1/F73E0220`. This is the form accepted by `start_replication/3`.
 
   For more information on Log Sequence Numbers, see
   [PostgreSQL pg_lsn docs](https://www.postgresql.org/docs/current/datatype-pg-lsn.html) and
   [PostgreSQL WAL internals docs](https://www.postgresql.org/docs/current/wal-internals.html).
   """
-  @spec lsn_int_to_string(integer) :: String.t()
-  def lsn_int_to_string(lsn) when is_integer(lsn) do
+  @spec encode_lsn(integer) :: {:ok, String.t()} | :error
+  def encode_lsn(lsn) when is_integer(lsn) do
     if 0 <= lsn and lsn <= @max_uint64 do
       <<file_id::32, offset::32>> = <<lsn::64>>
-      Integer.to_string(file_id, 16) <> "/" <> Integer.to_string(offset, 16)
+      {:ok, Integer.to_string(file_id, 16) <> "/" <> Integer.to_string(offset, 16)}
     else
-      raise ArgumentError, "invalid unsigned 64-bit integer"
+      :error
     end
   end
 
   @doc """
   Returns the integer representation of an LSN value, given its string representation.
 
+  It returns `:error` if the provided string is not a valid LSN.
+
+  ## Log Sequence Numbers
+
   PostgreSQL uses two representations for the Log Sequence Number (LSN):
 
     * An unsigned 64-bit integer. Used internally by PostgreSQL and sent in the XLogData
     replication messages.
 
-    * A string of two hexadecimal numbers of up to 8 digits each, separated
+    * A string of two hexadecimal numbers of up to eight digits each, separated
     by a slash. e.g. `1/F73E0220`. This is the form accepted by `start_replication/3`.
 
   For more information on Log Sequence Numbers, see
   [PostgreSQL pg_lsn docs](https://www.postgresql.org/docs/current/datatype-pg-lsn.html) and
   [PostgreSQL WAL internals docs](https://www.postgresql.org/docs/current/wal-internals.html).
   """
-  @spec lsn_string_to_int(String.t()) :: integer
-  def lsn_string_to_int(lsn) when is_binary(lsn) do
+  @spec decode_lsn(String.t()) :: {:ok, integer} | :error
+  def decode_lsn(lsn) when is_binary(lsn) do
     with [file_id, offset] <- String.split(lsn, "/", trim: true),
          true <- byte_size(file_id) <= @max_lsn_component_size,
          true <- byte_size(offset) <= @max_lsn_component_size,
-         false <- String.first(file_id) == "-",
-         false <- String.first(offset) == "-" do
-      try do
-        file_id = String.to_integer(file_id, 16)
-        offset = String.to_integer(offset, 16)
-
-        file_id <<< 32 ||| offset
-      rescue
-        ArgumentError ->
-          reraise ArgumentError, "invalid LSN format", __STACKTRACE__
-      end
+         {file_id, ""} when file_id >= 0 <- Integer.parse(file_id, 16),
+         {offset, ""} when offset >= 0 <- Integer.parse(offset, 16) do
+      {:ok, file_id <<< 32 ||| offset}
     else
-      _ ->
-        raise ArgumentError, "invalid LSN format"
+      _ -> :error
     end
   end
 

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -447,7 +447,7 @@ defmodule Postgrex.Replication do
   @doc """
   Returns the string representation of an LSN value, given its integer representation.
 
-  PostgreSQL uses 2 representations for the Log Sequence Number (LSN):
+  PostgreSQL uses two representations for the Log Sequence Number (LSN):
 
     * An unsigned 64-bit integer. Used internally by PostgreSQL and sent in the XLogData
     replication messages.
@@ -472,7 +472,7 @@ defmodule Postgrex.Replication do
   @doc """
   Returns the integer representation of an LSN value, given its string representation.
 
-  PostgreSQL uses 2 representations for the Log Sequence Number (LSN):
+  PostgreSQL uses two representations for the Log Sequence Number (LSN):
 
     * An unsigned 64-bit integer. Used internally by PostgreSQL and sent in the XLogData
     replication messages.

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -488,7 +488,9 @@ defmodule Postgrex.Replication do
   def lsn_string_to_int(lsn) when is_binary(lsn) do
     with [file_id, offset] <- String.split(lsn, "/", trim: true),
          true <- byte_size(file_id) <= @max_lsn_component_size,
-         true <- byte_size(offset) <= @max_lsn_component_size do
+         true <- byte_size(offset) <= @max_lsn_component_size,
+         false <- String.first(file_id) == "-",
+         false <- String.first(offset) == "-" do
       try do
         file_id = String.to_integer(file_id, 16)
         offset = String.to_integer(offset, 16)

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -180,6 +180,8 @@ defmodule ReplicationTest do
     assert_raise ArgumentError, ~r/invalid LSN/, fn -> PR.lsn_string_to_int("123G/0123ABC") end
     assert_raise ArgumentError, ~r/invalid LSN/, fn -> PR.lsn_string_to_int("0/012345678") end
     assert_raise ArgumentError, ~r/invalid LSN/, fn -> PR.lsn_string_to_int("012345678/0") end
+    assert_raise ArgumentError, ~r/invalid LSN/, fn -> PR.lsn_string_to_int("-0FA23/08FACD1") end
+    assert_raise ArgumentError, ~r/invalid LSN/, fn -> PR.lsn_string_to_int("0FA23/-08FACD1") end
   end
 
   test "invalid LSN integers raise ArgumentError" do


### PR DESCRIPTION
### Motivation ###
This PR introduces two functions to convert LSN between its integer representation and string representation. 

These can come in handy when trying to reconcile the LSN coming from the replication messages (integer) against the LSN needed to start replication/the values returned by simple queries such as `identify_system` (string). 

For instance, a user might want to persist the last WAL record they processed so they can restart where they left off if their app crashes. I'd also like to use these to improve replication restart on auto reconnect so that the already processed WAL messages aren't replayed. 

### Conversion Formulas ###
I didn't see any official conversion formulas in the PostgreSQL docs, so I looked at their source code and also the source code from Debezium to see how they both do it. What I found was the following:

1. String to Integer: This is basically removing the slash, treating the result as a hexadecimal number in string form and then converting it to integer.
2. Integer to string. This is splitting the integer into two 32-bit sections, converting them to hexadecimal separately and then sticking them together in a string with a slash between them.

Postgres Source:
  * [String to Integer](https://github.com/postgres/postgres/blob/c30f54ad732ca5c8762bb68bbe0f51de9137dd72/src/backend/utils/adt/pg_lsn.c#L30)
  * [Integer to String](https://github.com/postgres/postgres/blob/c30f54ad732ca5c8762bb68bbe0f51de9137dd72/src/backend/utils/adt/pg_lsn.c#L81) and also need [this macro to understand it completely](https://github.com/postgres/postgres/blob/96b665083eb72570e226cf2d25c960b3acc62040/src/include/access/xlogdefs.h#L43)

Debezium Source:
  * [String to integer](https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/Lsn.java#L71)
  * [Integer to string](https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/Lsn.java#L111)

### Design Choices ###

There were some choices I was unsure about but that I tried to make by comparing to similar places in Elixir. Please let me know if any of these aren't idiomatic and I'm happy to address it:

1. Most of the `Module.to_type` functions I saw returned the converted value or raised an `ArgumentError`. My code tries to mimic that instead of returning `{:ok, converted_value}` / `{:error, reason}`.
2. I `use Bitwise` to help with some of the calculations but not sure if there is a more idiomatic way.
3. When validating the string in `lsn_string_to_int` I used a `with` statement that has multiple clauses. This seemed more readable to me than using guards, but not sure how idiomatic it is. 

