### PR TITLE
docs:  fix typo in typedoc

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -8,7 +8,7 @@ defmodule Postgrex.Types do
 
   @typedoc """
   PostgreSQL internal identifier that maps to a type. See
-  http://www.postgresql.org/docs/9.4/static/datatype-oid.html.
+  [http://www.postgresql.org/docs/9.4/static/datatype-oid.html](http://www.postgresql.org/docs/9.4/static/datatype-oid.html).
   """
   @type oid :: pos_integer
 

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -8,7 +8,7 @@ defmodule Postgrex.Types do
 
   @typedoc """
   PostgreSQL internal identifier that maps to a type. See
-  [http://www.postgresql.org/docs/9.4/static/datatype-oid.html](http://www.postgresql.org/docs/9.4/static/datatype-oid.html).
+  <https://www.postgresql.org/docs/9.4/static/datatype-oid.html>.
   """
   @type oid :: pos_integer
 


### PR DESCRIPTION
When the [hexdocs are generated](https://hexdocs.pm/postgrex/Postgrex.Types.html#t:oid/0), the link to postgres oid documentation is bad (points [here](http://www.postgresql.org/docs/9.4/static/datatype-oid.html.) instead of [here](http://www.postgresql.org/docs/9.4/static/datatype-oid.html)). This just updates to markdown so the link doesn't include the period at the end of the sentence.