### PR TITLE
Fix! Replication streaming can be resumed after reconnect

### DIFF
--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -75,7 +75,7 @@ defmodule Postgrex.ReplicationConnection do
 
         @impl true
         def handle_connect(state) do
-          query = "CREATE_REPLICATION_SLOT postgrex TEMPORARY LOGICAL pg_output NOEXPORT_SNAPSHOT"
+          query = "CREATE_REPLICATION_SLOT postgrex TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT"
           {:query, query, %{state | step: :create_slot}}
         end
 
@@ -566,7 +566,7 @@ defmodule Postgrex.ReplicationConnection do
        when error in [:error, :disconnect] do
     %{state: {mod, mod_state}} = s
     {:noreply, s} = maybe_handle(mod, :handle_disconnect, [mod_state], s)
-    {:connect, :reconnect, s}
+    {:connect, :reconnect, %{s | streaming: nil}}
   end
 
   defp opts(), do: Process.get(__MODULE__)


### PR DESCRIPTION
When `:auto_reconnect` is set to true it isn't possible to resume the replication after a reconnect due to the process being in a streaming state. 
Any `{:query, ...}` or `{:stream, ...}` from in the `handle_connect` callback end up in the [`stream_in_progress`](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex/replication_connection.ex#L552) and the warning `09:21:28.465 [warning] received query while stream is already in progress` is printed.

The actual replication is not resumed / restarted just the connection.
This PR just sets `:streaming` to `nil` on disconnect so that one can resume / recreate the replication slot in `handle_connect`.

Also a documentation fix for the correct plugin name 😄 
