### PR TITLE
Add SCRAM server signature verification

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -811,13 +811,13 @@ defmodule Postgrex.Protocol do
   end
 
   defp auth_sasl(s, status = _, buffer) do
-    auth_send(s, msg_password(pass: Postgrex.SCRAM.challenge()), status, buffer)
+    auth_send(s, msg_password(pass: Postgrex.SCRAM.client_first()), status, buffer)
   end
 
   defp auth_cont(s, %{opts: opts} = status, data, buffer) do
-    {proof_msg, scram_state} = Postgrex.SCRAM.client_proof(data, opts)
+    {client_final_msg, scram_state} = Postgrex.SCRAM.client_final(data, opts)
     s = %{s | scram: scram_state}
-    auth_send(s, msg_password(pass: proof_msg), status, buffer)
+    auth_send(s, msg_password(pass: client_final_msg), status, buffer)
   end
 
   defp auth_fin(s, %{opts: opts} = status, data, buffer) do

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -815,9 +815,9 @@ defmodule Postgrex.Protocol do
   end
 
   defp auth_cont(s, %{opts: opts} = status, data, buffer) do
-    {verify_msg, scram_state} = Postgrex.SCRAM.verify_client(data, opts)
+    {proof_msg, scram_state} = Postgrex.SCRAM.client_proof(data, opts)
     s = %{s | scram: scram_state}
-    auth_send(s, msg_password(pass: verify_msg), status, buffer)
+    auth_send(s, msg_password(pass: proof_msg), status, buffer)
   end
 
   defp auth_fin(s, %{opts: opts} = status, data, buffer) do

--- a/lib/postgrex/scram.ex
+++ b/lib/postgrex/scram.ex
@@ -42,8 +42,9 @@ defmodule Postgrex.SCRAM do
   end
 
   def verify_server(data, scram_state, opts) do
-    server = parse_server_data(data)
-    do_verify_server(server, scram_state, opts)
+    data
+    |> parse_server_data()
+    |> do_verify_server(scram_state, opts)
   end
 
   defp do_verify_server(%{?e => server_e}, _scram_state, _opts) do

--- a/lib/postgrex/scram.ex
+++ b/lib/postgrex/scram.ex
@@ -9,12 +9,12 @@ defmodule Postgrex.SCRAM do
   @nonce_prefix "n,,n=,r="
   @nonce_encoded_size <<byte_size(@nonce_prefix) + @nonce_length::signed-size(32)>>
 
-  def challenge do
+  def client_first do
     nonce = @nonce_rand_bytes |> :crypto.strong_rand_bytes() |> Base.encode64()
     ["SCRAM-SHA-256", 0, @nonce_encoded_size, @nonce_prefix, nonce]
   end
 
-  def client_proof(data, opts) do
+  def client_final(data, opts) do
     server = parse_server_data(data)
     {:ok, server_s} = Base.decode64(server[?s])
     server_i = String.to_integer(server[?i])

--- a/lib/postgrex/scram.ex
+++ b/lib/postgrex/scram.ex
@@ -48,7 +48,7 @@ defmodule Postgrex.SCRAM do
   end
 
   defp do_verify_server(%{?e => server_e}, _scram_state, _opts) do
-    msg = "error received from server in SCRAM-SHA-256 server final message: #{inspect(server_e)}"
+    msg = "error received in SCRAM-SHA-256 server final message: #{inspect(server_e)}"
     {:error, %Postgrex.Error{message: msg}}
   end
 

--- a/lib/postgrex/scram.ex
+++ b/lib/postgrex/scram.ex
@@ -48,7 +48,7 @@ defmodule Postgrex.SCRAM do
   end
 
   defp do_verify_server(%{?e => server_e}, _scram_state, _opts) do
-    msg = "error received in SCRAM-SHA-256 server final message: #{inspect(server_e)}"
+    msg = "error received in SCRAM server final message: #{inspect(server_e)}"
     {:error, %Postgrex.Error{message: msg}}
   end
 
@@ -64,13 +64,13 @@ defmodule Postgrex.SCRAM do
     if expected_server_sig == server_sig do
       :ok
     else
-      msg = "cannot verify SCRAM-SHA-256 server signature"
+      msg = "cannot verify SCRAM server signature"
       {:error, %Postgrex.Error{message: msg}}
     end
   end
 
   defp do_verify_server(server, _scram_state, _opts) do
-    msg = "unsupported SCRAM-SHA-256 server final message: #{inspect(server)}"
+    msg = "unsupported SCRAM server final message: #{inspect(server)}"
     {:error, %Postgrex.Error{message: msg}}
   end
 

--- a/lib/postgrex/scram.ex
+++ b/lib/postgrex/scram.ex
@@ -53,15 +53,15 @@ defmodule Postgrex.SCRAM do
   end
 
   defp do_verify_server(%{?v => server_v}, scram_state, opts) do
-    {:ok, server_signature} = Base.decode64(server_v)
+    {:ok, server_sig} = Base.decode64(server_v)
 
     pass = Keyword.fetch!(opts, :password)
     cache_key = {:crypto.hash(:sha256, pass), scram_state.salt, scram_state.iterations}
     {_client_key, server_key} = SCRAM.LockedCache.get(cache_key)
 
-    expected_server_signature = hmac(:sha256, server_key, scram_state.auth_message)
+    expected_server_sig = hmac(:sha256, server_key, scram_state.auth_message)
 
-    if expected_server_signature == server_signature do
+    if expected_server_sig == server_sig do
       :ok
     else
       msg = "cannot verify SCRAM-SHA-256 server signature"

--- a/lib/postgrex/scram.ex
+++ b/lib/postgrex/scram.ex
@@ -14,7 +14,7 @@ defmodule Postgrex.SCRAM do
     ["SCRAM-SHA-256", 0, @nonce_encoded_size, @nonce_prefix, nonce]
   end
 
-  def verify_client(data, opts) do
+  def client_proof(data, opts) do
     server = parse_server_data(data)
     {:ok, server_s} = Base.decode64(server[?s])
     server_i = String.to_integer(server[?i])

--- a/lib/postgrex/scram/locked_cache.ex
+++ b/lib/postgrex/scram/locked_cache.ex
@@ -15,6 +15,13 @@ defmodule Postgrex.SCRAM.LockedCache do
   @timeout :infinity
 
   @doc """
+  Reads the cache key.
+  """
+  def get(key) do
+    soft_read(key)
+  end
+
+  @doc """
   Reads cache key or executes the given function if not
   cached yet.
   """
@@ -47,6 +54,14 @@ defmodule Postgrex.SCRAM.LockedCache do
   defp init(), do: :ets.new(@name, [:public, :set, :named_table, read_concurrency: true])
   defp write(key, value), do: :ets.insert(@name, {key, value})
   defp hard_read(key), do: :ets.lookup_element(@name, key, 2)
+
+  defp soft_read(key) do
+    try do
+      :ets.lookup_element(@name, key, 2)
+    catch
+      :error, :badarg -> nil
+    end
+  end
 
   ## Callbacks
 


### PR DESCRIPTION
Adds a final step in the SCRAM authentication to verify the server signature is correct.

Disclaimer: I'm for sure not an expert in this stuff. I just studied how libpq implemented it: https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/fe-auth-scram.c.