### PR TITLE
Notification callback module

### DIFF
--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -61,100 +61,21 @@ defmodule Postgrex.Notifications do
 
     2. If you cannot wrap the channel name in quotes when sending a notification,
        then make sure to give the lowercased channel name when listening
-
   """
 
-  use Connection
+  alias Postgrex.SimpleConnection
+
+  @behaviour SimpleConnection
+
   require Logger
 
-  alias Postgrex.Protocol
+  defstruct [:from, :ref, connected: false, listeners: %{}, listener_channels: %{}]
 
   @timeout 5000
 
   @doc false
-  defstruct idle_interval: 5000,
-            protocol: nil,
-            auto_reconnect: false,
-            reconnect_backoff: 500,
-            state: nil
-
-  ## PUBLIC API ##
-
-  @type query :: iodata
-  @type server :: GenServer.server()
-  @type state :: term
-
-  @doc """
-  Callback for process initialization.
-
-  This is called once and before the Postgrex notification connection is established.
-  """
-  @callback init(term) :: {:ok, state}
-
-  @doc """
-  Invoked after connecting.
-
-  This may be called multiple times if `:auto_reconnect` is true.
-  """
-  @callback handle_connect(state) :: {:noreply, state} | {:query, query, state}
-
-  @doc """
-  Invoked after disconnection, regardless of `:auto_reconnect`.
-  """
-  @callback handle_disconnect(state) :: {:noreply, state}
-
-  @doc """
-  Callback for `call/3`.
-
-  Replies must be sent with `reply/2`.
-  """
-  @callback handle_call(term, GenServer.from(), state) ::
-              {:noreply, state}
-              | {:query, query, state}
-
-  @doc """
-  Callback for `Kernel.send/2`.
-  """
-  @callback handle_info(term, state) :: {:noreply, state} | {:query, query, state}
-
-  @doc """
-  Callback for processing or relaying query results.
-  """
-  @callback handle_result(Postgrex.Result.t() | Postgrex.Error.t(), state) :: {:noreply, state}
-
-  @doc """
-  Callback for processing or relaying pubsub notifications.
-  """
-  @callback handle_notification(binary, binary, state) :: {:noreply, state}
-
-  @optional_callbacks handle_info: 2,
-                      handle_call: 3,
-                      handle_connect: 1,
-                      handle_disconnect: 1
-
-  @doc """
-  Replies to the given client.
-
-  Wrapper for `GenServer.reply/2`.
-  """
-  defdelegate reply(client, reply), to: GenServer
-
-  @doc """
-  Calls the given replication server.
-
-  Wrapper for `GenServer.call/3`.
-  """
-  defdelegate call(server, message, timeout \\ 5000), to: GenServer
-
-  @doc false
   def child_spec(opts) do
-    opts =
-      case opts do
-        [mod, _args, _opts] when is_atom(mod) -> opts
-        _ -> [opts]
-      end
-
-    %{id: __MODULE__, start: {__MODULE__, :start_link, opts}}
+    %{id: __MODULE__, start: {SimpleConnection, :start_link, [__MODULE__, [], opts]}}
   end
 
   @doc """
@@ -184,13 +105,9 @@ defmodule Postgrex.Notifications do
       configure the options as a `{module, function, args}`, where the current
       options will prepended to `args`. Defaults to `nil`.
   """
-  @spec start_link(module(), term(), Keyword.t()) ::
-          {:ok, pid} | {:error, Postgrex.Error.t() | term}
-  def start_link(module \\ Postgrex.Notifications.Default, args \\ [], opts) do
-    {server_opts, opts} = Keyword.split(opts, [:name])
-    opts = Keyword.put_new(opts, :sync_connect, true)
-    connection_opts = Postgrex.Utils.default_opts(opts)
-    Connection.start_link(__MODULE__, {module, args, connection_opts}, server_opts)
+  @spec start_link(Keyword.t()) :: {:ok, pid} | {:error, Postgrex.Error.t() | term}
+  def start_link(opts) do
+    SimpleConnection.start_link(__MODULE__, [], opts)
   end
 
   @doc """
@@ -208,15 +125,16 @@ defmodule Postgrex.Notifications do
 
     * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
-  @spec listen(server, String.t(), Keyword.t()) :: {:ok, reference} | {:eventually, reference}
+  @spec listen(GenServer.t(), String.t(), Keyword.t()) ::
+          {:ok, reference} | {:eventually, reference}
   def listen(pid, channel, opts \\ []) do
-    call(pid, {:listen, channel}, Keyword.get(opts, :timeout, @timeout))
+    SimpleConnection.call(pid, {:listen, channel}, Keyword.get(opts, :timeout, @timeout))
   end
 
   @doc """
   Listens to an asynchronous notification channel `channel`. See `listen/2`.
   """
-  @spec listen!(server, String.t(), Keyword.t()) :: reference
+  @spec listen!(GenServer.t(), String.t(), Keyword.t()) :: reference
   def listen!(pid, channel, opts \\ []) do
     {:ok, ref} = listen(pid, channel, opts)
     ref
@@ -230,16 +148,16 @@ defmodule Postgrex.Notifications do
 
     * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
-  @spec unlisten(server, reference, Keyword.t()) :: :ok | :error
+  @spec unlisten(GenServer.t(), reference, Keyword.t()) :: :ok | :error
   def unlisten(pid, ref, opts \\ []) do
-    call(pid, {:unlisten, ref}, Keyword.get(opts, :timeout, @timeout))
+    SimpleConnection.call(pid, {:unlisten, ref}, Keyword.get(opts, :timeout, @timeout))
   end
 
   @doc """
   Stops listening on the given channel by passing the reference returned from
   `listen/2`.
   """
-  @spec unlisten!(server, reference, Keyword.t()) :: :ok
+  @spec unlisten!(GenServer.t(), reference, Keyword.t()) :: :ok
   def unlisten!(pid, ref, opts \\ []) do
     case unlisten(pid, ref, opts) do
       :ok -> :ok
@@ -249,165 +167,18 @@ defmodule Postgrex.Notifications do
 
   ## CALLBACKS ##
 
-  @doc false
-  def init({mod, args, opts}) do
-    case mod.init(args) do
-      {:ok, mod_state} ->
-        idle_timeout = opts[:idle_timeout]
-
-        if idle_timeout do
-          Logger.warn(
-            ":idle_timeout in Postgrex.Notifications is deprecated, " <>
-              "please use :idle_interval instead"
-          )
-        end
-
-        {idle_interval, opts} = Keyword.pop(opts, :idle_interval, idle_timeout || 5000)
-        {auto_reconnect, opts} = Keyword.pop(opts, :auto_reconnect, false)
-        {reconnect_backoff, opts} = Keyword.pop(opts, :reconnect_backoff, 500)
-
-        state = %__MODULE__{
-          idle_interval: idle_interval,
-          auto_reconnect: auto_reconnect,
-          reconnect_backoff: reconnect_backoff,
-          state: {mod, mod_state}
-        }
-
-        put_opts(opts)
-
-        if opts[:sync_connect] do
-          case connect(:init, state) do
-            {:ok, _} = ok -> ok
-            {:backoff, _, _} = backoff -> backoff
-            {:stop, reason, _} -> {:stop, reason}
-          end
-        else
-          {:connect, :init, state}
-        end
-    end
-  end
-
-  @doc false
-  def connect(_, %{state: {mod, mod_state}} = state) do
-    opts =
-      case Keyword.get(opts(), :configure) do
-        {module, fun, args} -> apply(module, fun, [opts() | args])
-        fun when is_function(fun, 1) -> fun.(opts())
-        nil -> opts()
-      end
-
-    case Protocol.connect(opts) do
-      {:ok, protocol} ->
-        state = %{state | protocol: protocol}
-
-        with {:noreply, state, _} <- maybe_handle(mod, :handle_connect, [mod_state], state) do
-          {:ok, state}
-        end
-
-      {:error, reason} ->
-        if state.auto_reconnect do
-          {:backoff, state.reconnect_backoff, state}
-        else
-          {:stop, reason, state}
-        end
-    end
-  end
-
-  @doc false
-  def handle_call(msg, from, %{state: {mod, mod_state}} = state) do
-    maybe_handle(mod, :handle_call, [msg, from, mod_state], state)
-  end
-
-  @doc false
-  def handle_info(:timeout, %{protocol: protocol} = state) do
-    case Protocol.ping(protocol) do
-      {:ok, protocol} ->
-        {:noreply, %{state | protocol: protocol}, state.idle_interval}
-
-      {error, reason, protocol} ->
-        reconnect_or_stop(error, reason, protocol, state)
-    end
-  end
-
-  def handle_info(msg, %{protocol: protocol, state: {mod, mod_state}} = state) do
-    opts = [notify: &mod.handle_notification(&1, &2, mod_state)]
-
-    case Protocol.handle_info(msg, opts, protocol) do
-      {:ok, protocol} ->
-        {:noreply, %{state | protocol: protocol}, state.idle_interval}
-
-      {:unknown, protocol} ->
-        maybe_handle(mod, :handle_info, [msg, mod_state], %{state | protocol: protocol})
-
-      {error, reason, protocol} ->
-        reconnect_or_stop(error, reason, protocol, state)
-    end
-  end
-
-  def handle_info(msg, %{state: {mod, mod_state}} = state) do
-    maybe_handle(mod, :handle_info, [msg, mod_state], state)
-  end
-
-  defp maybe_handle(mod, fun, args, state) do
-    if function_exported?(mod, fun, length(args)) do
-      handle(mod, fun, args, nil, state)
-    else
-      {:noreply, state}
-    end
-  end
-
-  defp handle(mod, fun, args, from, state) do
-    case apply(mod, fun, args) do
-      {:noreply, mod_state} ->
-        {:noreply, %{state | state: {mod, mod_state}}, state.idle_interval}
-
-      {:query, query, mod_state} ->
-        opts = [notify: &mod.handle_notification(&1, &2, mod_state)]
-
-        state = %{state | state: {mod, mod_state}}
-
-        with {:ok, result, protocol} <- Protocol.handle_simple(query, opts, state.protocol),
-             {:ok, protocol} <- Protocol.checkin(protocol) do
-          state = %{state | protocol: protocol}
-
-          handle(mod, :handle_result, [result, mod_state], from, state)
-        else
-          {error, reason, protocol} ->
-            from && reply(from, {__MODULE__, reason})
-
-            {:noreply, state, _} = maybe_handle(mod, :handle_disconnect, [mod_state], state)
-
-            reconnect_or_stop(error, reason, protocol, state)
-        end
-    end
-  end
-
-  defp reconnect_or_stop(_error, reason, protocol, %{auto_reconnect: false} = state) do
-    {:stop, reason, %{state | protocol: protocol}}
-  end
-
-  defp reconnect_or_stop(_error, _reason, _protocol, %{auto_reconnect: true} = state) do
-    {:connect, :reconnect, state}
-  end
-
-  defp opts(), do: Process.get(__MODULE__)
-  defp put_opts(opts), do: Process.put(__MODULE__, opts)
-end
-
-defmodule Postgrex.Notifications.Default do
-  @moduledoc false
-
-  @behaviour Postgrex.Notifications
-
-  require Logger
-
-  alias Postgrex.Notifications
-
-  defstruct [:from, :ref, connected: false, listeners: %{}, listener_channels: %{}]
-
   @impl true
   def init(args) do
     {:ok, struct!(__MODULE__, args)}
+  end
+
+  @impl true
+  def notify(channel, payload, state) do
+    for {ref, pid} <- Map.get(state.listener_channels, channel, []) do
+      send(pid, {:notification, self(), ref, channel, payload})
+    end
+
+    :ok
   end
 
   @impl true
@@ -442,7 +213,7 @@ defmodule Postgrex.Notifications.Default do
 
     cond do
       not state.connected ->
-        Notifications.reply(from, {:eventually, ref})
+        SimpleConnection.reply(from, {:eventually, ref})
 
         {:noreply, state}
 
@@ -450,7 +221,7 @@ defmodule Postgrex.Notifications.Default do
         {:query, ~s(LISTEN "#{channel}"), %{state | from: from, ref: ref}}
 
       true ->
-        Notifications.reply(from, {:ok, ref})
+        SimpleConnection.reply(from, {:ok, ref})
 
         {:noreply, state}
     end
@@ -469,13 +240,13 @@ defmodule Postgrex.Notifications.Default do
 
           {:query, ~s(UNLISTEN "#{channel}"), %{state | from: from}}
         else
-          from && Notifications.reply(from, :ok)
+          from && SimpleConnection.reply(from, :ok)
 
           {:noreply, state}
         end
 
       _ ->
-        from && Notifications.reply(from, :error)
+        from && SimpleConnection.reply(from, :error)
 
         {:noreply, state}
     end
@@ -499,24 +270,17 @@ defmodule Postgrex.Notifications.Default do
   def handle_result(_message, %{from: from, ref: ref} = state) do
     cond do
       from && ref ->
-        Notifications.reply(from, {:ok, ref})
+        SimpleConnection.reply(from, {:ok, ref})
 
         {:noreply, %{state | from: nil, ref: nil}}
 
       from ->
-        Notifications.reply(from, :ok)
+        SimpleConnection.reply(from, :ok)
 
         {:noreply, %{state | from: nil}}
 
       true ->
         {:noreply, state}
-    end
-  end
-
-  @impl true
-  def handle_notification(channel, payload, state) do
-    for {ref, pid} <- Map.get(state.listener_channels, channel, []) do
-      send(pid, {:notification, self(), ref, channel, payload})
     end
   end
 end

--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -134,7 +134,7 @@ defmodule Postgrex.Notifications do
 
     * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
-  @spec listen(GenServer.t(), String.t(), Keyword.t()) ::
+  @spec listen(GenServer.server(), String.t(), Keyword.t()) ::
           {:ok, reference} | {:eventually, reference}
   def listen(pid, channel, opts \\ []) do
     SimpleConnection.call(pid, {:listen, channel}, Keyword.get(opts, :timeout, @timeout))
@@ -143,7 +143,7 @@ defmodule Postgrex.Notifications do
   @doc """
   Listens to an asynchronous notification channel `channel`. See `listen/2`.
   """
-  @spec listen!(GenServer.t(), String.t(), Keyword.t()) :: reference
+  @spec listen!(GenServer.server(), String.t(), Keyword.t()) :: reference
   def listen!(pid, channel, opts \\ []) do
     {:ok, ref} = listen(pid, channel, opts)
     ref
@@ -157,7 +157,7 @@ defmodule Postgrex.Notifications do
 
     * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
-  @spec unlisten(GenServer.t(), reference, Keyword.t()) :: :ok | :error
+  @spec unlisten(GenServer.server(), reference, Keyword.t()) :: :ok | :error
   def unlisten(pid, ref, opts \\ []) do
     SimpleConnection.call(pid, {:unlisten, ref}, Keyword.get(opts, :timeout, @timeout))
   end
@@ -166,7 +166,7 @@ defmodule Postgrex.Notifications do
   Stops listening on the given channel by passing the reference returned from
   `listen/2`.
   """
-  @spec unlisten!(GenServer.t(), reference, Keyword.t()) :: :ok
+  @spec unlisten!(GenServer.server(), reference, Keyword.t()) :: :ok
   def unlisten!(pid, ref, opts \\ []) do
     case unlisten(pid, ref, opts) do
       :ok -> :ok

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -553,6 +553,7 @@ defmodule Postgrex.Protocol do
 
   @spec handle_info(any, Keyword.t(), state) ::
           {:ok, state}
+          | {:unknown, state}
           | {:error, Postgrex.Error.t(), state}
           | {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_info(msg, opts \\ [], s) do
@@ -560,16 +561,8 @@ defmodule Postgrex.Protocol do
       {:data, data} ->
         handle_data(s, opts, data)
 
-      :unknown ->
-        Logger.info(fn ->
-          context = " received unexpected message: "
-          [inspect(__MODULE__), ?\s, inspect(self()), context | inspect(msg)]
-        end)
-
-        {:ok, s}
-
-      disconnect ->
-        disconnect
+      disconnect_or_unknown ->
+        disconnect_or_unknown
     end
   end
 
@@ -597,8 +590,8 @@ defmodule Postgrex.Protocol do
     disconnect(s, :ssl, "async recv", reason)
   end
 
-  defp handle_socket(_, _) do
-    :unknown
+  defp handle_socket(_, s) do
+    {:unknown, s}
   end
 
   ## connect

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -558,17 +558,10 @@ defmodule Postgrex.Protocol do
           | {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_info(msg, opts \\ [], s) do
     case handle_socket(msg, s) do
-      {:data, data} ->
-        handle_data(s, opts, data)
-
-      :ignore ->
-        {:ok, s}
-
-      :unknown ->
-        {:unknown, s}
-
-      disconnect ->
-        disconnect
+      {:data, data} -> handle_data(s, opts, data)
+      :ignore -> {:ok, s}
+      :unknown -> {:unknown, s}
+      disconnect -> disconnect
     end
   end
 
@@ -1137,6 +1130,7 @@ defmodule Postgrex.Protocol do
   def handle_copy_recv(msg, s) do
     case handle_socket(msg, s) do
       {:data, data} -> handle_copy_recv(s, [], data)
+      :ignore -> {:ok, [], s}
       :unknown -> :unknown
       disconnect -> disconnect
     end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -561,8 +561,14 @@ defmodule Postgrex.Protocol do
       {:data, data} ->
         handle_data(s, opts, data)
 
-      disconnect_or_unknown ->
-        disconnect_or_unknown
+      :ignore ->
+        {:ok, s}
+
+      :unknown ->
+        {:unknown, s}
+
+      disconnect ->
+        disconnect
     end
   end
 
@@ -590,8 +596,16 @@ defmodule Postgrex.Protocol do
     disconnect(s, :ssl, "async recv", reason)
   end
 
-  defp handle_socket(_, s) do
-    {:unknown, s}
+  defp handle_socket({closed, _sock}, _) when closed in [:tcp_closed, :ssl_closed] do
+    :ignore
+  end
+
+  defp handle_socket({error, _sock, _reason}, _) when error in [:tcp_error, :ssl_error] do
+    :ignore
+  end
+
+  defp handle_socket(_, _) do
+    :unknown
   end
 
   ## connect

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -2866,7 +2866,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp done(%{connection_id: connection_id}, %{messages: messages}, tags) do
-    {command, nil} = decode_tags(tags)
+    {command, _} = decode_tags(tags)
 
     %Postgrex.Result{
       command: command,
@@ -2884,7 +2884,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp done(%{connection_id: connection_id}, %{messages: messages}, columns, rows, tags) do
-    {command, nil} = decode_tags(tags)
+    {command, _} = decode_tags(tags)
 
     %Postgrex.Result{
       command: command,

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -1,0 +1,274 @@
+defmodule Postgrex.SimpleConnection do
+  @moduledoc false
+
+  use Connection
+
+  require Logger
+
+  alias Postgrex.Protocol
+
+  @doc false
+  defstruct idle_interval: 5000,
+            protocol: nil,
+            auto_reconnect: false,
+            reconnect_backoff: 500,
+            state: nil
+
+  ## PUBLIC API ##
+
+  @type query :: iodata
+  @type state :: term
+
+  @doc """
+  Callback for process initialization.
+
+  This is called once and before the Postgrex connection is established.
+  """
+  @callback init(term) :: {:ok, state}
+
+  @doc """
+  Callback for processing or relaying pubsub notifications.
+  """
+  @callback notify(binary, binary, state) :: :ok
+
+  @doc """
+  Invoked after connecting.
+
+  This may be called multiple times if `:auto_reconnect` is true.
+  """
+  @callback handle_connect(state) :: {:noreply, state} | {:query, query, state}
+
+  @doc """
+  Invoked after disconnection, regardless of `:auto_reconnect`.
+  """
+  @callback handle_disconnect(state) :: {:noreply, state}
+
+  @doc """
+  Callback for `call/3`.
+
+  Replies must be sent with `reply/2`.
+  """
+  @callback handle_call(term, GenServer.from(), state) ::
+              {:noreply, state} | {:query, query, state}
+
+  @doc """
+  Callback for `Kernel.send/2`.
+  """
+  @callback handle_info(term, state) :: {:noreply, state} | {:query, query, state}
+
+  @doc """
+  Callback for processing or relaying query results.
+  """
+  @callback handle_result(Postgrex.Result.t() | Postgrex.Error.t(), state) :: {:noreply, state}
+
+  @optional_callbacks handle_call: 3,
+                      handle_connect: 1,
+                      handle_disconnect: 1,
+                      handle_info: 2,
+                      handle_result: 2
+
+  @doc """
+  Replies to the given client.
+
+  Wrapper for `GenServer.reply/2`.
+  """
+  defdelegate reply(client, reply), to: GenServer
+
+  @doc """
+  Calls the given server.
+
+  Wrapper for `GenServer.call/3`.
+  """
+  defdelegate call(server, message, timeout \\ 5000), to: GenServer
+
+  @doc false
+  def child_spec(opts) do
+    %{id: __MODULE__, start: {__MODULE__, :start_link, opts}}
+  end
+
+  @doc """
+  Start the connection process and connect to Postgres.
+
+  The options that this function accepts are the same as those accepted by
+  `Postgrex.start_link/1`, as well as the extra options `:sync_connect`,
+  `:auto_reconnect`, `:reconnect_backoff`, and `:configure`.
+
+  ## Options
+
+    * `:auto_reconnect` - automatically attempt to reconnect to the database
+      in event of a disconnection. See the
+      [note about async connect and auto-reconnects](#module-async-connect-and-auto-reconnects)
+      above. Defaults to `false`, which means the process terminates.
+
+    * `:configure` - A function to run before every connect attempt to dynamically
+      configure the options as a `{module, function, args}`, where the current
+      options will prepended to `args`. Defaults to `nil`.
+
+    * `:idle_interval` - while also accepted on `Postgrex.start_link/1`, it has
+      a default of `5000ms` in `Postgrex.SimpleConnection` (instead of 1000ms).
+
+    * `:reconnect_backoff` - time (in ms) between reconnection attempts when
+      `auto_reconnect` is enabled. Defaults to `500`.
+
+    * `:sync_connect` - controls if the connection should be established on boot
+      or asynchronously right after boot. Defaults to `true`.
+  """
+  @spec start_link(module, term, Keyword.t()) :: {:ok, pid} | {:error, Postgrex.Error.t() | term}
+  def start_link(module, args, opts) do
+    {server_opts, opts} = Keyword.split(opts, [:name])
+    opts = Keyword.put_new(opts, :sync_connect, true)
+    connection_opts = Postgrex.Utils.default_opts(opts)
+    Connection.start_link(__MODULE__, {module, args, connection_opts}, server_opts)
+  end
+
+  ## CALLBACKS ##
+
+  @doc false
+  def init({mod, args, opts}) do
+    case mod.init(args) do
+      {:ok, mod_state} ->
+        idle_timeout = opts[:idle_timeout]
+
+        if idle_timeout do
+          Logger.warn(
+            ":idle_timeout in Postgrex.SimpleConnection is deprecated, " <>
+              "please use :idle_interval instead"
+          )
+        end
+
+        {idle_interval, opts} = Keyword.pop(opts, :idle_interval, idle_timeout || 5000)
+        {auto_reconnect, opts} = Keyword.pop(opts, :auto_reconnect, false)
+        {reconnect_backoff, opts} = Keyword.pop(opts, :reconnect_backoff, 500)
+
+        state = %__MODULE__{
+          idle_interval: idle_interval,
+          auto_reconnect: auto_reconnect,
+          reconnect_backoff: reconnect_backoff,
+          state: {mod, mod_state}
+        }
+
+        put_opts(mod, opts)
+
+        if opts[:sync_connect] do
+          case connect(:init, state) do
+            {:ok, _} = ok -> ok
+            {:backoff, _, _} = backoff -> backoff
+            {:stop, reason, _} -> {:stop, reason}
+          end
+        else
+          {:connect, :init, state}
+        end
+    end
+  end
+
+  @doc false
+  def connect(_, %{state: {mod, mod_state}} = state) do
+    opts =
+      case Keyword.get(opts(mod), :configure) do
+        {module, fun, args} -> apply(module, fun, [opts(mod) | args])
+        fun when is_function(fun, 1) -> fun.(opts(mod))
+        nil -> opts(mod)
+      end
+
+    case Protocol.connect(opts) do
+      {:ok, protocol} ->
+        state = %{state | protocol: protocol}
+
+        with {:noreply, state, _} <- maybe_handle(mod, :handle_connect, [mod_state], state) do
+          {:ok, state}
+        end
+
+      {:error, reason} ->
+        if state.auto_reconnect do
+          {:backoff, state.reconnect_backoff, state}
+        else
+          {:stop, reason, state}
+        end
+    end
+  end
+
+  @doc false
+  def handle_call(msg, from, %{state: {mod, mod_state}} = state) do
+    handle(mod, :handle_call, [msg, from, mod_state], from, state)
+  end
+
+  @doc false
+  def handle_info(:timeout, %{protocol: protocol} = state) do
+    case Protocol.ping(protocol) do
+      {:ok, protocol} ->
+        {:noreply, %{state | protocol: protocol}, state.idle_interval}
+
+      {error, reason, protocol} ->
+        reconnect_or_stop(error, reason, protocol, state)
+    end
+  end
+
+  def handle_info(msg, %{protocol: protocol, state: {mod, mod_state}} = state) do
+    opts = [notify: &mod.notify(&1, &2, mod_state)]
+
+    case Protocol.handle_info(msg, opts, protocol) do
+      {:ok, protocol} ->
+        {:noreply, %{state | protocol: protocol}, state.idle_interval}
+
+      {:unknown, protocol} ->
+        maybe_handle(mod, :handle_info, [msg, mod_state], %{state | protocol: protocol})
+
+      {error, reason, protocol} ->
+        reconnect_or_stop(error, reason, protocol, state)
+    end
+  end
+
+  def handle_info(msg, %{state: {mod, mod_state}} = state) do
+    maybe_handle(mod, :handle_info, [msg, mod_state], state)
+  end
+
+  defp maybe_handle(mod, fun, args, state) do
+    if function_exported?(mod, fun, length(args)) do
+      handle(mod, fun, args, nil, state)
+    else
+      {:noreply, state, state.idle_interval}
+    end
+  end
+
+  defp handle(mod, fun, args, from, state) do
+    case apply(mod, fun, args) do
+      {:noreply, mod_state} ->
+        {:noreply, %{state | state: {mod, mod_state}}, state.idle_interval}
+
+      {:query, query, mod_state} ->
+        opts = [notify: &mod.notify(&1, &2, mod_state)]
+
+        state = %{state | state: {mod, mod_state}}
+
+        with {:ok, result, protocol} <- Protocol.handle_simple(query, opts, state.protocol),
+             {:ok, protocol} <- Protocol.checkin(protocol) do
+          state = %{state | protocol: protocol}
+
+          handle(mod, :handle_result, [result, mod_state], from, state)
+        else
+          {:error, %Postgrex.Error{} = error, protocol} ->
+            handle(mod, :handle_result, [error, mod_state], from, %{state | protocol: protocol})
+
+          {:disconnect, reason, protocol} ->
+            from && reply(from, {__MODULE__, reason})
+
+            reconnect_or_stop(:disconnect, reason, protocol, state)
+        end
+    end
+  end
+
+  defp reconnect_or_stop(error, reason, protocol, %{state: {mod, mod_state}} = state)
+       when error in [:error, :disconnect] do
+    {:noreply, state, _} = maybe_handle(mod, :handle_disconnect, [mod_state], state)
+
+    if state.auto_reconnect do
+      {:connect, :reconnect, state}
+    else
+      {:stop, reason, %{state | protocol: protocol}}
+    end
+  end
+
+  defp opts(mod), do: Process.get(mod)
+
+  defp put_opts(mod, opts), do: Process.put(mod, opts)
+end

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -145,8 +145,7 @@ defmodule NotificationTest do
       disconnect(context.pid_ps)
 
       # Also attempt to subscribe while it is down
-      assert {ok_or_eventually, ref2} = PN.listen(context.pid_ps, "channel2")
-      assert ok_or_eventually in [:ok, :eventually]
+      assert {:eventually, ref2} = PN.listen(context.pid_ps, "channel2")
 
       # Give the notifier a chance to re-establish the connection and listeners
       Process.sleep(500)

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -38,7 +38,9 @@ defmodule NotificationTest do
   end
 
   test "listening", context do
-    assert {:ok, _} = PN.listen(context.pid_ps, "channel")
+    assert {:ok, ref} = PN.listen(context.pid_ps, "channel")
+
+    assert is_reference(ref)
   end
 
   test "notifying", context do
@@ -200,8 +202,8 @@ defmodule NotificationTest do
       end
 
       @impl true
-      def connect(state) do
-        {:ok, state}
+      def handle_connect(state) do
+        {:noreply, state}
       end
 
       @impl true

--- a/test/simple_connection_test.exs
+++ b/test/simple_connection_test.exs
@@ -1,0 +1,144 @@
+defmodule SimpleConnectionTest do
+  use ExUnit.Case, async: true
+
+  alias Postgrex.SimpleConnection, as: SC
+
+  defmodule Conn do
+    @behaviour Postgrex.SimpleConnection
+
+    @impl true
+    def init(pid) do
+      {:ok, %{from: nil, pid: pid}}
+    end
+
+    @impl true
+    def notify(channel, payload, state) do
+      send(state.pid, {channel, payload})
+
+      :ok
+    end
+
+    @impl true
+    def handle_connect(state) do
+      send(state.pid, {:connect, System.unique_integer()})
+
+      {:noreply, state}
+    end
+
+    @impl true
+    def handle_disconnect(state) do
+      send(state.pid, {:disconnect, System.unique_integer()})
+
+      {:noreply, state}
+    end
+
+    @impl true
+    def handle_call(:ping, from, state) do
+      Postgrex.SimpleConnection.reply(from, :pong)
+
+      {:noreply, state}
+    end
+
+    def handle_call({:query, query}, from, state) do
+      {:query, query, %{state | from: from}}
+    end
+
+    @impl true
+    def handle_info(:ping, state) do
+      send(state.pid, :pong)
+
+      {:noreply, state}
+    end
+
+    @impl true
+    def handle_result(result, %{from: from} = state) do
+      Postgrex.SimpleConnection.reply(from, {:ok, result})
+
+      {:noreply, state}
+    end
+  end
+
+  @opts [database: "postgrex_test", sync_connect: true, auto_reconnect: false]
+
+  setup context do
+    opts = Keyword.merge(@opts, context[:opts] || [])
+    conn = start_supervised!({SC, [Conn, [self()], opts]})
+
+    {:ok, conn: conn}
+  end
+
+  describe "handle_call/3" do
+    test "forwarding calls to the callback module", context do
+      assert :pong == SC.call(context.conn, :ping)
+    end
+  end
+
+  describe "handle_info/2" do
+    test "forwarding unknown messages to the callback module", context do
+      send(context.conn, :ping)
+
+      assert_receive :pong
+    end
+  end
+
+  describe "handle_result/2" do
+    test "relaying query results", context do
+      assert {:ok, %Postgrex.Result{}} = SC.call(context.conn, {:query, "SELECT 1"})
+    end
+
+    test "relaying query errors", context do
+      assert {:ok, %Postgrex.Error{}} = SC.call(context.conn, {:query, "SELCT"})
+    end
+  end
+
+  describe "notify/3" do
+    test "relaying pubsub notifications", context do
+      assert {:ok, _result} = SC.call(context.conn, {:query, ~s(LISTEN "channel")})
+      assert {:ok, _result} = SC.call(context.conn, {:query, ~s(NOTIFY "channel", 'hello')})
+
+      assert_receive {"channel", "hello"}
+    end
+  end
+
+  describe "auto-reconnect" do
+    @tag opts: [auto_reconnect: true]
+    test "disconnect and connect handlers are invoked on reconnection", context do
+      assert_receive {:connect, i1}
+
+      :sys.suspend(context.conn)
+      {_pid, ref} = spawn_monitor(fn -> SC.call(context.conn, {:query, "SELECT 1"}) end)
+      disconnect(context.conn)
+      :sys.resume(context.conn)
+
+      assert_receive {:DOWN, ^ref, _, _, _}
+      assert {:ok, %Postgrex.Result{}} = SC.call(context.conn, {:query, "SELECT 1"})
+      assert_receive {:disconnect, i2} when i1 < i2
+      assert_receive {:connect, i3} when i2 < i3
+    end
+
+    @tag capture_log: true
+    test "disconnect handler is invoked and the process stays down", context do
+      assert_receive {:connect, _}
+
+      Process.flag(:trap_exit, true)
+
+      :sys.suspend(context.conn)
+      {_pid, ref} = spawn_monitor(fn -> SC.call(context.conn, {:query, "SELECT 1"}) end)
+      disconnect(context.conn)
+      :sys.resume(context.conn)
+
+      assert_receive {:DOWN, ^ref, _, _, _}
+      assert_received {:disconnect, _}
+
+      ref = Process.monitor(context.conn)
+      assert_receive {:DOWN, ^ref, _, _, _}
+
+      refute_received {:connect, _}
+    end
+  end
+
+  defp disconnect(conn) do
+    {:gen_tcp, sock} = :sys.get_state(conn).mod_state.protocol.sock
+    :gen_tcp.shutdown(sock, :read_write)
+  end
+end


### PR DESCRIPTION
I am opening this to get discussion and feedback going.

The goal is to make `Postgrex.Notifications` flexible enough to handle running simple arbitrary queries, in addition to the listen/unlisten/notify work it does currently. To make that possible without exposing private APIs, `Notifications` accepts a callback module with a default implementation that maintains the current functionality, but is extensible enough for people to implement their own notification logic.

#### Steps

- [x] Base notifications callback module
- [x] Simple query execution and handling
- [x] Listen/Unlisten/Notification abstraction
- [x] Extract SimpleConnection
- [x] Doc updates