### PR TITLE
Gracefully terminate connection when disconnecting

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -210,6 +210,7 @@ defmodule Postgrex.Protocol do
     # every time the connection is explicitly disconnected
     # because the associated PID will no longer exist.
     cancel_request(s)
+    terminate(s)
     sock_close(s)
     _ = recv_buffer(s)
     delete_parameters(s)
@@ -3423,6 +3424,12 @@ defmodule Postgrex.Protocol do
 
   defp setopts(:gen_tcp, sock, opts), do: :inet.setopts(sock, opts)
   defp setopts(:ssl, sock, opts), do: :ssl.setopts(sock, opts)
+
+  defp terminate(%{sock: {:gen_tcp, sock}}) do
+    msg = msg_terminate()
+
+    :gen_tcp.send(sock, encode_msg(msg))
+  end
 
   defp cancel_request(%{connection_key: nil}), do: :ok
 


### PR DESCRIPTION
While looking into an ultimately unrelated PG issue and perusing our PgBouncer logs we noticed that our Ecto connections are not being gracefully terminated. This manifested in spurious `client unexpected eof` disconnection messages, which could make a real scenario involving dropped connection trickier to diagnose were it ever to occur. So while this doesn't seem to impact the database in any material way, we figured it wouldn't hurt to follow the protocol if possible. This is what the [PostgreSQL protocol Message Flow section on Termination](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.6.7.11) has to say:
> The normal, graceful termination procedure is that the frontend sends a Terminate message and immediately closes the connection
> In rare cases (such as an administrator-commanded database shutdown) the backend might disconnect without any frontend request to do so. In such cases the backend will attempt to send an error or notice message giving the reason for the disconnection before it closes the connection.