### PR TITLE
Decode regconfig

### DIFF
--- a/lib/postgrex/extensions/oid.ex
+++ b/lib/postgrex/extensions/oid.ex
@@ -1,7 +1,7 @@
 defmodule Postgrex.Extensions.OID do
   @moduledoc false
   @oid_senders ~w(oidsend regprocsend regproceduresend regopersend
-                  regoperatorsend regclasssend regtypesend xidsend cidsend)
+                  regoperatorsend regclasssend regtypesend regconfigsend xidsend cidsend)
 
   import Postgrex.BinaryUtils, warn: false
   use Postgrex.BinaryExtension, Enum.map(@oid_senders, &{:send, &1})

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -497,6 +497,8 @@ defmodule QueryTest do
     assert [[597]] = query("select 'pg_catalog.||/'::regoper;", [])
     assert [[551]] = query("select '+(integer,integer)'::regoperator;", [])
     assert [[1247]] = query("select 'pg_type'::regclass;", [])
+    [[regconfig_oid]] = query("select 'english'::regconfig;", [])
+    assert is_integer(regconfig_oid)
     assert [[23]] = query("select 'int4'::regtype;", [])
 
     # xid type

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -488,6 +488,7 @@ defmodule QueryTest do
     assert [["||/"]] = query("select 'pg_catalog.||/'::regoper::text;", [])
     assert [["+(integer,integer)"]] = query("select '+(integer,integer)'::regoperator::text;", [])
     assert [["pg_type"]] = query("select 'pg_type'::regclass::text;", [])
+    assert [["english"]] = query("select 'english'::regconfig::text;", [])
     assert [["integer"]] = query("select 'int4'::regtype::text;", [])
 
     assert [[0]] = query("select '-'::regproc;", [])
@@ -496,6 +497,7 @@ defmodule QueryTest do
     assert [[597]] = query("select 'pg_catalog.||/'::regoper;", [])
     assert [[551]] = query("select '+(integer,integer)'::regoperator;", [])
     assert [[1247]] = query("select 'pg_type'::regclass;", [])
+    assert [[13390]] = query("select 'english'::regconfig;", [])
     assert [[23]] = query("select 'int4'::regtype;", [])
 
     # xid type

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -497,7 +497,6 @@ defmodule QueryTest do
     assert [[597]] = query("select 'pg_catalog.||/'::regoper;", [])
     assert [[551]] = query("select '+(integer,integer)'::regoperator;", [])
     assert [[1247]] = query("select 'pg_type'::regclass;", [])
-    assert [[13390]] = query("select 'english'::regconfig;", [])
     assert [[23]] = query("select 'int4'::regtype;", [])
 
     # xid type


### PR DESCRIPTION
So that queries like this will work: `query("select $1::text::regconfig", ["english"])`