### PR TITLE
Accept `nil` as first argument in `disconnect/2`

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -203,7 +203,7 @@ defmodule Postgrex.Protocol do
   end
 
   @impl true
-  @spec disconnect(Exception.t(), state) :: :ok
+  @spec disconnect(Exception.t() | nil, state) :: :ok
   def disconnect(_, s) do
     # cancel the request first otherwise PostgreSQL will log
     # every time the connection is explicitly disconnected


### PR DESCRIPTION
The first argument in `Protocol.disconnect/2` is not currently used. Sometimes we find ourselves wanting to call `disconnect/2` without an exception (so `nil` is the first argument). This change removes the Dialyzer warning that occurs when you pass in `nil` as the first argument.