### PR TITLE
Add Multirange extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           - version: 11
           - version: 12
           - version: 13
+          - version: 14
 
         pair:
           - elixir: 1.11.4

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ iex> Postgrex.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'hey
     array           [1, 2, 3]
     composite type  {42, "title", "content"}
     range           %Postgrex.Range{lower: 1, upper: 5}
-    multirange      [%Postgrex.Range{lower: 1, upper: 5}, %Postgrex.Range{lower: 20, upper: 23}]
+    multirange      %Postgrex.Multirange{ranges: [%Postgrex.Range{lower: 1, upper: 5}, %Postgrex.Range{lower: 20, upper: 23}]}
     uuid            <<160,238,188,153,156,11,78,248,187,109,107,185,189,56,10,17>>
     hstore          %{"foo" => "bar"}
     oid types       42

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ iex> Postgrex.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'hey
     array           [1, 2, 3]
     composite type  {42, "title", "content"}
     range           %Postgrex.Range{lower: 1, upper: 5}
+    multirange      [%Postgrex.Range{lower: 1, upper: 5}, %Postgrex.Range{lower: 20, upper: 23}]
     uuid            <<160,238,188,153,156,11,78,248,187,109,107,185,189,56,10,17>>
     hstore          %{"foo" => "bar"}
     oid types       42

--- a/lib/postgrex/builtins.ex
+++ b/lib/postgrex/builtins.ex
@@ -71,6 +71,21 @@ defmodule Postgrex.Range do
   defstruct lower: nil, upper: nil, lower_inclusive: true, upper_inclusive: true
 end
 
+defmodule Postgrex.Multirange do
+  @moduledoc """
+  Struct for PostgreSQL `multirange`.
+
+  ## Fields
+
+    * `ranges`
+
+  """
+
+  @type t :: %__MODULE__{ranges: [Postgrex.Range.t()]}
+
+  defstruct ranges: nil
+end
+
 defmodule Postgrex.INET do
   @moduledoc """
   Struct for PostgreSQL `inet` / `cidr`.

--- a/lib/postgrex/extensions/multi_range.ex
+++ b/lib/postgrex/extensions/multi_range.ex
@@ -1,0 +1,70 @@
+defmodule Postgrex.Extensions.MultiRange do
+  import Postgrex.BinaryUtils, warn: false
+
+  @behaviour Postgrex.SuperExtension
+
+  def init(_), do: nil
+
+  def matching(_state), do: [send: "multirange_send"]
+
+  def format(_), do: :super_binary
+
+  def oids(%Postgrex.TypeInfo{base_type: base_oid}, _) do
+    [base_oid]
+  end
+
+  def encode(_) do
+    quote location: :keep do
+      list, [_oid], [type] when is_list(list) ->
+        # encode_value/2 defined by TypeModule
+        encoder = &encode_value(&1, type)
+        unquote(__MODULE__).encode(list, encoder)
+
+      other, _, _ ->
+        raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, "a list")
+    end
+  end
+
+  def decode(_) do
+    quote location: :keep do
+      <<len::int32(), data::binary-size(len)>>, [_oid], [type] ->
+        <<_num_ranges::int32(), ranges::binary>> = data
+        # decode_list/2 defined by TypeModule
+        decoder = &decode_list(&1, type)
+        unquote(__MODULE__).decode(ranges, decoder, [])
+    end
+  end
+
+  ## Helpers
+
+  def encode(ranges, encoder) do
+    encoded_ranges =
+      Enum.map(ranges, fn range ->
+        %{lower: lower, upper: upper} = range
+        lower = if is_atom(lower), do: lower, else: encoder.(lower)
+        upper = if is_atom(upper), do: upper, else: encoder.(upper)
+        Postgrex.Extensions.Range.encode(range, lower, upper)
+      end)
+
+    num_ranges = length(ranges)
+    iodata = [<<num_ranges::int32()>> | encoded_ranges]
+    [<<IO.iodata_length(iodata)::int32()>> | iodata]
+  end
+
+  def decode(<<>>, _decoder, acc), do: Enum.reverse(acc)
+
+  def decode(<<len::int32(), encoded_range::binary-size(len), rest::binary>>, decoder, acc) do
+    <<flags, data::binary>> = encoded_range
+
+    decoded_range =
+      case decoder.(data) do
+        [upper, lower] ->
+          Postgrex.Extensions.Range.decode(flags, [lower, upper])
+
+        empty_or_one ->
+          Postgrex.Extensions.Range.decode(flags, empty_or_one)
+      end
+
+    decode(rest, decoder, [decoded_range | acc])
+  end
+end

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -74,7 +74,7 @@ defmodule Postgrex.Types do
     {rngsubtype, join_range} =
       if version >= {9, 2, 0} do
         {"coalesce(r.rngsubtype, 0)",
-         "LEFT JOIN pg_range AS r ON r.rngtypid = t.oid OR (t.typbasetype <> 0 AND r.rngtypid = t.typbasetype)"}
+         "LEFT JOIN pg_range AS r ON r.rngtypid = t.oid OR r.rngmultitypid = t.oid OR (t.typbasetype <> 0 AND r.rngtypid = t.typbasetype)"}
       else
         {"0", ""}
       end

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -72,11 +72,17 @@ defmodule Postgrex.Types do
       end
 
     {rngsubtype, join_range} =
-      if version >= {9, 2, 0} do
-        {"coalesce(r.rngsubtype, 0)",
-         "LEFT JOIN pg_range AS r ON r.rngtypid = t.oid OR r.rngmultitypid = t.oid OR (t.typbasetype <> 0 AND r.rngtypid = t.typbasetype)"}
-      else
-        {"0", ""}
+      cond do
+        version >= {14, 0, 0} ->
+          {"coalesce(r.rngsubtype, 0)",
+           "LEFT JOIN pg_range AS r ON r.rngtypid = t.oid OR r.rngmultitypid = t.oid OR (t.typbasetype <> 0 AND r.rngtypid = t.typbasetype)"}
+
+        version >= {9, 2, 0} ->
+          {"coalesce(r.rngsubtype, 0)",
+           "LEFT JOIN pg_range AS r ON r.rngtypid = t.oid OR (t.typbasetype <> 0 AND r.rngtypid = t.typbasetype)"}
+
+        true ->
+          {"0", ""}
       end
 
     """

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -21,6 +21,7 @@ defmodule Postgrex.Utils do
     Postgrex.Extensions.Line,
     Postgrex.Extensions.LineSegment,
     Postgrex.Extensions.MACADDR,
+    Postgrex.Extensions.MultiRange,
     Postgrex.Extensions.Name,
     Postgrex.Extensions.Numeric,
     Postgrex.Extensions.OID,

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -21,7 +21,7 @@ defmodule Postgrex.Utils do
     Postgrex.Extensions.Line,
     Postgrex.Extensions.LineSegment,
     Postgrex.Extensions.MACADDR,
-    Postgrex.Extensions.MultiRange,
+    Postgrex.Extensions.Multirange,
     Postgrex.Extensions.Name,
     Postgrex.Extensions.Numeric,
     Postgrex.Extensions.OID,

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1048,6 +1048,72 @@ defmodule QueryTest do
              )
   end
 
+  @tag min_pg_version: "14.0"
+  test "encode multirange", context do
+    # Postgres will normalize discrete ranges so that they are lower inclusive and upper exclusive
+    int_ranges_param = [
+      %Postgrex.Range{lower: 1, upper: 3, lower_inclusive: false, upper_inclusive: false},
+      %Postgrex.Range{lower: 14, upper: 26, lower_inclusive: true, upper_inclusive: true}
+    ]
+
+    expected_int_ranges = [
+      %Postgrex.Range{lower: 2, upper: 3, lower_inclusive: true, upper_inclusive: false},
+      %Postgrex.Range{lower: 14, upper: 27, lower_inclusive: true, upper_inclusive: false}
+    ]
+
+    assert [[expected_int_ranges]] == query("SELECT $1::int4multirange", [int_ranges_param])
+
+    date_ranges_param = [
+      %Postgrex.Range{
+        lower: %Date{year: 2014, month: 1, day: 1},
+        upper: %Date{year: 2014, month: 1, day: 10},
+        lower_inclusive: false,
+        upper_inclusive: true
+      },
+      %Postgrex.Range{
+        lower: %Date{year: 2015, month: 1, day: 1},
+        upper: %Date{year: 2015, month: 1, day: 10},
+        lower_inclusive: true,
+        upper_inclusive: false
+      }
+    ]
+
+    expected_date_ranges = [
+      %Postgrex.Range{
+        lower: %Date{year: 2014, month: 1, day: 2},
+        upper: %Date{year: 2014, month: 1, day: 11},
+        lower_inclusive: true,
+        upper_inclusive: false
+      },
+      %Postgrex.Range{
+        lower: %Date{year: 2015, month: 1, day: 1},
+        upper: %Date{year: 2015, month: 1, day: 10},
+        lower_inclusive: true,
+        upper_inclusive: false
+      }
+    ]
+
+    assert [[expected_date_ranges]] == query("SELECT $1::datemultirange", [date_ranges_param])
+
+    # Continuous ranges can't be normalized the way discrete ranges are
+    num_ranges = [
+      %Postgrex.Range{
+        lower: Decimal.new("1.1"),
+        upper: Decimal.new("3.3"),
+        lower_inclusive: true,
+        upper_inclusive: false
+      },
+      %Postgrex.Range{
+        lower: Decimal.new("4.4"),
+        upper: Decimal.new("6.6"),
+        lower_inclusive: false,
+        upper_inclusive: true
+      }
+    ]
+
+    assert [[num_ranges]] == query("SELECT $1::nummultirange", [num_ranges])
+  end
+
   @tag min_pg_version: "9.0"
   test "encode hstore", context do
     assert [

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -419,6 +419,10 @@ defmodule QueryTest do
 
   @tag min_pg_version: "14.0"
   test "decode multirange", context do
+    # empty ranges
+    empty_multirange = %Postgrex.Multirange{ranges: []}
+    assert [[empty_multirange]] == query("SELECT '{}'::int4multirange", [])
+
     # Postgres will normalize discrete ranges so they are lower inclusive and upper exclusive
     expected_int_multirange = %Postgrex.Multirange{
       ranges: [
@@ -1108,6 +1112,10 @@ defmodule QueryTest do
 
   @tag min_pg_version: "14.0"
   test "encode multirange", context do
+    # empty ranges
+    empty_multirange = %Postgrex.Multirange{ranges: []}
+    assert [[empty_multirange]] == query("SELECT $1::int4multirange", [empty_multirange])
+
     # Postgres will normalize discrete ranges so that they are lower inclusive and upper exclusive
     int_multirange_param = %Postgrex.Multirange{
       ranges: [


### PR DESCRIPTION
This PR adds support for the multirange data type. This was introduced into Postgres in version 14. Someone expressed interest in it here: https://groups.google.com/g/elixir-ecto/c/yVVBLLcLCD4.

A multirange looks like an array of ranges but it is different in a few ways. Postgres will remove overlaps if they exist, the binary protocol is different and the oid and sub oids are classified differently in the pg_type/pg_range catalogs

References:

- Postgres docs: https://www.postgresql.org/docs/14/rangetypes.html
- Binary protocol: https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/multirangetypes.c#L328