### PR TITLE
separate multiple results in simple queries

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1030,7 +1030,7 @@ defmodule Postgrex.Protocol do
   ## replication/notifications
 
   @spec handle_simple(String.t() | iolist(), state) ::
-          {:ok, Postgrex.Result.t() | [Postgrex.Result.t()], state}
+          {:ok, [Postgrex.Result.t()], state}
           | {:error, Postgrex.Error.t(), state}
           | {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_simple(statement, opts \\ [], %{buffer: buffer} = s) do
@@ -1068,9 +1068,8 @@ defmodule Postgrex.Protocol do
         error_ready(s, status, err, buffer)
 
       {:ok, msg_ready(status: postgres), buffer} ->
-        results = format_simple_results(results)
         s = %{s | postgres: postgres, buffer: buffer}
-        {:ok, results, s}
+        {:ok, Enum.reverse(results), s}
 
       {:ok, msg, buffer} ->
         {s, status} = handle_msg(s, status, msg)
@@ -1080,10 +1079,6 @@ defmodule Postgrex.Protocol do
         dis
     end
   end
-
-  defp format_simple_results([result]), do: result
-  defp format_simple_results([_ | _] = results), do: Enum.reverse(results)
-  defp format_simple_results(results), do: results
 
   @spec handle_copy_send([binary], state) ::
           :ok

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1030,7 +1030,7 @@ defmodule Postgrex.Protocol do
   ## replication/notifications
 
   @spec handle_simple(String.t() | iolist(), state) ::
-          {:ok, Postgrex.Result.t(), state}
+          {:ok, Postgrex.Result.t() | [Postgrex.Result.t()], state}
           | {:error, Postgrex.Error.t(), state}
           | {:disconnect, %DBConnection.ConnectionError{}, state}
   def handle_simple(statement, opts \\ [], %{buffer: buffer} = s) do
@@ -1039,7 +1039,7 @@ defmodule Postgrex.Protocol do
 
     case msg_send(%{s | buffer: nil}, msgs, buffer) do
       :ok ->
-        recv_simple(s, status, [], [], [], buffer)
+        recv_simple(s, status, [], [], [], [], buffer)
 
       {:disconnect, err, s} ->
         {:disconnect, err, s}
@@ -1049,35 +1049,41 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp recv_simple(s, status, columns, rows, tags, buffer) do
+  defp recv_simple(s, status, results, columns, rows, tags, buffer) do
     case msg_recv(s, :infinity, buffer) do
       {:ok, msg_row_desc(fields: fields), buffer} ->
         columns = column_names(fields)
-        recv_simple(s, status, columns, rows, tags, buffer)
+        recv_simple(s, status, results, columns, rows, tags, buffer)
 
       {:ok, msg_data_row(values: values), buffer} ->
         row = Types.decode_simple(values, s.types)
-        recv_simple(s, status, columns, [row | rows], tags, buffer)
+        recv_simple(s, status, results, columns, [row | rows], tags, buffer)
 
       {:ok, msg_command_complete(tag: tag), buffer} ->
-        recv_simple(s, status, columns, rows, [tag | tags], buffer)
+        result = done(s, status, columns, Enum.reverse(rows), Enum.reverse([tag | tags]))
+        recv_simple(s, status, [result | results], [], [], [], buffer)
 
       {:ok, msg_error(fields: fields), buffer} ->
         err = Postgrex.Error.exception(postgres: fields)
         error_ready(s, status, err, buffer)
 
       {:ok, msg_ready(status: postgres), buffer} ->
+        results = format_simple_results(results)
         s = %{s | postgres: postgres, buffer: buffer}
-        {:ok, done(s, status, columns, Enum.reverse(rows), Enum.reverse(tags)), s}
+        {:ok, results, s}
 
       {:ok, msg, buffer} ->
         {s, status} = handle_msg(s, status, msg)
-        recv_simple(s, status, columns, rows, tags, buffer)
+        recv_simple(s, status, results, columns, rows, tags, buffer)
 
       {:disconnect, _, _} = dis ->
         dis
     end
   end
+
+  defp format_simple_results([result]), do: result
+  defp format_simple_results([_ | _] = results), do: Enum.reverse(results)
+  defp format_simple_results(results), do: results
 
   @spec handle_copy_send([binary], state) ::
           :ok

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -80,7 +80,7 @@ defmodule Postgrex.ReplicationConnection do
         end
 
         @impl true
-        def handle_result(%Postgrex.Result{}, %{step: :create_slot} = state) do
+        def handle_result(_results, %{step: :create_slot} = state) when is_list(results) do
           query = "START_REPLICATION SLOT postgrex LOGICAL 0/0 (proto_version '1', publication_names 'postgrex_example')"
           {:stream, query, [], %{state | step: :streaming}}
         end
@@ -251,9 +251,11 @@ defmodule Postgrex.ReplicationConnection do
 
   If any callback returns `{:query, iodata, state}`,
   then this callback will be immediatelly called with
-  the result of the query.
+  the result of the query. If successful, this will
+  always be a list because the simple protocol allows
+  multiple commands to be given in a single query.
   """
-  @callback handle_result(Postgrex.Result.t() | Postgrex.Error.t(), state) ::
+  @callback handle_result([Postgrex.Result.t()] | Postgrex.Error.t(), state) ::
               {:noreply, state}
               | {:noreply, ack, state}
               | {:query, query, state}
@@ -529,8 +531,8 @@ defmodule Postgrex.ReplicationConnection do
 
       {:query, query, mod_state} when streaming == nil ->
         case Protocol.handle_simple(query, [], s.protocol) do
-          {:ok, %Postgrex.Result{} = result, protocol} ->
-            handle(mod, :handle_result, [result, mod_state], from, %{s | protocol: protocol})
+          {:ok, results, protocol} when is_list(results) ->
+            handle(mod, :handle_result, [results, mod_state], from, %{s | protocol: protocol})
 
           {:error, %Postgrex.Error{} = error, protocol} ->
             handle(mod, :handle_result, [error, mod_state], from, %{s | protocol: protocol})

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -251,9 +251,11 @@ defmodule Postgrex.ReplicationConnection do
 
   If any callback returns `{:query, iodata, state}`,
   then this callback will be immediatelly called with
-  the result of the query. If successful, this will
-  always be a list because the simple protocol allows
-  multiple commands to be given in a single query.
+  the result of the query. Please note that Postgres
+  currently limits replication connections to single
+  command queries. This means every result passed into
+  this callback will be a list with a single entry.
+  Multiple command queries will return an error.
   """
   @callback handle_result([Postgrex.Result.t()] | Postgrex.Error.t(), state) ::
               {:noreply, state}

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -80,7 +80,7 @@ defmodule Postgrex.ReplicationConnection do
         end
 
         @impl true
-        def handle_result(_results, %{step: :create_slot} = state) when is_list(results) do
+        def handle_result(results, %{step: :create_slot} = state) when is_list(results) do
           query = "START_REPLICATION SLOT postgrex LOGICAL 0/0 (proto_version '1', publication_names 'postgrex_example')"
           {:stream, query, [], %{state | step: :streaming}}
         end

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -251,11 +251,12 @@ defmodule Postgrex.ReplicationConnection do
 
   If any callback returns `{:query, iodata, state}`,
   then this callback will be immediatelly called with
-  the result of the query. Please note that Postgres
-  currently limits replication connections to single
-  command queries. This means every result passed into
-  this callback will be a list with a single entry.
-  Multiple command queries will return an error.
+  the result of the query. Please note that even though
+  replicaton connections use the simple query protocol,
+  Postgres currently limits them to single command queries.
+  Due to this constraint, this callback will be passed
+  either a list with a single successful query result or
+  an error.
   """
   @callback handle_result([Postgrex.Result.t()] | Postgrex.Error.t(), state) ::
               {:noreply, state}

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -182,7 +182,7 @@ defmodule Postgrex.SimpleConnection do
 
   @doc """
   Callback for processing or relaying queries executed via `{:query, query, state}`.
-  If successful, this will always be a list because the simple protocol allows multiple
+  The results will always be passed as a list because the simple protocol allows multiple
   commands to be given in a single query.
   """
   @callback handle_result([Postgrex.Result.t()] | Postgrex.Error.t(), state) ::

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -182,8 +182,9 @@ defmodule Postgrex.SimpleConnection do
 
   @doc """
   Callback for processing or relaying queries executed via `{:query, query, state}`.
-  The results will always be passed as a list because the simple protocol allows multiple
-  commands to be given in a single query.
+  Either a list of sucessful query results or an error will be passed to this callback.
+  A list is passed because the simple query protocol allows multiple commands to be
+  issued in a single query.
   """
   @callback handle_result([Postgrex.Result.t()] | Postgrex.Error.t(), state) ::
               {:noreply, state}

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -33,6 +33,20 @@ defmodule Postgrex.SimpleConnection do
 
           {:noreply, state}
         end
+
+        @impl true
+        def handle_result(results, state) when is_list(results) do
+          SimpleConnection.reply(state.from, results)
+
+          {:noreply, state}
+        end
+
+        @impl true
+        def handle_result(%Postgrex.Error{} = error, state) do
+          SimpleConnection.reply(state.from, error)
+
+          {:noreply, state}
+        end
       end
 
       # Start the connection
@@ -176,7 +190,8 @@ defmodule Postgrex.SimpleConnection do
   @doc """
   Callback for processing or relaying queries executed via `{:query, query, state}`.
   """
-  @callback handle_result(Postgrex.Result.t() | Postgrex.Error.t(), state) :: {:noreply, state}
+  @callback handle_result(Postgrex.Result.t() | [Postgrex.Result.t()] | Postgrex.Error.t(), state) ::
+              {:noreply, state}
 
   @optional_callbacks handle_call: 3,
                       handle_connect: 1,

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -28,13 +28,6 @@ defmodule Postgrex.SimpleConnection do
         end
 
         @impl true
-        def handle_result(%Postgrex.Result{} = result, state) do
-          SimpleConnection.reply(state.from, result)
-
-          {:noreply, state}
-        end
-
-        @impl true
         def handle_result(results, state) when is_list(results) do
           SimpleConnection.reply(state.from, results)
 
@@ -99,7 +92,7 @@ defmodule Postgrex.SimpleConnection do
         end
 
         @impl true
-        def handle_result(_result, state) do
+        def handle_result(_results, state) do
           SimpleConnection.reply(state.from, :ok)
 
           {:noreply, %{state | from: nil}}
@@ -189,8 +182,10 @@ defmodule Postgrex.SimpleConnection do
 
   @doc """
   Callback for processing or relaying queries executed via `{:query, query, state}`.
+  If successful, this will always be a list because the simple protocol allows multiple
+  commands to be given in a single query.
   """
-  @callback handle_result(Postgrex.Result.t() | [Postgrex.Result.t()] | Postgrex.Error.t(), state) ::
+  @callback handle_result([Postgrex.Result.t()] | Postgrex.Error.t(), state) ::
               {:noreply, state}
 
   @optional_callbacks handle_call: 3,
@@ -376,11 +371,11 @@ defmodule Postgrex.SimpleConnection do
 
         state = %{state | state: {mod, mod_state}}
 
-        with {:ok, result, protocol} <- Protocol.handle_simple(query, opts, state.protocol),
+        with {:ok, results, protocol} <- Protocol.handle_simple(query, opts, state.protocol),
              {:ok, protocol} <- Protocol.checkin(protocol) do
           state = %{state | protocol: protocol}
 
-          handle(mod, :handle_result, [result, mod_state], from, state)
+          handle(mod, :handle_result, [results, mod_state], from, state)
         else
           {:error, %Postgrex.Error{} = error, protocol} ->
             handle(mod, :handle_result, [error, mod_state], from, %{state | protocol: protocol})

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -182,7 +182,8 @@ defmodule Postgrex.SimpleConnection do
 
   @doc """
   Callback for processing or relaying queries executed via `{:query, query, state}`.
-  Either a list of sucessful query results or an error will be passed to this callback.
+
+  Either a list of successful query results or an error will be passed to this callback.
   A list is passed because the simple query protocol allows multiple commands to be
   issued in a single query.
   """

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -145,7 +145,8 @@ defmodule NotificationTest do
       disconnect(context.pid_ps)
 
       # Also attempt to subscribe while it is down
-      assert {:eventually, ref2} = PN.listen(context.pid_ps, "channel2")
+      assert {ok_or_eventually, ref2} = PN.listen(context.pid_ps, "channel2")
+      assert ok_or_eventually in [:ok, :eventually]
 
       # Give the notifier a chance to re-establish the connection and listeners
       Process.sleep(500)

--- a/test/replication_connection_test.exs
+++ b/test/replication_connection_test.exs
@@ -110,6 +110,16 @@ defmodule ReplicationTest do
       assert {:ok, [%Postgrex.Result{}]} = PR.call(context.repl, {:query, "SELECT 1"})
     end
 
+    test "on multiple results", context do
+      assert {:ok, [%Postgrex.Result{} = result1, %Postgrex.Result{} = result2]} =
+               PR.call(context.repl, {:query, "SELECT 1; SELECT 2;"})
+
+      assert result1.rows == [["1"]]
+      assert result1.num_rows == 1
+      assert result2.rows == [["2"]]
+      assert result2.num_rows == 1
+    end
+
     test "on error", context do
       assert {:ok, %Postgrex.Error{}} = PR.call(context.repl, {:query, "SELCT"})
     end

--- a/test/replication_connection_test.exs
+++ b/test/replication_connection_test.exs
@@ -107,7 +107,7 @@ defmodule ReplicationTest do
 
   describe "handle_result" do
     test "on result", context do
-      assert {:ok, %Postgrex.Result{}} = PR.call(context.repl, {:query, "SELECT 1"})
+      assert {:ok, [%Postgrex.Result{}]} = PR.call(context.repl, {:query, "SELECT 1"})
     end
 
     test "on error", context do
@@ -140,7 +140,7 @@ defmodule ReplicationTest do
       disconnect(context.repl)
       :sys.resume(context.repl)
       assert Task.await(task) == :reconnecting
-      assert {:ok, %Postgrex.Result{}} = PR.call(context.repl, {:query, "SELECT 1"})
+      assert {:ok, [%Postgrex.Result{}]} = PR.call(context.repl, {:query, "SELECT 1"})
       assert_receive {:disconnect, i2} when i1 < i2, @timeout
       assert_receive {:connect, i3} when i2 < i3, @timeout
     end
@@ -237,7 +237,7 @@ defmodule ReplicationTest do
       assert_receive {:done, i3} when i2 < i3, @timeout
 
       # Can query after copy is done
-      {:ok, %Postgrex.Result{}} = PR.call(context.repl, {:query, "SELECT 1"})
+      {:ok, [%Postgrex.Result{}]} = PR.call(context.repl, {:query, "SELECT 1"})
     end
   end
 

--- a/test/replication_connection_test.exs
+++ b/test/replication_connection_test.exs
@@ -116,10 +116,6 @@ defmodule ReplicationTest do
       assert {:ok, [%Postgrex.Result{}]} = PR.call(context.repl, {:query, "SELECT 1"})
     end
 
-    test "on multiple results", context do
-      assert {:error, %Postgrex.Error{}} = PR.call(context.repl, {:query, "SELECT 1; SELECT 2;"})
-    end
-
     test "on error", context do
       assert {:error, %Postgrex.Error{}} = PR.call(context.repl, {:query, "SELCT"})
     end

--- a/test/simple_connection_test.exs
+++ b/test/simple_connection_test.exs
@@ -88,6 +88,16 @@ defmodule SimpleConnectionTest do
       assert {:ok, %Postgrex.Result{}} = SC.call(context.conn, {:query, "SELECT 1"})
     end
 
+    test "relaying multi-statement query results", context do
+      assert {:ok, [%Postgrex.Result{} = result1, %Postgrex.Result{} = result2]} =
+               SC.call(context.conn, {:query, "SELECT 1; SELECT 2;"})
+
+      assert result1.rows == [["1"]]
+      assert result1.num_rows == 1
+      assert result2.rows == [["2"]]
+      assert result2.num_rows == 1
+    end
+
     test "relaying query errors", context do
       assert {:ok, %Postgrex.Error{}} = SC.call(context.conn, {:query, "SELCT"})
     end

--- a/test/simple_connection_test.exs
+++ b/test/simple_connection_test.exs
@@ -85,7 +85,7 @@ defmodule SimpleConnectionTest do
 
   describe "handle_result/2" do
     test "relaying query results", context do
-      assert {:ok, %Postgrex.Result{}} = SC.call(context.conn, {:query, "SELECT 1"})
+      assert {:ok, [%Postgrex.Result{}]} = SC.call(context.conn, {:query, "SELECT 1"})
     end
 
     test "relaying multi-statement query results", context do
@@ -122,7 +122,7 @@ defmodule SimpleConnectionTest do
       disconnect(context.conn)
       :sys.resume(context.conn)
 
-      assert {:ok, %Postgrex.Result{}} = SC.call(context.conn, {:query, "SELECT 1"})
+      assert {:ok, [%Postgrex.Result{}]} = SC.call(context.conn, {:query, "SELECT 1"})
       assert :reconnecting == Task.await(task)
       assert_receive {:disconnect, i2} when i1 < i2
       assert_receive {:connect, i3} when i2 < i3


### PR DESCRIPTION
Previously a query like `SELECT 1; SELECT 2;` would pass `%PostgrexResult{rows:[["1"], ["2"]]}` to the `handle_result` callback. Now it will send `[%PostgrexResult{rows:[["1"]]}, %PostgrexResult{rows:[["2"]]}]`.

This implementation reuses the `:query` return value and the `handle_result` callback. Another way to go is to make a new return value/callback for multiple result queries. The former is a bit more straightforward imo but the latter is more in line with MyXQL's semantics. 

Actually, now that I'm writing this, I'm thinking it's probably better to keep the semantics the same between the drivers, even if the implementation is completely different. But please let me know what you think. Thanks!

One more thing I realized: it will add some extra complexity to use MyXQL's semantics because we'd have to return  errors if a multi-result query is issued using `:query`.