### PR TITLE
Fix Elixir 1.15 warnings

### DIFF
--- a/lib/postgrex/extensions/array.ex
+++ b/lib/postgrex/extensions/array.ex
@@ -28,8 +28,8 @@ defmodule Postgrex.Extensions.Array do
 
   def decode(_) do
     quote location: :keep do
-      <<len::int32, binary::binary-size(len)>>, [oid], [type] ->
-        <<ndims::int32, _has_null::int32, ^oid::uint32, dims::size(ndims)-binary-unit(64),
+      <<len::int32(), binary::binary-size(len)>>, [oid], [type] ->
+        <<ndims::int32(), _has_null::int32(), ^oid::uint32(), dims::size(ndims)-binary-unit(64),
           data::binary>> = binary
 
         # decode_list/2 defined by TypeModule
@@ -45,14 +45,14 @@ defmodule Postgrex.Extensions.Array do
   # While libpq will decode an payload encoded for a 0-dim array, CockroachDB will not.
   # Also, this is how libpq actually encodes 0-dim arrays.
   def encode([], elem_oid, _encoder) do
-    <<20::int32, 1::int32, 0::int32, elem_oid::uint32, 0::int32, 1::int32>>
+    <<20::int32(), 1::int32(), 0::int32(), elem_oid::uint32(), 0::int32(), 1::int32()>>
   end
 
   def encode(list, elem_oid, encoder) do
     {data, ndims, lengths} = encode(list, 0, [], encoder)
-    lengths = for len <- Enum.reverse(lengths), do: <<len::int32, 1::int32>>
-    iodata = [<<ndims::int32, 0::int32, elem_oid::uint32>>, lengths, data]
-    [<<IO.iodata_length(iodata)::int32>> | iodata]
+    lengths = for len <- Enum.reverse(lengths), do: <<len::int32(), 1::int32()>>
+    iodata = [<<ndims::int32(), 0::int32(), elem_oid::uint32()>>, lengths, data]
+    [<<IO.iodata_length(iodata)::int32()>> | iodata]
   end
 
   defp encode([], ndims, lengths, _encoder) do
@@ -96,7 +96,7 @@ defmodule Postgrex.Extensions.Array do
     end
   end
 
-  defp decode_dims(<<len::int32, _lbound::int32, rest::binary>>, acc) do
+  defp decode_dims(<<len::int32(), _lbound::int32(), rest::binary>>, acc) do
     decode_dims(rest, [len | acc])
   end
 

--- a/lib/postgrex/extensions/bit_string.ex
+++ b/lib/postgrex/extensions/bit_string.ex
@@ -8,7 +8,7 @@ defmodule Postgrex.Extensions.BitString do
   def encode(_) do
     quote location: :keep, generated: true do
       val when is_binary(val) ->
-        [<<byte_size(val) + 4::int32, bit_size(val)::uint32>> | val]
+        [<<byte_size(val) + 4::int32(), bit_size(val)::uint32()>> | val]
 
       val when is_bitstring(val) ->
         bin_size = byte_size(val)
@@ -18,7 +18,7 @@ defmodule Postgrex.Extensions.BitString do
         bit_count = bit_size(val)
 
         [
-          <<bin_size + 4::int32, bit_count::uint32>>,
+          <<bin_size + 4::int32(), bit_count::uint32()>>,
           binary
           | <<last::bits, 0::size(pad)>>
         ]
@@ -30,7 +30,7 @@ defmodule Postgrex.Extensions.BitString do
 
   def decode(:copy) do
     quote location: :keep do
-      <<len::int32, value::binary-size(len)>> ->
+      <<len::int32(), value::binary-size(len)>> ->
         copy = :binary.copy(value)
         <<len::unsigned-32, bits::bits-size(len), _::bits>> = copy
         bits
@@ -39,8 +39,8 @@ defmodule Postgrex.Extensions.BitString do
 
   def decode(:reference) do
     quote location: :keep do
-      <<len::int32, value::binary-size(len)>> ->
-        <<len::int32, bits::bits-size(len), _::bits>> = value
+      <<len::int32(), value::binary-size(len)>> ->
+        <<len::int32(), bits::bits-size(len), _::bits>> = value
         bits
     end
   end

--- a/lib/postgrex/extensions/bool.ex
+++ b/lib/postgrex/extensions/bool.ex
@@ -6,10 +6,10 @@ defmodule Postgrex.Extensions.Bool do
   def encode(_) do
     quote location: :keep do
       true ->
-        <<1::int32, 1>>
+        <<1::int32(), 1>>
 
       false ->
-        <<1::int32, 0>>
+        <<1::int32(), 0>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a boolean")
@@ -18,8 +18,8 @@ defmodule Postgrex.Extensions.Bool do
 
   def decode(_) do
     quote location: :keep do
-      <<1::int32, 1>> -> true
-      <<1::int32, 0>> -> false
+      <<1::int32(), 1>> -> true
+      <<1::int32(), 0>> -> false
     end
   end
 end

--- a/lib/postgrex/extensions/box.ex
+++ b/lib/postgrex/extensions/box.ex
@@ -10,7 +10,7 @@ defmodule Postgrex.Extensions.Box do
         encoded_p1 = Point.encode_point(p1, Postgrex.Box)
         encoded_p2 = Point.encode_point(p2, Postgrex.Box)
         # 2 points -> 16 bytes each
-        [<<32::int32>>, encoded_p1 | encoded_p2]
+        [<<32::int32()>>, encoded_p1 | encoded_p2]
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Line)
@@ -20,7 +20,7 @@ defmodule Postgrex.Extensions.Box do
   def decode(_) do
     quote location: :keep do
       # 2 points -> 16 bytes each
-      <<32::int32, x1::float64, y1::float64, x2::float64, y2::float64>> ->
+      <<32::int32(), x1::float64(), y1::float64(), x2::float64(), y2::float64()>> ->
         p1 = %Postgrex.Point{x: x1, y: y1}
         p2 = %Postgrex.Point{x: x2, y: y2}
         %Postgrex.Box{upper_right: p1, bottom_left: p2}

--- a/lib/postgrex/extensions/circle.ex
+++ b/lib/postgrex/extensions/circle.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Extensions.Circle do
     quote location: :keep do
       %Postgrex.Circle{center: %Postgrex.Point{x: x, y: y}, radius: r}
       when is_number(x) and is_number(y) and is_number(r) and r >= 0 ->
-        <<24::int32, x::float64, y::float64, r::float64>>
+        <<24::int32(), x::float64(), y::float64(), r::float64()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Path)
@@ -16,7 +16,7 @@ defmodule Postgrex.Extensions.Circle do
 
   def decode(_) do
     quote location: :keep do
-      <<24::int32, x::float64, y::float64, r::float64>> ->
+      <<24::int32(), x::float64(), y::float64(), r::float64()>> ->
         %Postgrex.Circle{center: %Postgrex.Point{x: x, y: y}, radius: r}
     end
   end

--- a/lib/postgrex/extensions/date.ex
+++ b/lib/postgrex/extensions/date.ex
@@ -26,7 +26,7 @@ defmodule Postgrex.Extensions.Date do
 
   def decode(_) do
     quote location: :keep do
-      <<4::int32, days::int32>> ->
+      <<4::int32(), days::int32()>> ->
         unquote(__MODULE__).day_to_elixir(days)
     end
   end
@@ -34,7 +34,7 @@ defmodule Postgrex.Extensions.Date do
   ## Helpers
 
   def encode_elixir(%Date{year: year} = date) when year <= @max_year do
-    <<4::int32, Date.to_gregorian_days(date) - @gd_epoch::int32>>
+    <<4::int32(), Date.to_gregorian_days(date) - @gd_epoch::int32()>>
   end
 
   def encode_elixir(%Date{} = date) do

--- a/lib/postgrex/extensions/float4.ex
+++ b/lib/postgrex/extensions/float4.ex
@@ -6,16 +6,16 @@ defmodule Postgrex.Extensions.Float4 do
   def encode(_) do
     quote location: :keep do
       n when is_number(n) ->
-        <<4::int32, n::float32>>
+        <<4::int32(), n::float32()>>
 
       :NaN ->
-        <<4::int32, 0::1, 255, 1::1, 0::22>>
+        <<4::int32(), 0::1, 255, 1::1, 0::22>>
 
       :inf ->
-        <<4::int32, 0::1, 255, 0::23>>
+        <<4::int32(), 0::1, 255, 0::23>>
 
       :"-inf" ->
-        <<4::int32, 1::1, 255, 0::23>>
+        <<4::int32(), 1::1, 255, 0::23>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a float")
@@ -24,10 +24,10 @@ defmodule Postgrex.Extensions.Float4 do
 
   def decode(_) do
     quote location: :keep do
-      <<4::int32, 0::1, 255, 0::23>> -> :inf
-      <<4::int32, 1::1, 255, 0::23>> -> :"-inf"
-      <<4::int32, _::1, 255, _::23>> -> :NaN
-      <<4::int32, float::float32>> -> float
+      <<4::int32(), 0::1, 255, 0::23>> -> :inf
+      <<4::int32(), 1::1, 255, 0::23>> -> :"-inf"
+      <<4::int32(), _::1, 255, _::23>> -> :NaN
+      <<4::int32(), float::float32()>> -> float
     end
   end
 end

--- a/lib/postgrex/extensions/float8.ex
+++ b/lib/postgrex/extensions/float8.ex
@@ -6,16 +6,16 @@ defmodule Postgrex.Extensions.Float8 do
   def encode(_) do
     quote location: :keep do
       n when is_number(n) ->
-        <<8::int32, n::float64>>
+        <<8::int32(), n::float64()>>
 
       :NaN ->
-        <<8::int32, 0::1, 2047::11, 1::1, 0::51>>
+        <<8::int32(), 0::1, 2047::11, 1::1, 0::51>>
 
       :inf ->
-        <<8::int32, 0::1, 2047::11, 0::52>>
+        <<8::int32(), 0::1, 2047::11, 0::52>>
 
       :"-inf" ->
-        <<8::int32, 1::1, 2047::11, 0::52>>
+        <<8::int32(), 1::1, 2047::11, 0::52>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a float")
@@ -24,10 +24,10 @@ defmodule Postgrex.Extensions.Float8 do
 
   def decode(_) do
     quote location: :keep do
-      <<8::int32, 0::1, 2047::11, 0::52>> -> :inf
-      <<8::int32, 1::1, 2047::11, 0::52>> -> :"-inf"
-      <<8::int32, _::1, 2047::11, _::52>> -> :NaN
-      <<8::int32, float::float64>> -> float
+      <<8::int32(), 0::1, 2047::11, 0::52>> -> :inf
+      <<8::int32(), 1::1, 2047::11, 0::52>> -> :"-inf"
+      <<8::int32(), _::1, 2047::11, _::52>> -> :NaN
+      <<8::int32(), float::float64()>> -> float
     end
   end
 end

--- a/lib/postgrex/extensions/hstore.ex
+++ b/lib/postgrex/extensions/hstore.ex
@@ -9,7 +9,7 @@ defmodule Postgrex.Extensions.HStore do
     quote location: :keep do
       %{} = map ->
         data = unquote(__MODULE__).encode_hstore(map)
-        [<<IO.iodata_length(data)::int32>> | data]
+        [<<IO.iodata_length(data)::int32()>> | data]
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a map")
@@ -18,7 +18,7 @@ defmodule Postgrex.Extensions.HStore do
 
   def decode(mode) do
     quote do
-      <<len::int32, data::binary-size(len)>> ->
+      <<len::int32(), data::binary-size(len)>> ->
         unquote(__MODULE__).decode_hstore(data, unquote(mode))
     end
   end
@@ -31,7 +31,7 @@ defmodule Postgrex.Extensions.HStore do
         [acc, encode_hstore_key(key), encode_hstore_value(value)]
       end)
 
-    [<<map_size(hstore_map)::int32>> | keys_and_values]
+    [<<map_size(hstore_map)::int32()>> | keys_and_values]
   end
 
   defp encode_hstore_key(key) when is_binary(key) do
@@ -43,19 +43,19 @@ defmodule Postgrex.Extensions.HStore do
   end
 
   defp encode_hstore_value(nil) do
-    <<-1::int32>>
+    <<-1::int32()>>
   end
 
   defp encode_hstore_value(value) when is_binary(value) do
     value_byte_size = byte_size(value)
-    <<value_byte_size::int32>> <> value
+    <<value_byte_size::int32()>> <> value
   end
 
-  def decode_hstore(<<_length::int32, pairs::binary>>, :reference) do
+  def decode_hstore(<<_length::int32(), pairs::binary>>, :reference) do
     decode_hstore_ref(pairs, %{})
   end
 
-  def decode_hstore(<<_length::int32, pairs::binary>>, :copy) do
+  def decode_hstore(<<_length::int32(), pairs::binary>>, :copy) do
     decode_hstore_copy(pairs, %{})
   end
 
@@ -65,14 +65,14 @@ defmodule Postgrex.Extensions.HStore do
 
   # in the case of a NULL value, there won't be a length
   defp decode_hstore_ref(
-         <<key_length::int32, key::binary(key_length), -1::int32, rest::binary>>,
+         <<key_length::int32(), key::binary(key_length), -1::int32(), rest::binary>>,
          acc
        ) do
     decode_hstore_ref(rest, Map.put(acc, key, nil))
   end
 
   defp decode_hstore_ref(
-         <<key_length::int32, key::binary(key_length), value_length::int32,
+         <<key_length::int32(), key::binary(key_length), value_length::int32(),
            value::binary(value_length), rest::binary>>,
          acc
        ) do
@@ -85,14 +85,14 @@ defmodule Postgrex.Extensions.HStore do
 
   # in the case of a NULL value, there won't be a length
   defp decode_hstore_copy(
-         <<key_length::int32, key::binary(key_length), -1::int32, rest::binary>>,
+         <<key_length::int32(), key::binary(key_length), -1::int32(), rest::binary>>,
          acc
        ) do
     decode_hstore_copy(rest, Map.put(acc, :binary.copy(key), nil))
   end
 
   defp decode_hstore_copy(
-         <<key_length::int32, key::binary(key_length), value_length::int32,
+         <<key_length::int32(), key::binary(key_length), value_length::int32(),
            value::binary(value_length), rest::binary>>,
          acc
        ) do

--- a/lib/postgrex/extensions/inet.ex
+++ b/lib/postgrex/extensions/inet.ex
@@ -7,16 +7,16 @@ defmodule Postgrex.Extensions.INET do
   def encode(_) do
     quote location: :keep do
       %Postgrex.INET{address: {a, b, c, d}, netmask: nil} ->
-        <<8::int32, 2, 32, 0, 4, a, b, c, d>>
+        <<8::int32(), 2, 32, 0, 4, a, b, c, d>>
 
       %Postgrex.INET{address: {a, b, c, d}, netmask: n} ->
-        <<8::int32, 2, n, 1, 4, a, b, c, d>>
+        <<8::int32(), 2, n, 1, 4, a, b, c, d>>
 
       %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: nil} ->
-        <<20::int32, 3, 128, 0, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+        <<20::int32(), 3, 128, 0, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
 
       %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: n} ->
-        <<20::int32, 3, n, 1, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+        <<20::int32(), 3, n, 1, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.INET)
@@ -25,11 +25,11 @@ defmodule Postgrex.Extensions.INET do
 
   def decode(_) do
     quote location: :keep do
-      <<8::int32, 2, n, cidr?, 4, a, b, c, d>> ->
+      <<8::int32(), 2, n, cidr?, 4, a, b, c, d>> ->
         n = if(cidr? == 1 or n != 32, do: n, else: nil)
         %Postgrex.INET{address: {a, b, c, d}, netmask: n}
 
-      <<20::int32, 3, n, cidr?, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> ->
+      <<20::int32(), 3, n, cidr?, 16, a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> ->
         n = if(cidr? == 1 or n != 128, do: n, else: nil)
         %Postgrex.INET{address: {a, b, c, d, e, f, g, h}, netmask: n}
     end

--- a/lib/postgrex/extensions/int2.ex
+++ b/lib/postgrex/extensions/int2.ex
@@ -10,7 +10,7 @@ defmodule Postgrex.Extensions.Int2 do
 
     quote location: :keep do
       int when is_integer(int) and int in unquote(range) ->
-        <<2::int32, int::int16>>
+        <<2::int32(), int::int16()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, unquote(range))
@@ -19,7 +19,7 @@ defmodule Postgrex.Extensions.Int2 do
 
   def decode(_) do
     quote location: :keep do
-      <<2::int32, int::int16>> -> int
+      <<2::int32(), int::int16()>> -> int
     end
   end
 end

--- a/lib/postgrex/extensions/int4.ex
+++ b/lib/postgrex/extensions/int4.ex
@@ -10,7 +10,7 @@ defmodule Postgrex.Extensions.Int4 do
 
     quote location: :keep do
       int when is_integer(int) and int in unquote(range) ->
-        <<4::int32, int::int32>>
+        <<4::int32(), int::int32()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, unquote(range))
@@ -19,7 +19,7 @@ defmodule Postgrex.Extensions.Int4 do
 
   def decode(_) do
     quote location: :keep do
-      <<4::int32, int::int32>> -> int
+      <<4::int32(), int::int32()>> -> int
     end
   end
 end

--- a/lib/postgrex/extensions/int8.ex
+++ b/lib/postgrex/extensions/int8.ex
@@ -10,7 +10,7 @@ defmodule Postgrex.Extensions.Int8 do
 
     quote location: :keep do
       int when is_integer(int) and int in unquote(range) ->
-        <<8::int32, int::int64>>
+        <<8::int32(), int::int64()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, unquote(range))
@@ -19,7 +19,7 @@ defmodule Postgrex.Extensions.Int8 do
 
   def decode(_) do
     quote location: :keep do
-      <<8::int32, int::int64>> -> int
+      <<8::int32(), int::int64()>> -> int
     end
   end
 end

--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Extensions.Interval do
     quote location: :keep do
       %Postgrex.Interval{months: months, days: days, secs: secs, microsecs: microsecs} ->
         microsecs = secs * 1_000_000 + microsecs
-        <<16::int32, microsecs::int64, days::int32, months::int32>>
+        <<16::int32(), microsecs::int64(), days::int32(), months::int32()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Interval)
@@ -16,7 +16,7 @@ defmodule Postgrex.Extensions.Interval do
 
   def decode(_) do
     quote location: :keep do
-      <<16::int32, microsecs::int64, days::int32, months::int32>> ->
+      <<16::int32(), microsecs::int64(), days::int32(), months::int32()>> ->
         secs = div(microsecs, 1_000_000)
         microsecs = rem(microsecs, 1_000_000)
         %Postgrex.Interval{months: months, days: days, secs: secs, microsecs: microsecs}

--- a/lib/postgrex/extensions/json.ex
+++ b/lib/postgrex/extensions/json.ex
@@ -33,13 +33,13 @@ defmodule Postgrex.Extensions.JSON do
     quote location: :keep do
       map ->
         data = unquote(library).encode_to_iodata!(map)
-        [<<IO.iodata_length(data)::int32>> | data]
+        [<<IO.iodata_length(data)::int32()>> | data]
     end
   end
 
   def decode({library, :copy}) do
     quote location: :keep do
-      <<len::int32, json::binary-size(len)>> ->
+      <<len::int32(), json::binary-size(len)>> ->
         json
         |> :binary.copy()
         |> unquote(library).decode!()
@@ -48,7 +48,7 @@ defmodule Postgrex.Extensions.JSON do
 
   def decode({library, :reference}) do
     quote location: :keep do
-      <<len::int32, json::binary-size(len)>> ->
+      <<len::int32(), json::binary-size(len)>> ->
         unquote(library).decode!(json)
     end
   end

--- a/lib/postgrex/extensions/jsonb.ex
+++ b/lib/postgrex/extensions/jsonb.ex
@@ -24,13 +24,13 @@ defmodule Postgrex.Extensions.JSONB do
     quote location: :keep do
       map ->
         data = unquote(library).encode_to_iodata!(map)
-        [<<IO.iodata_length(data) + 1::int32, 1>> | data]
+        [<<IO.iodata_length(data) + 1::int32(), 1>> | data]
     end
   end
 
   def decode({library, :copy}) do
     quote location: :keep do
-      <<len::int32, data::binary-size(len)>> ->
+      <<len::int32(), data::binary-size(len)>> ->
         <<1, json::binary>> = data
 
         json
@@ -41,7 +41,7 @@ defmodule Postgrex.Extensions.JSONB do
 
   def decode({library, :reference}) do
     quote location: :keep do
-      <<len::int32, data::binary-size(len)>> ->
+      <<len::int32(), data::binary-size(len)>> ->
         <<1, json::binary>> = data
         unquote(library).decode!(json)
     end

--- a/lib/postgrex/extensions/line.ex
+++ b/lib/postgrex/extensions/line.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Extensions.Line do
     quote location: :keep do
       %Postgrex.Line{a: a, b: b, c: c} when is_number(a) and is_number(b) and is_number(c) ->
         # a, b, c are 8 bytes each
-        <<24::int32, a::float64, b::float64, c::float64>>
+        <<24::int32(), a::float64(), b::float64(), c::float64()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Line)
@@ -17,7 +17,7 @@ defmodule Postgrex.Extensions.Line do
   def decode(_) do
     quote location: :keep do
       # a, b, c are 8 bytes each
-      <<24::int32, a::float64, b::float64, c::float64>> ->
+      <<24::int32(), a::float64(), b::float64(), c::float64()>> ->
         %Postgrex.Line{a: a, b: b, c: c}
     end
   end

--- a/lib/postgrex/extensions/line_segment.ex
+++ b/lib/postgrex/extensions/line_segment.ex
@@ -10,7 +10,7 @@ defmodule Postgrex.Extensions.LineSegment do
         encoded_p1 = Point.encode_point(p1, Postgrex.LineSegment)
         encoded_p2 = Point.encode_point(p2, Postgrex.LineSegment)
         # 2 points -> 16 bytes each
-        [<<32::int32>>, encoded_p1 | encoded_p2]
+        [<<32::int32()>>, encoded_p1 | encoded_p2]
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Line)
@@ -20,7 +20,7 @@ defmodule Postgrex.Extensions.LineSegment do
   def decode(_) do
     quote location: :keep do
       # 2 points -> 16 bytes each
-      <<32::int32, x1::float64, y1::float64, x2::float64, y2::float64>> ->
+      <<32::int32(), x1::float64(), y1::float64(), x2::float64(), y2::float64()>> ->
         p1 = %Postgrex.Point{x: x1, y: y1}
         p2 = %Postgrex.Point{x: x2, y: y2}
         %Postgrex.LineSegment{point1: p1, point2: p2}

--- a/lib/postgrex/extensions/macaddr.ex
+++ b/lib/postgrex/extensions/macaddr.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.MACADDR do
   def encode(_) do
     quote location: :keep do
       %Postgrex.MACADDR{address: {a, b, c, d, e, f}} ->
-        <<6::int32, a, b, c, d, e, f>>
+        <<6::int32(), a, b, c, d, e, f>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.MACADDR)
@@ -15,7 +15,7 @@ defmodule Postgrex.Extensions.MACADDR do
 
   def decode(_) do
     quote location: :keep do
-      <<6::int32, a::8, b::8, c::8, d::8, e::8, f::8>> ->
+      <<6::int32(), a::8, b::8, c::8, d::8, e::8, f::8>> ->
         %Postgrex.MACADDR{address: {a, b, c, d, e, f}}
     end
   end

--- a/lib/postgrex/extensions/name.ex
+++ b/lib/postgrex/extensions/name.ex
@@ -8,7 +8,7 @@ defmodule Postgrex.Extensions.Name do
   def encode(_) do
     quote location: :keep, generated: true do
       name when is_binary(name) and byte_size(name) < 64 ->
-        [<<byte_size(name)::int32>> | name]
+        [<<byte_size(name)::int32()>> | name]
 
       other ->
         msg = "a binary string of less than 64 bytes"
@@ -18,13 +18,13 @@ defmodule Postgrex.Extensions.Name do
 
   def decode(:reference) do
     quote location: :keep do
-      <<len::int32, name::binary-size(len)>> -> name
+      <<len::int32(), name::binary-size(len)>> -> name
     end
   end
 
   def decode(:copy) do
     quote location: :keep do
-      <<len::int32, name::binary-size(len)>> -> :binary.copy(name)
+      <<len::int32(), name::binary-size(len)>> -> :binary.copy(name)
     end
   end
 end

--- a/lib/postgrex/extensions/oid.ex
+++ b/lib/postgrex/extensions/oid.ex
@@ -13,7 +13,7 @@ defmodule Postgrex.Extensions.OID do
 
     quote location: :keep do
       oid when is_integer(oid) and oid in unquote(range) ->
-        <<4::int32, oid::uint32>>
+        <<4::int32(), oid::uint32()>>
 
       binary when is_binary(binary) ->
         msg =
@@ -30,7 +30,7 @@ defmodule Postgrex.Extensions.OID do
 
   def decode(_) do
     quote location: :keep do
-      <<4::int32, oid::uint32>> -> oid
+      <<4::int32(), oid::uint32()>> -> oid
     end
   end
 end

--- a/lib/postgrex/extensions/path.ex
+++ b/lib/postgrex/extensions/path.ex
@@ -16,7 +16,7 @@ defmodule Postgrex.Extensions.Path do
 
         # 1 byte for open/closed flag, 4 for length, 16 for each point
         nbytes = 5 + 16 * len
-        [<<nbytes::int32>>, open_byte, <<len::int32>> | encoded_points]
+        [<<nbytes::int32()>>, open_byte, <<len::int32()>> | encoded_points]
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Path)
@@ -25,12 +25,12 @@ defmodule Postgrex.Extensions.Path do
 
   def decode(_) do
     quote location: :keep do
-      <<nbytes::int32, path_data::binary-size(nbytes)>> ->
+      <<nbytes::int32(), path_data::binary-size(nbytes)>> ->
         Path.decode_path(path_data)
     end
   end
 
-  def decode_path(<<o::int8, n::int32, point_data::binary-size(n)-unit(128)>>) do
+  def decode_path(<<o::int8(), n::int32(), point_data::binary-size(n)-unit(128)>>) do
     open = o == 0
     points = decode_points(point_data, [])
     %Postgrex.Path{open: open, points: points}
@@ -41,7 +41,7 @@ defmodule Postgrex.Extensions.Path do
 
   defp decode_points(<<>>, points), do: Enum.reverse(points)
 
-  defp decode_points(<<x::float64, y::float64, rest::bits>>, points) do
+  defp decode_points(<<x::float64(), y::float64(), rest::bits>>, points) do
     decode_points(rest, [%Postgrex.Point{x: x, y: y} | points])
   end
 end

--- a/lib/postgrex/extensions/point.ex
+++ b/lib/postgrex/extensions/point.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.Point do
   def encode(_) do
     quote location: :keep do
       %Postgrex.Point{x: x, y: y} ->
-        <<16::int32, x::float64, y::float64>>
+        <<16::int32(), x::float64(), y::float64()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Point)
@@ -15,13 +15,13 @@ defmodule Postgrex.Extensions.Point do
 
   def decode(_) do
     quote location: :keep do
-      <<16::int32, x::float64, y::float64>> -> %Postgrex.Point{x: x, y: y}
+      <<16::int32(), x::float64(), y::float64()>> -> %Postgrex.Point{x: x, y: y}
     end
   end
 
   # used by other extensions
   def encode_point(%Postgrex.Point{x: x, y: y}, _) do
-    <<x::float64, y::float64>>
+    <<x::float64(), y::float64()>>
   end
 
   def encode_point(other, wanted) do

--- a/lib/postgrex/extensions/polygon.ex
+++ b/lib/postgrex/extensions/polygon.ex
@@ -18,7 +18,7 @@ defmodule Postgrex.Extensions.Polygon do
         # 32 bits for len, 64 for each x and each y
         nbytes = 4 + 16 * len
 
-        [<<nbytes::int32>>, <<len::int32>> | vert]
+        [<<nbytes::int32()>>, <<len::int32()>> | vert]
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Polygon)
@@ -27,20 +27,20 @@ defmodule Postgrex.Extensions.Polygon do
 
   def decode(_) do
     quote location: :keep do
-      <<nbytes::int32, polygon_data::binary-size(nbytes)>> ->
+      <<nbytes::int32(), polygon_data::binary-size(nbytes)>> ->
         vertices = Polygon.decode_vertices(polygon_data)
         %Postgrex.Polygon{vertices: vertices}
     end
   end
 
   # n vertices, 128 bits for each vertex - 64 for x, 64 for y
-  def decode_vertices(<<n::int32, vert_data::binary-size(n)-unit(128)>>) do
+  def decode_vertices(<<n::int32(), vert_data::binary-size(n)-unit(128)>>) do
     decode_vertices(vert_data, [])
   end
 
   defp decode_vertices(<<>>, v), do: Enum.reverse(v)
 
-  defp decode_vertices(<<x::float64, y::float64, rest::bits>>, v) do
+  defp decode_vertices(<<x::float64(), y::float64(), rest::bits>>, v) do
     decode_vertices(rest, [%Postgrex.Point{x: x, y: y} | v])
   end
 end

--- a/lib/postgrex/extensions/range.ex
+++ b/lib/postgrex/extensions/range.ex
@@ -35,7 +35,7 @@ defmodule Postgrex.Extensions.Range do
 
   def decode(_) do
     quote location: :keep do
-      <<len::int32, binary::binary-size(len)>>, [oid], [type] ->
+      <<len::int32(), binary::binary-size(len)>>, [oid], [type] ->
         <<flags, data::binary>> = binary
         # decode_list/2 defined by TypeModule
         case decode_list(data, type) do
@@ -51,7 +51,7 @@ defmodule Postgrex.Extensions.Range do
   ## Helpers
 
   def encode(_range, _oid, :empty, :empty) do
-    [<<1::int32, @range_empty>>]
+    [<<1::int32(), @range_empty>>]
   end
 
   def encode(%{lower_inclusive: lower_inc, upper_inclusive: upper_inc}, _oid, lower, upper) do
@@ -83,7 +83,7 @@ defmodule Postgrex.Extensions.Range do
         false -> flags
       end
 
-    [<<IO.iodata_length(data) + 1::int32>>, flags | data]
+    [<<IO.iodata_length(data) + 1::int32()>>, flags | data]
   end
 
   def decode(flags, _oid, []) when (flags &&& @range_empty) != 0 do

--- a/lib/postgrex/extensions/raw.ex
+++ b/lib/postgrex/extensions/raw.ex
@@ -17,7 +17,7 @@ defmodule Postgrex.Extensions.Raw do
   def encode(_) do
     quote location: :keep, generated: true do
       bin when is_binary(bin) ->
-        [<<byte_size(bin)::int32>> | bin]
+        [<<byte_size(bin)::int32()>> | bin]
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a binary")
@@ -26,13 +26,13 @@ defmodule Postgrex.Extensions.Raw do
 
   def decode(:copy) do
     quote location: :keep do
-      <<len::int32, value::binary-size(len)>> -> :binary.copy(value)
+      <<len::int32(), value::binary-size(len)>> -> :binary.copy(value)
     end
   end
 
   def decode(:reference) do
     quote location: :keep do
-      <<len::int32, value::binary-size(len)>> -> value
+      <<len::int32(), value::binary-size(len)>> -> value
     end
   end
 end

--- a/lib/postgrex/extensions/record.ex
+++ b/lib/postgrex/extensions/record.ex
@@ -22,7 +22,7 @@ defmodule Postgrex.Extensions.Record do
       tuple, oids, types when is_tuple(tuple) ->
         # encode_tuple/3 defined by TypeModule
         data = encode_tuple(tuple, oids, types)
-        [<<IO.iodata_length(data) + 4::int32, tuple_size(tuple)::int32>> | data]
+        [<<IO.iodata_length(data) + 4::int32(), tuple_size(tuple)::int32()>> | data]
 
       other, _, _ ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a tuple")
@@ -31,13 +31,13 @@ defmodule Postgrex.Extensions.Record do
 
   def decode(_) do
     quote location: :keep do
-      <<len::int32, binary::binary-size(len)>>, nil, types ->
-        <<count::int32, data::binary>> = binary
+      <<len::int32(), binary::binary-size(len)>>, nil, types ->
+        <<count::int32(), data::binary>> = binary
         # decode_tuple/3 defined by TypeModule
         decode_tuple(data, count, types)
 
-      <<len::int32, binary::binary-size(len)>>, oids, types ->
-        <<_::int32, data::binary>> = binary
+      <<len::int32(), binary::binary-size(len)>>, oids, types ->
+        <<_::int32(), data::binary>> = binary
         # decode_tuple/3 defined by TypeModule
         decode_tuple(data, oids, types)
     end

--- a/lib/postgrex/extensions/tid.ex
+++ b/lib/postgrex/extensions/tid.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.TID do
   def encode(_) do
     quote location: :keep do
       {block, tuple} ->
-        <<6::int32, block::uint32, tuple::uint16>>
+        <<6::int32(), block::uint32(), tuple::uint16()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a tuple of 2 integers")
@@ -15,7 +15,7 @@ defmodule Postgrex.Extensions.TID do
 
   def decode(_) do
     quote location: :keep do
-      <<6::int32, block::uint32, tuple::uint16>> ->
+      <<6::int32(), block::uint32(), tuple::uint16()>> ->
         {block, tuple}
     end
   end

--- a/lib/postgrex/extensions/time.ex
+++ b/lib/postgrex/extensions/time.ex
@@ -15,7 +15,7 @@ defmodule Postgrex.Extensions.Time do
 
   def decode(_) do
     quote location: :keep do
-      <<8::int32, microsecs::int64>> ->
+      <<8::int32(), microsecs::int64()>> ->
         unquote(__MODULE__).microsecond_to_elixir(microsecs)
     end
   end
@@ -25,7 +25,7 @@ defmodule Postgrex.Extensions.Time do
   def encode_elixir(%Time{hour: hour, minute: min, second: sec, microsecond: {usec, _}})
       when hour in 0..23 and min in 0..59 and sec in 0..59 and usec in 0..999_999 do
     time = {hour, min, sec}
-    <<8::int32, :calendar.time_to_seconds(time) * 1_000_000 + usec::int64>>
+    <<8::int32(), :calendar.time_to_seconds(time) * 1_000_000 + usec::int64()>>
   end
 
   def microsecond_to_elixir(microsec) do

--- a/lib/postgrex/extensions/timestamp.ex
+++ b/lib/postgrex/extensions/timestamp.ex
@@ -27,7 +27,7 @@ defmodule Postgrex.Extensions.Timestamp do
 
   def decode(infinity?) do
     quote location: :keep do
-      <<8::int32, microsecs::int64>> ->
+      <<8::int32(), microsecs::int64()>> ->
         unquote(__MODULE__).microsecond_to_elixir(microsecs, unquote(infinity?))
     end
   end
@@ -48,7 +48,7 @@ defmodule Postgrex.Extensions.Timestamp do
              usec in 0..999_999 do
     {gregorian_seconds, usec} = NaiveDateTime.to_gregorian_seconds(date_time)
     secs = gregorian_seconds - @gs_epoch
-    <<8::int32, secs * 1_000_000 + usec::int64>>
+    <<8::int32(), secs * 1_000_000 + usec::int64()>>
   end
 
   def microsecond_to_elixir(@plus_infinity, infinity?) do

--- a/lib/postgrex/extensions/timestamptz.ex
+++ b/lib/postgrex/extensions/timestamptz.ex
@@ -32,7 +32,7 @@ defmodule Postgrex.Extensions.TimestampTZ do
 
   def decode(infinity?) do
     quote location: :keep do
-      <<8::int32, microsecs::int64>> ->
+      <<8::int32(), microsecs::int64()>> ->
         unquote(__MODULE__).microsecond_to_elixir(microsecs, unquote(infinity?))
     end
   end
@@ -42,7 +42,7 @@ defmodule Postgrex.Extensions.TimestampTZ do
   def encode_elixir(%DateTime{utc_offset: 0, std_offset: 0} = datetime) do
     case DateTime.to_unix(datetime, :microsecond) do
       microsecs when microsecs in @us_min..@us_max ->
-        <<8::int32, microsecs - @us_epoch::int64>>
+        <<8::int32(), microsecs - @us_epoch::int64()>>
 
       _ ->
         raise ArgumentError, "#{inspect(datetime)} is not in the year range -4713..9999"

--- a/lib/postgrex/extensions/timetz.ex
+++ b/lib/postgrex/extensions/timetz.ex
@@ -17,7 +17,7 @@ defmodule Postgrex.Extensions.TimeTZ do
 
   def decode(_) do
     quote location: :keep do
-      <<12::int32, microsecs::int64, tz::int32>> ->
+      <<12::int32(), microsecs::int64(), tz::int32()>> ->
         unquote(__MODULE__).microsecond_to_elixir(microsecs, tz)
     end
   end
@@ -40,7 +40,7 @@ defmodule Postgrex.Extensions.TimeTZ do
   def encode_elixir(%Time{hour: hour, minute: min, second: sec, microsecond: {usec, _}})
       when hour in 0..23 and min in 0..59 and sec in 0..59 and usec in 0..999_999 do
     time = {hour, min, sec}
-    <<12::int32, :calendar.time_to_seconds(time) * 1_000_000 + usec::int64, 0::int32>>
+    <<12::int32(), :calendar.time_to_seconds(time) * 1_000_000 + usec::int64(), 0::int32()>>
   end
 
   def microsecond_to_elixir(microsec, tz) do

--- a/lib/postgrex/extensions/tsvector.ex
+++ b/lib/postgrex/extensions/tsvector.ex
@@ -8,7 +8,7 @@ defmodule Postgrex.Extensions.TSVector do
     quote location: :keep do
       values when is_list(values) ->
         encoded_tsvectors = unquote(__MODULE__).encode_tsvector(values)
-        <<byte_size(encoded_tsvectors)::int32, encoded_tsvectors::binary>>
+        <<byte_size(encoded_tsvectors)::int32(), encoded_tsvectors::binary>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a list of tsvectors")
@@ -17,8 +17,8 @@ defmodule Postgrex.Extensions.TSVector do
 
   def decode(_) do
     quote do
-      <<len::int32, value::binary-size(len)>> ->
-        <<nb_lexemes::int32, words::binary>> = value
+      <<len::int32(), value::binary-size(len)>> ->
+        <<nb_lexemes::int32(), words::binary>> = value
         unquote(__MODULE__).decode_tsvector_values(words)
     end
   end
@@ -26,7 +26,7 @@ defmodule Postgrex.Extensions.TSVector do
   ## Helpers
 
   def encode_tsvector(values) do
-    <<length(values)::int32, encode_lexemes(values)::binary>>
+    <<length(values)::int32(), encode_lexemes(values)::binary>>
   end
 
   defp encode_lexemes(values) do

--- a/lib/postgrex/extensions/uuid.ex
+++ b/lib/postgrex/extensions/uuid.ex
@@ -8,7 +8,7 @@ defmodule Postgrex.Extensions.UUID do
   def encode(_) do
     quote location: :keep, generated: true do
       uuid when is_binary(uuid) and byte_size(uuid) == 16 ->
-        [<<16::int32>> | uuid]
+        [<<16::int32()>> | uuid]
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a binary of 16 bytes")
@@ -17,13 +17,13 @@ defmodule Postgrex.Extensions.UUID do
 
   def decode(:copy) do
     quote location: :keep do
-      <<16::int32, uuid::binary-16>> -> :binary.copy(uuid)
+      <<16::int32(), uuid::binary-16>> -> :binary.copy(uuid)
     end
   end
 
   def decode(:reference) do
     quote location: :keep do
-      <<16::int32, uuid::binary-16>> -> uuid
+      <<16::int32(), uuid::binary-16>> -> uuid
     end
   end
 end

--- a/lib/postgrex/extensions/void_binary.ex
+++ b/lib/postgrex/extensions/void_binary.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.VoidBinary do
   def encode(_) do
     quote location: :keep do
       :void ->
-        <<0::int32>>
+        <<0::int32()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "the atom :void")
@@ -15,7 +15,7 @@ defmodule Postgrex.Extensions.VoidBinary do
 
   def decode(_) do
     quote location: :keep do
-      <<0::int32>> -> :void
+      <<0::int32()>> -> :void
     end
   end
 end

--- a/lib/postgrex/extensions/void_text.ex
+++ b/lib/postgrex/extensions/void_text.ex
@@ -12,7 +12,7 @@ defmodule Postgrex.Extensions.VoidText do
   def encode(_) do
     quote location: :keep do
       :void ->
-        <<0::int32>>
+        <<0::int32()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "the atom :void")
@@ -21,7 +21,7 @@ defmodule Postgrex.Extensions.VoidText do
 
   def decode(_) do
     quote location: :keep do
-      <<0::int32>> -> :void
+      <<0::int32()>> -> :void
     end
   end
 end

--- a/lib/postgrex/extensions/xid8.ex
+++ b/lib/postgrex/extensions/xid8.ex
@@ -10,7 +10,7 @@ defmodule Postgrex.Extensions.Xid8 do
 
     quote location: :keep do
       int when int in unquote(range) ->
-        <<8::int32, int::uint64>>
+        <<8::int32(), int::uint64()>>
 
       other ->
         raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, unquote(range))
@@ -19,7 +19,7 @@ defmodule Postgrex.Extensions.Xid8 do
 
   def decode(_) do
     quote location: :keep do
-      <<8::int32, int::uint64>> -> int
+      <<8::int32(), int::uint64()>> -> int
     end
   end
 end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -875,7 +875,7 @@ defmodule Postgrex.Protocol do
         check_target_server_type_recv(s, status, buffer)
 
       {:ok, msg_data_row(values: values), buffer} ->
-        <<len::uint32, read_only_value::binary(len)>> = values
+        <<len::uint32(), read_only_value::binary(len)>> = values
 
         actual_server_type =
           case read_only_value do
@@ -3131,7 +3131,7 @@ defmodule Postgrex.Protocol do
     {:more, 0}
   end
 
-  defp msg_decode(<<type::int8, size::int32, rest::binary>>) do
+  defp msg_decode(<<type::int8(), size::int32(), rest::binary>>) do
     size = size - 4
 
     case rest do

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -550,7 +550,7 @@ defmodule Postgrex.ReplicationConnection do
   end
 
   defp stream_in_progress(command, mod, mod_state, from, s) do
-    Logger.warn("received #{command} while stream is already in progress")
+    Logger.warning("received #{command} while stream is already in progress")
     from && reply(from, {__MODULE__, :stream_in_progress})
     {:noreply, %{s | state: {mod, mod_state}}}
   end

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -263,7 +263,7 @@ defmodule Postgrex.SimpleConnection do
         idle_timeout = opts[:idle_timeout]
 
         if idle_timeout do
-          Logger.warn(
+          Logger.warning(
             ":idle_timeout in Postgrex.SimpleConnection is deprecated, " <>
               "please use :idle_interval instead"
           )

--- a/lib/postgrex/type_module.ex
+++ b/lib/postgrex/type_module.ex
@@ -161,7 +161,7 @@ defmodule Postgrex.TypeModule do
 
       defp encode_tuple(tuple, n, [oid | oids], [type | types], acc) do
         param = :erlang.element(n, tuple)
-        acc = [acc, <<oid::uint32>> | encode_value(param, type)]
+        acc = [acc, <<oid::uint32()>> | encode_value(param, type)]
         encode_tuple(tuple, n + 1, oids, types, acc)
       end
 
@@ -264,13 +264,13 @@ defmodule Postgrex.TypeModule do
 
   defp encode_null(extension, :super_binary) do
     quote do
-      defp unquote(extension)(@null, _sub_oids, _sub_types), do: <<-1::int32>>
+      defp unquote(extension)(@null, _sub_oids, _sub_types), do: <<-1::int32()>>
     end
   end
 
   defp encode_null(extension, _) do
     quote do
-      defp unquote(extension)(@null), do: <<-1::int32>>
+      defp unquote(extension)(@null), do: <<-1::int32()>>
     end
   end
 
@@ -346,7 +346,7 @@ defmodule Postgrex.TypeModule do
       end
 
       defp decode_rows(
-             <<?D, size::int32, _::int16, unquote(rest)::binary>>,
+             <<?D, size::int32(), _::int16(), unquote(rest)::binary>>,
              rem,
              unquote(full),
              unquote(rows)
@@ -360,9 +360,9 @@ defmodule Postgrex.TypeModule do
         end
       end
 
-      defp decode_rows(<<?D, size::int32, rest::binary>>, rem, _, rows) do
+      defp decode_rows(<<?D, size::int32(), rest::binary>>, rem, _, rows) do
         more = size + 1 - rem
-        {:more, [?D, <<size::int32>> | rest], rows, more}
+        {:more, [?D, <<size::int32()>> | rest], rows, more}
       end
 
       defp decode_rows(<<?D, rest::binary>>, _, _, rows) do
@@ -506,7 +506,7 @@ defmodule Postgrex.TypeModule do
       end
 
       defp decode_tuple(
-             <<oid::int32, unquote(rest)::binary>>,
+             <<oid::int32(), unquote(rest)::binary>>,
              [oid | unquote(oids)],
              types,
              unquote(n),
@@ -522,7 +522,7 @@ defmodule Postgrex.TypeModule do
       end
 
       defp decode_tuple(
-             <<oid::int32, unquote(rest)::binary>>,
+             <<oid::int32(), unquote(rest)::binary>>,
              rem,
              types,
              unquote(n),
@@ -685,7 +685,7 @@ defmodule Postgrex.TypeModule do
   defp decode_extension_null(extension, dispatch, rest, acc, rem, full, rows) do
     quote do
       defp unquote(extension)(
-             <<-1::int32, unquote(rest)::binary>>,
+             <<-1::int32(), unquote(rest)::binary>>,
              types,
              acc,
              unquote(rem),
@@ -699,7 +699,7 @@ defmodule Postgrex.TypeModule do
         end
       end
 
-      defp unquote(extension)(<<-1::int32, rest::binary>>, acc) do
+      defp unquote(extension)(<<-1::int32(), rest::binary>>, acc) do
         unquote(extension)(rest, [@null | acc])
       end
 
@@ -707,7 +707,7 @@ defmodule Postgrex.TypeModule do
         acc
       end
 
-      defp unquote(extension)(<<-1::int32, rest::binary>>, acc, callback) do
+      defp unquote(extension)(<<-1::int32(), rest::binary>>, acc, callback) do
         unquote(extension)(rest, [@null | acc], callback)
       end
 
@@ -715,7 +715,7 @@ defmodule Postgrex.TypeModule do
         callback.(rest, acc)
       end
 
-      defp unquote(extension)(<<-1::int32, rest::binary>>, oids, types, n, acc) do
+      defp unquote(extension)(<<-1::int32(), rest::binary>>, oids, types, n, acc) do
         decode_tuple(rest, oids, types, n, acc)
       end
     end
@@ -872,7 +872,7 @@ defmodule Postgrex.TypeModule do
   defp decode_super_null(extension, dispatch, rest, acc, rem, full, rows) do
     quote do
       defp unquote(extension)(
-             <<-1::int32, unquote(rest)::binary>>,
+             <<-1::int32(), unquote(rest)::binary>>,
              _sub_oids,
              _sub_types,
              types,
@@ -888,7 +888,7 @@ defmodule Postgrex.TypeModule do
         end
       end
 
-      defp unquote(extension)(<<-1::int32, rest::binary>>, sub_oids, sub_types, acc) do
+      defp unquote(extension)(<<-1::int32(), rest::binary>>, sub_oids, sub_types, acc) do
         unquote(extension)(rest, sub_oids, sub_types, [@null | acc])
       end
 
@@ -897,7 +897,7 @@ defmodule Postgrex.TypeModule do
       end
 
       defp unquote(extension)(
-             <<-1::int32, rest::binary>>,
+             <<-1::int32(), rest::binary>>,
              _sub_oids,
              _sub_types,
              oids,

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -201,11 +201,11 @@ defmodule Postgrex.Types do
 
   defp row_decode(<<>>), do: []
 
-  defp row_decode(<<-1::int32, rest::binary>>) do
+  defp row_decode(<<-1::int32(), rest::binary>>) do
     [nil | row_decode(rest)]
   end
 
-  defp row_decode(<<len::uint32, value::binary(len), rest::binary>>) do
+  defp row_decode(<<len::uint32(), value::binary(len), rest::binary>>) do
     [value | row_decode(rest)]
   end
 

--- a/test/custom_extensions_test.exs
+++ b/test/custom_extensions_test.exs
@@ -22,13 +22,13 @@ defmodule CustomExtensionsTest do
     def encode([]) do
       quote do
         int ->
-          <<4::int32, int + 1::int32>>
+          <<4::int32(), int + 1::int32()>>
       end
     end
 
     def decode([]) do
       quote do
-        <<4::int32, int::int32>> -> int + 1
+        <<4::int32(), int::int32()>> -> int + 1
       end
     end
   end
@@ -48,13 +48,13 @@ defmodule CustomExtensionsTest do
     def encode({}) do
       quote do
         value ->
-          [<<byte_size(value)::int32>> | value]
+          [<<byte_size(value)::int32()>> | value]
       end
     end
 
     def decode({}) do
       quote do
-        <<len::int32, binary::binary-size(len)>> ->
+        <<len::int32(), binary::binary-size(len)>> ->
           binary
       end
     end
@@ -88,7 +88,7 @@ defmodule CustomExtensionsTest do
 
     def decode([]) do
       quote do
-        <<1::int32, _>> ->
+        <<1::int32(), _>> ->
           raise @decode_msg
       end
     end


### PR DESCRIPTION
Fixes the compiler warnings with Elixir 1.15.
Basically just ran `mix format` and changed `Logger.warn` to `Logger.warning`.