### PR TITLE
Fixes PUBLICATION name in docs 

### DIFF
--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -38,16 +38,16 @@ defmodule Postgrex.ReplicationConnection do
   Then you must create a publication to be replicated.
   This can be done in any session:
 
-      CREATE PUBLICATION example FOR ALL TABLES;
+      CREATE PUBLICATION postgrex_example FOR ALL TABLES;
 
   You can also filter if you want to publish insert, update,
   delete or a subset of them:
 
       # Skips updates (keeps inserts, deletes, begins, commits, etc)
-      create PUBLICATION example FOR ALL TABLES WITH (publish = 'insert,delete');
+      create PUBLICATION postgrex_example FOR ALL TABLES WITH (publish = 'insert,delete');
 
       # Skips inserts, updates, and deletes (keeps begins, commits, etc)
-      create PUBLICATION example FOR ALL TABLES WITH (publish = '');
+      create PUBLICATION postgrex_example FOR ALL TABLES WITH (publish = '');
 
   Now we are ready to create module that starts a replication slot
   and listens to our publication. Our example will use the pgoutput


### PR DESCRIPTION
to match `START_REPLICATION` `publication_names` ([line 84](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex/replication_connection.ex#L84)).

This fixes the error
`message: "publication \"postgrex_example\" does not exist"`
otherwise experienced if `auto_reconnect: false`. If auto_reconnect is `true`, it will simply reconnect after error, but won't display any error messages, which is failing silently to anyone trying the example exs script.

You can observe `handle_disconnect` being called after _any_ time the connection gets wal content, which led to me experimenting with setting `auto_reconnect` to `false` in hopes an error message would surface (and it did).