### PR TITLE
Replication: copy tables

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.12.1-otp-23
+erlang 23.3.4.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.12.1-otp-23
-erlang 23.3.4.4

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1165,6 +1165,9 @@ defmodule Postgrex.Protocol do
         s = %{s | postgres: postgres, buffer: buffer}
         {:ok, Enum.reverse([:copy_done | copies]), s}
 
+      {:ok, _msg, buffer} ->
+        handle_copy_recv(s, max_copies, copies, ncopies, buffer)
+
       {:disconnect, _, _} = dis ->
         dis
     end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1080,7 +1080,7 @@ defmodule Postgrex.Protocol do
   end
 
   @spec handle_replication(String.t() | iolist(), state) ::
-          {:ok, Postgrex.Result.t(), state}
+          {:ok, state}
           | {:error, Postgrex.Error.t(), state}
           | {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_replication(statement, %{buffer: buffer} = s) do
@@ -1124,18 +1124,25 @@ defmodule Postgrex.Protocol do
   end
 
   @spec handle_copy_recv(any, Keyword.t(), state) ::
-          {:ok, [binary], state}
+          {:ok, [binary | atom], state}
+          | :unknown
           | {:error, Postgrex.Error.t(), state}
           | {:disconnect, %DBConnection.ConnectionError{}, state}
-  def handle_copy_recv(msg, s) do
+  def handle_copy_recv(msg, max_copies, s) do
     case handle_socket(msg, s) do
-      {:data, data} -> handle_copy_recv(s, [], data)
+      {:data, data} -> handle_copy_recv(s, max_copies, [], 0, data)
       :unknown -> :unknown
       disconnect -> disconnect
     end
   end
 
-  defp handle_copy_recv(%{timeout: timeout} = s, copies, buffer) do
+  defp handle_copy_recv(s, max_copies, copies, max_copies, buffer) do
+    with {:ok, s} <- activate(s, buffer) do
+      {:ok, Enum.reverse(copies), s}
+    end
+  end
+
+  defp handle_copy_recv(%{timeout: timeout} = s, max_copies, copies, ncopies, buffer) do
     case msg_recv(s, timeout, buffer) do
       {:ok, msg_error(fields: fields), buffer} ->
         disconnect(s, Postgrex.Error.exception(postgres: fields), buffer)
@@ -1146,7 +1153,52 @@ defmodule Postgrex.Protocol do
         end
 
       {:ok, msg_copy_data(data: data), buffer} ->
-        handle_copy_recv(s, [data | copies], buffer)
+        handle_copy_recv(s, max_copies, [data | copies], ncopies + 1, buffer)
+
+      {:ok, msg_copy_done(), buffer} ->
+        handle_copy_recv(s, max_copies, copies, ncopies, buffer)
+
+      {:ok, msg_command_complete(), buffer} ->
+        handle_copy_recv(s, max_copies, copies, ncopies, buffer)
+
+      {:ok, msg_ready(status: postgres), buffer} ->
+        s = %{s | postgres: postgres, buffer: buffer}
+        {:ok, Enum.reverse([:copy_done | copies]), s}
+
+      {:disconnect, _, _} = dis ->
+        dis
+    end
+  end
+
+  @spec handle_copy_table(String.t() | iolist(), state) ::
+          {:ok, state}
+          | {:error, Postgrex.Error.t(), state}
+          | {:disconnect, %DBConnection.ConnectionError{}, state}
+  def handle_copy_table(statement, %{buffer: buffer} = s) do
+    status = new_status([], mode: :transaction)
+    msgs = [msg_query(statement: statement)]
+
+    case msg_send(%{s | buffer: nil}, msgs, buffer) do
+      :ok ->
+        recv_copy_table(s, buffer)
+
+      {:disconnect, err, s} ->
+        {:disconnect, err, s}
+
+      {:error, %Postgrex.Error{} = err, s, buffer} ->
+        error_ready(s, status, err, buffer)
+    end
+  end
+
+  defp recv_copy_table(s, buffer) do
+    case msg_recv(s, :infinity, buffer) do
+      {:ok, msg_copy_out_response(), buffer} ->
+        {:ok, %{s | buffer: buffer}}
+
+      {:ok, msg_error(fields: fields), buffer} ->
+        status = new_status([], mode: :transaction)
+        err = Postgrex.Error.exception(postgres: fields)
+        error_ready(s, status, err, buffer)
 
       {:disconnect, _, _} = dis ->
         dis
@@ -2884,7 +2936,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp done(%{connection_id: connection_id}, %{messages: messages}, columns, rows, tags) do
-    {command, nil} = decode_tags(tags)
+    {command, _} = decode_tags(tags)
 
     %Postgrex.Result{
       command: command,

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -144,7 +144,8 @@ defmodule Postgrex.Replication do
             state: nil,
             auto_reconnect: false,
             reconnect_backoff: 500,
-            replication_opts: nil
+            repl_opts: nil,
+            copy_opts: nil
 
   ## PUBLIC API ##
 
@@ -154,13 +155,19 @@ defmodule Postgrex.Replication do
   @timeout 5000
   @max_lsn_component_size 8
   @max_uint64 18_446_744_073_709_551_615
-  @commands [
+  @max_copy_messages 500
+  @copy_done :copy_done
+  @slot_name_prefix "pg_"
+  @slot_name_rand_bytes 18
+  @public_commands [
     :create_slot,
     :drop_slot,
     :start_replication,
     :show,
     :identify_system,
-    :timeline_history
+    :timeline_history,
+    :copy_table,
+    :publication_tables
   ]
 
   @doc """
@@ -171,12 +178,14 @@ defmodule Postgrex.Replication do
   @callback init(term) :: {:ok, state}
 
   @doc """
-  Receives `binary` replication messages.
+  Receives `binary` messages during replication and `Postgrex.Result.t()` messages during table copying.
 
-  The format of the messages are described [under the START_REPLICATION
+  The format of the row values in the copy messages are `text`.
+
+  The format of the replication messages are described [under the START_REPLICATION
   section in PostgreSQL docs](https://www.postgresql.org/docs/14/protocol-replication.html).
 
-  Some messages require explicit acknowledgement, which can be done
+  Some replication messages require explicit acknowledgement, which can be done
   by returning a list of binaries according to the replication protocol.
   """
   @callback handle_data(binary, state) :: {:noreply, [copy], state}
@@ -274,8 +283,8 @@ defmodule Postgrex.Replication do
 
   By default, PostgreSQL includes the `pgoutput` plugin.
 
-  Once replication has begun, no other commands can be given and this
-  function will return `{:error, :replication_started}`.
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
 
   ## Options
 
@@ -285,7 +294,8 @@ defmodule Postgrex.Replication do
       that eventually kill your primary instance. Prior to PostgreSQL 13, replication
       slots stop WAL segments from being removed until they are read by a consumer.
       Since PostgreSQL 13, the system parameter `max_slot_wal_keep_size` can be used
-      to prevent this. [See PostgreSQL docs](https://www.postgresql.org/docs/current/runtime-config-replication.html)
+      to prevent this.
+      [See PostgreSQL docs](https://www.postgresql.org/docs/current/runtime-config-replication.html).
       Defaults to `true`.
 
     * `:snapshot` - The type of logical snapshot for the slot. Must be one of
@@ -301,9 +311,9 @@ defmodule Postgrex.Replication do
   @spec create_slot(server, String.t(), atom(), Keyword.t()) ::
           {:ok, Postgrex.Result.t()}
           | {:error, Postgrex.Error.t()}
-          | {:error, :replication_started}
+          | {:error, :stream_in_progress}
   def create_slot(pid, slot_name, plugin, opts \\ []) do
-    opts = [slot: slot_name, plugin: plugin] ++ opts
+    opts = [slot_name: slot_name, plugin: plugin] ++ opts
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
     call(pid, {:create_slot, opts}, timeout)
   end
@@ -311,8 +321,8 @@ defmodule Postgrex.Replication do
   @doc """
   Drops logical replication slot with the given name.
 
-  Once replication has begun, no other commands can be given and this
-  function will return `{:error, :replication_started}`.
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
 
   ## Options
 
@@ -329,9 +339,9 @@ defmodule Postgrex.Replication do
   @spec drop_slot(server, String.t(), Keyword.t()) ::
           {:ok, Postgrex.Result.t()}
           | {:error, Postgrex.Error.t()}
-          | {:error, :replication_started}
+          | {:error, :stream_in_progress}
   def drop_slot(pid, slot_name, opts \\ []) do
-    opts = [slot: slot_name] ++ opts
+    opts = [slot_name: slot_name] ++ opts
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
     call(pid, {:drop_slot, opts}, timeout)
   end
@@ -346,8 +356,8 @@ defmodule Postgrex.Replication do
   duplicate WAL updates. Note that temporary slots cannot be restarted due to the
   fact that they automatically drop upon disconnect.
 
-  Once replication has begun, no other commands can be given and this
-  function will return `{:error, :replication_started}`.
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
 
   ## Options
 
@@ -359,6 +369,10 @@ defmodule Postgrex.Replication do
       each, separated by a slash. e.g. `1/F73E0220`.
       Defaults to `0/0`.
 
+    * `:max_messages` - The maximum number of replications messages that can be
+      accumulated from the wire until they are relayed to `handle_data/2`.
+      Defaults to `500`.
+
     * `:timeout` - Call timeout.
       Defaults to `5000`.
 
@@ -366,7 +380,7 @@ defmodule Postgrex.Replication do
   [see PostgreSQL replication docs](https://www.postgresql.org/docs/14/protocol-replication.html).
   """
   @spec start_replication(server, String.t(), Keyword.t()) ::
-          :ok | {:error, Postgrex.Error.t()} | {:error, :replication_started}
+          :ok | {:error, Postgrex.Error.t()} | {:error, :stream_in_progress}
   def start_replication(pid, slot_name, opts \\ []) do
     opts = [slot: slot_name] ++ opts
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
@@ -376,8 +390,8 @@ defmodule Postgrex.Replication do
   @doc """
   Returns the current setting of a run-time parameter.
 
-  Once replication has begun, no other commands can be given and this
-  function will return `{:error, :replication_started}`.
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
 
   ## Options
 
@@ -390,7 +404,7 @@ defmodule Postgrex.Replication do
   @spec show(server, String.t(), Keyword.t()) ::
           {:ok, Postgrex.Result.t()}
           | {:error, Postgrex.Error.t()}
-          | {:error, :replication_started}
+          | {:error, :stream_in_progress}
   def show(pid, name, opts \\ []) when is_binary(name) do
     opts = [name: name] ++ opts
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
@@ -400,8 +414,8 @@ defmodule Postgrex.Replication do
   @doc """
   Returns identification information for the server.
 
-  Once replication has begun, no other commands can be given and this
-  function will return `{:error, :replication_started}`.
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
 
   ## Options
 
@@ -414,7 +428,7 @@ defmodule Postgrex.Replication do
   @spec identify_system(server, Keyword.t()) ::
           {:ok, Postgrex.Result.t()}
           | {:error, Postgrex.Error.t()}
-          | {:error, :replication_started}
+          | {:error, :stream_in_progress}
   def identify_system(pid, opts \\ []) do
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
     call(pid, {:identify_system, opts}, timeout)
@@ -423,8 +437,8 @@ defmodule Postgrex.Replication do
   @doc """
   Returns the timeline history file for the specified timeline ID.
 
-  Once replication has begun, no other commands can be given and this
-  function will return `{:error, :replication_started}`.
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
 
   ## Options
 
@@ -437,11 +451,121 @@ defmodule Postgrex.Replication do
   @spec timeline_history(server, String.t(), Keyword.t()) ::
           {:ok, Postgrex.Result.t()}
           | {:error, Postgrex.Error.t()}
-          | {:error, :replication_started}
+          | {:error, :stream_in_progress}
   def timeline_history(pid, timeline_id, opts \\ []) when is_binary(timeline_id) do
     opts = [timeline_id: timeline_id] ++ opts
     {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
     call(pid, {:timeline_history, opts}, timeout)
+  end
+
+  @doc """
+  Returns the tables contained by the given publication using the system catalog
+  [pg_publication_tables](https://www.postgresql.org/docs/current/view-pg-publication-tables.html).
+
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
+
+  ## Options
+
+    * `:timeout` - Call timeout.
+      Defaults to `5000`.
+  """
+  @spec publication_tables(server, String.t(), Keyword.t()) ::
+          {:ok, Postgrex.Result.t()}
+          | {:error, Postgrex.Error.t()}
+          | {:error, :stream_in_progress}
+  def publication_tables(pid, publication_name, opts \\ []) when is_binary(publication_name) do
+    opts = [publication_name: publication_name] ++ opts
+    {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
+    call(pid, {:publication_tables, opts}, timeout)
+  end
+
+  @doc """
+  Starts streaming a copy of the given table.
+
+  This function can be used to initially synchronize the target system with
+  the primary PostgreSQL instance before starting replication. For increased
+  performance, a pool of replication processes can be created, each one
+  synchronizing a single table at at time.
+
+  The function performs the following steps:
+
+    * A transaction will begin with the `REPEATABLE READ` isolation level.
+
+    * A replication slot will be created with option `:snap_shot = :use`.
+      This ensures the data read during the transaction is consistent with
+      the way it  was when the slot was created.
+
+    * A `COPY` command will be issued for the given table and the rows
+      will be streamed to `handle_data/2`. The messages will be of the type
+      `Postgrex.Result.t()` with the row values having `text` format.
+
+    * Once all the rows have been copied, a final message of the form
+      `{:copy_done, table_name}` will be sent, the transaction will be
+      committed and the slot (optionally) dropped.
+
+  This function will return the created slot's information, the same as
+  `create_slot/4`. This information may be useful, for example, with the
+  following tasks:
+
+    * Using the slot's `consistent_point` to determine where to start
+      replication.
+
+    * Using the slot to catch up with the changes that occurred during copying.
+      In this scenario, there may be a single main replication process alongside
+      secondary replication processes for each table. An individual secondary process
+      can be used to copy the initial snapshot for a given table and then stream
+      replication messages for that table until it is caught up to the main process.
+      Once caught up, the secondary process can be terminated and control of the table
+      given back to the main process. This strategy minimizes the amount of time a
+      transaction must hold onto old transaction IDs as well as the amount of time
+      a slot must hold onto old WAL files.
+
+  If the connection was started with `auto_reconnect` set to `true`, then
+  copying will automatically restart from the beginning. You must ensure
+  your system will not be affected by receiving duplicate messages.
+
+  This function will return `{:error, :stream_in_progress}` while a table
+  is being copied or after replication has begun.
+
+  ## Options
+
+    * `:drop_slot` - Automatically drops the slot created by this function.
+      If `false`, care must be taken by the caller to drop the slot once
+      it is not needed anymore. See `create_slot/4` for more details.
+      Defaults to `true`.
+
+    * `:slot_opts` - Keyword list of options to create the slot with.
+      Only the keys `:slot_name`, `:temporary` and `:plugin` are allowed.
+      By default, a temporary slot with the `:pgoutput` plugin is created.
+      See `create_slot/4` for more details.
+
+    * `:max_messages` - The maximum number of messages that can be
+      accumulated from the wire until they are relayed to `handle_data/2`.
+      One message corresponds to one data row.
+      Defaults to `500`.
+
+    * `:timeout` - Call timeout.
+      Defaults to `5000`.
+  """
+  @spec copy_table(server, String.t(), Keyword.t()) ::
+          {:ok, Postgrex.Result.t()}
+          | {:error, Postgrex.Error.t()}
+          | {:error, :stream_in_progress}
+  def copy_table(pid, table_name, opts \\ []) when is_binary(table_name) do
+    {timeout, opts} = Keyword.pop(opts, :timeout, @timeout)
+    {slot_opts, opts} = Keyword.pop(opts, :slot_opts, [])
+
+    slot_opts =
+      slot_opts
+      |> Keyword.take([:slot_name, :temporary, :plugin])
+      |> Keyword.put_new(:plugin, :pgoutput)
+      |> Keyword.put_new(:slot_name, copy_table_slot_name())
+      |> Keyword.put(:snapshot, :use)
+
+    opts = [table_name: table_name] ++ slot_opts ++ opts
+
+    call(pid, {:copy_table, opts}, timeout)
   end
 
   @doc """
@@ -547,7 +671,7 @@ defmodule Postgrex.Replication do
   def connect(_, s) do
     case Protocol.connect(opts()) do
       {:ok, protocol} ->
-        maybe_restart_replication(%{s | protocol: protocol})
+        maybe_restart_streaming(%{s | protocol: protocol})
 
       {:error, reason} ->
         if s.auto_reconnect do
@@ -559,13 +683,12 @@ defmodule Postgrex.Replication do
   end
 
   @doc false
-  def handle_call({:start_replication, opts}, _from, %{replication_opts: nil} = s) do
-    %{protocol: protocol} = s
+  def handle_call({:start_replication, opts}, _from, %{repl_opts: nil, copy_opts: nil} = s) do
     statement = command(:start_replication, opts)
 
-    with {:ok, protocol} <- Protocol.handle_replication(statement, protocol),
+    with {:ok, protocol} <- Protocol.handle_replication(statement, s.protocol),
          {:ok, protocol} <- Protocol.checkin(protocol) do
-      s = %{s | protocol: protocol, replication_opts: opts}
+      s = %{s | protocol: protocol, repl_opts: opts}
       {:reply, :ok, s}
     else
       {:error, reason, protocol} ->
@@ -577,11 +700,34 @@ defmodule Postgrex.Replication do
   end
 
   @doc false
-  def handle_call({name, opts}, _from, %{replication_opts: nil} = s) when name in @commands do
-    %{protocol: protocol} = s
+  def handle_call({:copy_table, opts}, _from, %{repl_opts: nil, copy_opts: nil} = s) do
+    table_name = Keyword.fetch!(opts, :table_name)
+    begin_statement = command(:begin_copy, opts)
+    create_slot_statement = command(:create_slot, opts)
+    copy_statement = command(:copy_table, opts)
+
+    with {:ok, _, protocol} <- Protocol.handle_simple(begin_statement, s.protocol),
+         {:ok, slot, protocol} <- Protocol.handle_simple(create_slot_statement, protocol),
+         {:ok, columns, protocol} <- table_columns(table_name, protocol),
+         {:ok, protocol} <- Protocol.handle_copy_table(copy_statement, protocol),
+         {:ok, protocol} <- Protocol.checkin(protocol) do
+      s = %{s | protocol: protocol, copy_opts: Keyword.put(opts, :columns, columns)}
+      {:reply, {:ok, slot}, s}
+    else
+      {:error, reason, protocol} ->
+        {:reply, {:error, reason}, %{s | protocol: protocol}}
+
+      {:disconnect, reason, protocol} ->
+        reconnect_or_stop(:disconnect, reason, protocol, s)
+    end
+  end
+
+  @doc false
+  def handle_call({name, opts}, _from, %{repl_opts: nil, copy_opts: nil} = s)
+      when name in @public_commands do
     statement = command(name, opts)
 
-    case Protocol.handle_simple(statement, protocol) do
+    case Protocol.handle_simple(statement, s.protocol) do
       {:ok, %Postgrex.Result{} = result, protocol} ->
         {:reply, {:ok, result}, %{s | protocol: protocol}}
 
@@ -594,8 +740,8 @@ defmodule Postgrex.Replication do
   end
 
   @doc false
-  def handle_call({name, _opts}, _from, s) when name in @commands,
-    do: {:reply, {:error, :replication_started}, s}
+  def handle_call({name, _opts}, _from, s) when name in @public_commands,
+    do: {:reply, {:error, :stream_in_progress}, s}
 
   @doc false
   def handle_call(msg, from, %{state: {mod, mod_state}} = s) do
@@ -604,7 +750,9 @@ defmodule Postgrex.Replication do
 
   @doc false
   def handle_info(msg, %{protocol: protocol} = s) do
-    case Protocol.handle_copy_recv(msg, protocol) do
+    max_copies = max_copy_messages(s)
+
+    case Protocol.handle_copy_recv(msg, max_copies, protocol) do
       {:ok, copies, protocol} ->
         handle_data(copies, %{s | protocol: protocol})
 
@@ -624,7 +772,40 @@ defmodule Postgrex.Replication do
 
   defp handle_data([], s), do: {:noreply, s}
 
-  defp handle_data([copy | copies], %{state: {mod, mod_state}} = s) do
+  defp handle_data([copy | copies], %{copy_opts: nil} = s) do
+    %{state: {mod, mod_state}} = s
+
+    with {:noreply, s} <- handle(mod, :handle_data, [copy, mod_state], s) do
+      handle_data(copies, s)
+    end
+  end
+
+  defp handle_data([@copy_done | copies], s) do
+    %{state: {mod, mod_state}, copy_opts: copy_opts} = s
+    copy = format_text_copy(@copy_done, copy_opts, nil)
+
+    with {:noreply, s} <- handle(mod, :handle_data, [copy, mod_state], s),
+         {:ok, _, protocol} <- Protocol.handle_simple("COMMIT", s.protocol),
+         {:ok, _, protocol} <- maybe_drop_slot(copy_opts, protocol) do
+      handle_data(copies, %{s | protocol: protocol, copy_opts: nil})
+    else
+      {:error, reason, _protocol} ->
+        # If we can't commit the copy or drop the slot, we assume that auto_reconnect
+        # can't solve it either, so we just raise the error as a readable message.
+        raise reason
+
+      {:disconnect, reason, protocol} ->
+        reconnect_or_stop(:disconnect, reason, protocol, s)
+
+      reconnect_or_stop ->
+        reconnect_or_stop
+    end
+  end
+
+  defp handle_data([copy | copies], s) do
+    %{state: {mod, mod_state}, copy_opts: copy_opts, protocol: protocol} = s
+    copy = format_text_copy(copy, copy_opts, protocol)
+
     with {:noreply, s} <- handle(mod, :handle_data, [copy, mod_state], s) do
       handle_data(copies, s)
     end
@@ -656,10 +837,10 @@ defmodule Postgrex.Replication do
     {:connect, :reconnect, s}
   end
 
-  defp maybe_restart_replication(%{replication_opts: nil} = s), do: {:ok, s}
+  defp maybe_restart_streaming(%{repl_opts: nil, copy_opts: nil} = s), do: {:ok, s}
 
-  defp maybe_restart_replication(s) do
-    start = command(:start_replication, s.replication_opts)
+  defp maybe_restart_streaming(%{copy_opts: nil} = s) do
+    start = command(:start_replication, s.repl_opts)
 
     with {:ok, protocol} <- Protocol.handle_replication(start, s.protocol),
          {:ok, protocol} <- Protocol.checkin(protocol) do
@@ -672,9 +853,97 @@ defmodule Postgrex.Replication do
     end
   end
 
+  defp maybe_restart_streaming(%{repl_opts: nil} = s) do
+    table_name = Keyword.fetch!(s.copy_opts, :table_name)
+    begin_statement = command(:begin_copy, s.copy_opts)
+    copy_statement = command(:copy_table, s.copy_opts)
+
+    with {:ok, _, protocol} <- Protocol.handle_simple(begin_statement, s.protocol),
+         {:ok, _, protocol} <- maybe_create_slot(s.copy_opts, protocol),
+         {:ok, columns, protocol} <- table_columns(table_name, protocol),
+         {:ok, protocol} <- Protocol.handle_copy_table(copy_statement, protocol),
+         {:ok, protocol} <- Protocol.checkin(protocol) do
+      s = %{s | protocol: protocol, copy_opts: Keyword.put(s.copy_opts, :columns, columns)}
+      {:ok, s}
+    else
+      # If we can't restart copying, we assume that auto_reconnect can't
+      # solve it either, so we just raise the error as a readable message.
+      {_error, reason, _protocol} ->
+        raise reason
+    end
+  end
+
+  defp copy_table_slot_name do
+    rand_name =
+      @slot_name_rand_bytes
+      |> :crypto.strong_rand_bytes()
+      |> Base.encode32(padding: false)
+
+    "#{@slot_name_prefix}#{rand_name}"
+  end
+
+  defp max_copy_messages(%{repl_opts: nil, copy_opts: nil}), do: nil
+
+  defp max_copy_messages(%{repl_opts: nil} = s),
+    do: Keyword.get(s.copy_opts, :max_messages, @max_copy_messages)
+
+  defp max_copy_messages(s), do: Keyword.get(s.repl_opts, :max_messages, @max_copy_messages)
+
+  defp format_text_copy(@copy_done, opts, _) do
+    table_name = Keyword.fetch!(opts, :table_name)
+    {:copy_done, table_name}
+  end
+
+  defp format_text_copy(copy, opts, %{connection_id: connection_id}) do
+    columns = Keyword.fetch!(opts, :columns)
+    row = copy |> String.trim() |> String.split("\t")
+
+    %Postgrex.Result{
+      command: :copy_stream,
+      num_rows: 1,
+      rows: [row],
+      columns: columns,
+      connection_id: connection_id
+    }
+  end
+
+  defp table_columns(table_name, protocol) do
+    show_statement = command(:show, name: "server_version_num")
+
+    with {:ok, show_result, protocol} <- Protocol.handle_simple(show_statement, protocol),
+         %Postgrex.Result{rows: [[version]]} <- show_result,
+         columns_statement_opts <- [server_version: version, table_name: table_name],
+         columns_statement <- command(:table_columns, columns_statement_opts),
+         {:ok, columns_result, protocol} <- Protocol.handle_simple(columns_statement, protocol) do
+      {:ok, Enum.flat_map(columns_result.rows, & &1), protocol}
+    end
+  end
+
+  defp maybe_drop_slot(opts, protocol) do
+    if Keyword.get(opts, :drop_slot, true) do
+      statement = command(:drop_slot, opts)
+      Protocol.handle_simple(statement, protocol)
+    else
+      {:ok, nil, protocol}
+    end
+  end
+
+  defp maybe_create_slot(opts, protocol) do
+    state_statement = command(:slot_state, slot_name: opts.slot_name)
+
+    with {:ok, state_result, protocol} <- Protocol.handle_simple(state_statement, protocol) do
+      if state_result.rows == [[]] do
+        create_statement = command(:create_slot, opts)
+        Protocol.handle_simple(create_statement, protocol)
+      else
+        {:ok, nil, protocol}
+      end
+    end
+  end
+
   ## Queries
   defp command(:create_slot, opts) do
-    slot = Keyword.fetch!(opts, :slot)
+    slot = Keyword.fetch!(opts, :slot_name)
     temporary? = Keyword.get(opts, :temporary, true)
     plugin = Keyword.fetch!(opts, :plugin)
     snapshot = Keyword.get(opts, :snapshot, :export)
@@ -689,7 +958,7 @@ defmodule Postgrex.Replication do
   end
 
   defp command(:drop_slot, opts) do
-    slot = Keyword.fetch!(opts, :slot)
+    slot = Keyword.fetch!(opts, :slot_name)
     wait? = Keyword.get(opts, :wait, false)
 
     [
@@ -723,6 +992,40 @@ defmodule Postgrex.Replication do
   defp command(:timeline_history, opts) do
     timeline_id = Keyword.fetch!(opts, :timeline_id)
     ["TIMELINE_HISTORY ", timeline_id]
+  end
+
+  defp command(:copy_table, opts) do
+    table_name = Keyword.fetch!(opts, :table_name)
+    ["COPY ", table_name, " TO STDOUT"]
+  end
+
+  defp command(:begin_copy, _opts), do: ["BEGIN READ ONLY ISOLATION LEVEL REPEATABLE READ"]
+
+  defp command(:publication_tables, opts) do
+    publication_name = Keyword.fetch!(opts, :publication_name)
+    ["SELECT * FROM pg_publication_tables WHERE pubname = ", escape_string(publication_name)]
+  end
+
+  defp command(:slot_state, opts) do
+    slot_name = Keyword.fetch!(opts, :slot_name)
+    ["SELECT * FROM pg_replication_slots WHERE slot_name = ", escape_string(slot_name)]
+  end
+
+  defp command(:table_columns, opts) do
+    attgenerated_version = 120_000
+    table_name = Keyword.fetch!(opts, :table_name)
+    version = Keyword.fetch!(opts, :server_version)
+
+    [
+      "SELECT attname FROM pg_catalog.pg_attribute ",
+      "WHERE attnum > 0::pg_catalog.int2 ",
+      "AND NOT attisdropped ",
+      (String.to_integer(version) >= attgenerated_version && "AND attgenerated = ''") || "",
+      "AND attrelid = ",
+      escape_string(table_name),
+      "::regclass ",
+      "ORDER BY attnum"
+    ]
   end
 
   defp snapshot(:noexport), do: " NOEXPORT_SNAPSHOT"

--- a/lib/postgrex/replication.ex
+++ b/lib/postgrex/replication.ex
@@ -891,7 +891,7 @@ defmodule Postgrex.Replication do
 
   defp format_text_copy(@copy_done, opts, _) do
     table_name = Keyword.fetch!(opts, :table_name)
-    {:copy_done, table_name}
+    {@copy_done, table_name}
   end
 
   defp format_text_copy(copy, opts, %{connection_id: connection_id}) do

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -123,6 +123,11 @@ defmodule ReplicationTest do
     assert {:error, :stream_in_progress} == PR.create_slot(context.repl, "slot", :plugin)
     assert {:error, :stream_in_progress} == PR.drop_slot(context.repl, "slot")
     assert {:error, :stream_in_progress} == PR.start_replication(context.repl, "slot")
+    assert {:error, :stream_in_progress} == PR.identify_system(context.repl)
+    assert {:error, :stream_in_progress} == PR.show(context.repl, "value")
+    assert {:error, :stream_in_progress} == PR.timeline_history(context.repl, "timeline_id")
+    assert {:error, :stream_in_progress} == PR.publication_tables(context.repl, "publication")
+    assert {:error, :stream_in_progress} == PR.copy_table(context.repl, "table")
   end
 
   test "drop_slot with wait = false returns an error when being used by a connection", context do

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -74,29 +74,6 @@ defmodule ReplicationTest do
     assert_receive :pong
   end
 
-  test "handle_data", context do
-    start_replication(context.repl)
-    assert_receive <<?k, _::64, _::64, _>>, @timeout
-  end
-
-  test "receives pgoutput", context do
-    start_replication(context.repl)
-    pid = start_supervised!({P, @opts})
-    P.query!(pid, "CREATE TABLE repl_test (id int, text text)", [])
-    P.query!(pid, "INSERT INTO repl_test VALUES ($1, $2)", [42, "fortytwo"])
-
-    assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?B, _ls::64, _ts2::64, _xid::32>>,
-                   @timeout
-
-    assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?I, _rid::32, ?N, _nc::16, _::binary>>,
-                   @timeout
-
-    assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?C, _f, _ls::64, _le::64, _ts2::64>>,
-                   @timeout
-
-    P.query!(pid, "DROP TABLE repl_test", [])
-  end
-
   test "create slot returns results", context do
     %{slot: slot, plugin: plugin} = @repl_opts
     {:ok, %Postgrex.Result{} = result} = PR.create_slot(context.repl, slot, plugin)
@@ -116,18 +93,6 @@ defmodule ReplicationTest do
     %{slot: slot} = @repl_opts
     {:error, %Postgrex.Error{} = error} = PR.drop_slot(context.repl, slot)
     assert Exception.message(error) =~ "replication slot \"postgrex_example\" does not exist"
-  end
-
-  test "can't run other commands after replication has started", context do
-    start_replication(context.repl)
-    assert {:error, :stream_in_progress} == PR.create_slot(context.repl, "slot", :plugin)
-    assert {:error, :stream_in_progress} == PR.drop_slot(context.repl, "slot")
-    assert {:error, :stream_in_progress} == PR.start_replication(context.repl, "slot")
-    assert {:error, :stream_in_progress} == PR.identify_system(context.repl)
-    assert {:error, :stream_in_progress} == PR.show(context.repl, "value")
-    assert {:error, :stream_in_progress} == PR.timeline_history(context.repl, "timeline_id")
-    assert {:error, :stream_in_progress} == PR.publication_tables(context.repl, "publication")
-    assert {:error, :stream_in_progress} == PR.copy_table(context.repl, "table")
   end
 
   test "drop_slot with wait = false returns an error when being used by a connection", context do
@@ -214,68 +179,109 @@ defmodule ReplicationTest do
     assert [_ | _] = result.rows
   end
 
-  test "copy table", context do
-    pid = start_supervised!({P, @opts})
-    P.query!(pid, "CREATE TABLE repl_test (id int, text text)", [])
-    P.query!(pid, "INSERT INTO repl_test VALUES ($1, $2), ($3, $4)", [42, "fortytwo", 1, "one"])
-    {:ok, _} = PR.copy_table(context.repl, "repl_test")
-    assert_receive %Postgrex.Result{columns: ["id", "text"], rows: [["42", "fortytwo"]]}, @timeout
-    assert_receive %Postgrex.Result{columns: ["id", "text"], rows: [["1", "one"]]}, @timeout
-    assert_receive {:copy_done, "repl_test"}, @timeout
-    P.query!(pid, "DROP TABLE repl_test", [])
+  describe "replication" do
+    setup do
+      pid = start_supervised!({P, @opts}, id: :repl_conn)
+      repl = start_supervised!({Repl, {self(), @opts}}, id: :repl_repl)
+
+      P.query!(pid, "CREATE TABLE IF NOT EXISTS repl_test (id int, text text)", [])
+      start_replication(repl)
+
+      on_exit(fn ->
+        {:ok, pid} = P.start_link(@opts)
+        P.query!(pid, "DROP TABLE IF EXISTS repl_test", [])
+      end)
+
+      {:ok, pid: pid, repl: repl}
+    end
+
+    test "handle_data" do
+      assert_receive <<?k, _::64, _::64, _>>, @timeout
+    end
+
+    test "receives pgoutput", context do
+      P.query!(context.pid, "INSERT INTO repl_test VALUES ($1, $2)", [42, "fortytwo"])
+
+      assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?B, _ls::64, _ts2::64, _xid::32>>,
+                     @timeout
+
+      assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?I, _rid::32, ?N, _nc::16, _::binary>>,
+                     @timeout
+
+      assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?C, _f, _ls::64, _le::64, _ts2::64>>,
+                     @timeout
+    end
+
+    test "can't run other commands after replication has started", context do
+      assert {:error, :stream_in_progress} == PR.create_slot(context.repl, "slot", :plugin)
+      assert {:error, :stream_in_progress} == PR.drop_slot(context.repl, "slot")
+      assert {:error, :stream_in_progress} == PR.start_replication(context.repl, "slot")
+      assert {:error, :stream_in_progress} == PR.identify_system(context.repl)
+      assert {:error, :stream_in_progress} == PR.show(context.repl, "value")
+      assert {:error, :stream_in_progress} == PR.timeline_history(context.repl, "timeline_id")
+      assert {:error, :stream_in_progress} == PR.publication_tables(context.repl, "publication")
+      assert {:error, :stream_in_progress} == PR.copy_table(context.repl, "table")
+    end
   end
 
-  test "copy table, slot is automatically dropped", context do
-    pid = start_supervised!({P, @opts})
-    P.query!(pid, "CREATE TABLE repl_test (id int, text text)", [])
+  describe "copy_table" do
+    setup do
+      pid = start_supervised!({P, @opts}, id: :copy_conn)
+      repl = start_supervised!({Repl, {self(), @opts}}, id: :copy_repl)
 
-    {:ok, %Postgrex.Result{rows: [[slot_name | _]]}} =
-      PR.copy_table(context.repl, "repl_test", drop_slot: true)
+      P.query!(pid, "CREATE TABLE IF NOT EXISTS repl_test (id int, text text)", [])
 
-    {:error, %Postgrex.Error{} = error} = PR.drop_slot(context.repl, slot_name)
-    assert Exception.message(error) =~ "replication slot \"#{slot_name}\" does not exist"
-    P.query!(pid, "DROP TABLE repl_test", [])
-  end
+      on_exit(fn ->
+        {:ok, pid} = P.start_link(@opts)
+        P.query!(pid, "DROP TABLE IF EXISTS repl_test", [])
+      end)
 
-  test "copy table, slot is not automatically dropped", context do
-    pid = start_supervised!({P, @opts})
-    P.query!(pid, "CREATE TABLE repl_test (id int, text text)", [])
+      {:ok, pid: pid, repl: repl}
+    end
 
-    {:ok, %Postgrex.Result{rows: [[slot_name | _]]}} =
-      PR.copy_table(context.repl, "repl_test", drop_slot: false)
+    test "copy table", context do
+      P.query!(context.pid, "INSERT INTO repl_test VALUES ($1, $2), ($3, $4)", [42, "42", 1, "1"])
+      {:ok, _} = PR.copy_table(context.repl, "repl_test")
+      assert_receive %Postgrex.Result{columns: ["id", "text"], rows: [["42", "42"]]}, @timeout
+      assert_receive %Postgrex.Result{columns: ["id", "text"], rows: [["1", "1"]]}, @timeout
+      assert_receive {:copy_done, "repl_test"}, @timeout
+    end
 
-    assert {:ok, _} = PR.drop_slot(context.repl, slot_name)
-    P.query!(pid, "DROP TABLE repl_test", [])
-  end
+    test "copy table, slot is automatically dropped", context do
+      {:ok, result} = PR.copy_table(context.repl, "repl_test", drop_slot: true)
+      %Postgrex.Result{rows: [[slot_name | _]]} = result
+      {:error, %Postgrex.Error{} = error} = PR.drop_slot(context.repl, slot_name)
+      assert Exception.message(error) =~ "replication slot \"#{slot_name}\" does not exist"
+    end
 
-  test "can issue commands after copying is finished", context do
-    %{slot: slot, plugin: plugin} = @repl_opts
-    pid = start_supervised!({P, @opts})
-    P.query!(pid, "CREATE TABLE repl_test (id int, text text)", [])
-    {:ok, _} = PR.copy_table(context.repl, "repl_test")
-    assert_receive {:copy_done, "repl_test"}, @timeout
-    assert {:ok, _} = PR.create_slot(context.repl, slot, plugin)
-    P.query!(pid, "DROP TABLE repl_test", [])
-  end
+    test "copy table, slot is not automatically dropped", context do
+      {:ok, result} = PR.copy_table(context.repl, "repl_test", drop_slot: false)
+      %Postgrex.Result{rows: [[slot_name | _]]} = result
+      assert {:ok, _} = PR.drop_slot(context.repl, slot_name)
+    end
 
-  test "can start replication after copying is finished", context do
-    pid = start_supervised!({P, @opts})
-    P.query!(pid, "CREATE TABLE repl_test (id int, text text)", [])
-    {:ok, _} = PR.copy_table(context.repl, "repl_test")
-    assert_receive {:copy_done, "repl_test"}, @timeout
-    start_replication(context.repl)
-    P.query!(pid, "INSERT INTO repl_test VALUES ($1, $2)", [42, "fortytwo"])
+    test "can issue commands after copying is finished", context do
+      %{slot: slot, plugin: plugin} = @repl_opts
+      {:ok, _} = PR.copy_table(context.repl, "repl_test")
+      assert_receive {:copy_done, "repl_test"}, @timeout
+      assert {:ok, _} = PR.create_slot(context.repl, slot, plugin)
+    end
 
-    assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?B, _ls::64, _ts2::64, _xid::32>>,
-                   @timeout
+    test "can start replication after copying is finished", context do
+      {:ok, _} = PR.copy_table(context.repl, "repl_test")
+      assert_receive {:copy_done, "repl_test"}, @timeout
+      start_replication(context.repl)
+      P.query!(context.pid, "INSERT INTO repl_test VALUES ($1, $2)", [42, "fortytwo"])
 
-    assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?I, _rid::32, ?N, _nc::16, _::binary>>,
-                   @timeout
+      assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?B, _ls::64, _ts2::64, _xid::32>>,
+                     @timeout
 
-    assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?C, _f, _ls::64, _le::64, _ts2::64>>,
-                   @timeout
+      assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?I, _rid::32, ?N, _nc::16, _::binary>>,
+                     @timeout
 
-    P.query!(pid, "DROP TABLE repl_test", [])
+      assert_receive <<?w, _ws::64, _we::64, _ts1::64, ?C, _f, _ls::64, _le::64, _ts2::64>>,
+                     @timeout
+    end
   end
 
   defp start_replication(repl) do

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -261,10 +261,9 @@ defmodule ReplicationTest do
     end
 
     test "can issue commands after copying is finished", context do
-      %{slot: slot, plugin: plugin} = @repl_opts
       {:ok, _} = PR.copy_table(context.repl, "repl_test")
       assert_receive {:copy_done, "repl_test"}, @timeout
-      assert {:ok, _} = PR.create_slot(context.repl, slot, plugin)
+      assert {:ok, _} = PR.identify_system(context.repl)
     end
 
     test "can start replication after copying is finished", context do

--- a/test/replication_test.exs
+++ b/test/replication_test.exs
@@ -33,6 +33,12 @@ defmodule ReplicationTest do
     end
 
     @impl true
+    def handle_copy(msg, pid) do
+      send(pid, msg)
+      {:noreply, [], pid}
+    end
+
+    @impl true
     def handle_info(:ping, pid) do
       send(pid, :pong)
       {:noreply, [], pid}


### PR DESCRIPTION
This PR introduces 2 new functions: `copy_table/3` and `publication_tables/3`. 

It also introduces back pressure for the replication command because this was needed for `copy_table/3` and could be applied to `start_replication/3` for free.

**Motivation**

Would like to eventually expose the tools needed to simulate the `CREATE SUBSCRIPTION` command from Postgres. These 2 functions would be critical to providing the initial snapshot functionality from that command. 

The idea behind Postgres's initial snapshot functionality can be summarized by this excerpt from the `copy_table/3` doc:

```
... a single main replication process alongside secondary replication processes for each table. 
An individual secondary process can be used to copy the initial snapshot for a given table and
then stream replication messages for that table until it is caught up to the main process. Once 
caught up, the secondary process can be terminated and control of the table given back to the 
main process. This strategy minimizes the amount of time a transaction must hold onto old 
transaction IDs as well as the amount of time a slot must hold onto old WAL files.
```

**References**

  - https://www.postgresql.fastware.com/blog/logical-replication-tablesync-workers
  - https://github.com/postgres/postgres/blob/e997a0c642860a96df0151cbeccfecbdf0450d08/src/backend/replication/logical/tablesync.c
  - https://www.postgresql.org/docs/current/logical-replication-architecture.html
  - https://www.postgresql.org/docs/current/sql-createsubscription.html