### PR TITLE
Return `{:error, state}` on transaction error

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -2875,7 +2875,12 @@ defmodule Postgrex.Protocol do
         {:disconnect, err, s}
 
       {:error, %Postgrex.Error{} = err, s, buffer} ->
-        error_ready(s, status, err, buffer)
+        # We convert {:error, err, state} to {:error, state}
+        # so that DBConnection will disconnect during handle_begin/handle_rollback
+        # and will attempt to rollback during handle_commit
+        with {:error, _err, s} <- error_ready(s, status, err, buffer) do
+          {:error, s}
+        end
     end
   end
 


### PR DESCRIPTION
Postgrex version of this MyXQL PR: https://github.com/elixir-ecto/myxql/pull/162

The issue: 

When `handle_{begin, commit, rollback}` have an error, `{:error, error, state}` is returned to DBConnection and doesn't cause the connection to leave its transaction.  Returning `{:error, state}` to DBConnection will cause `handle_begin`/`handle_commit` to disconnect and `handle_commit` to attempt a rollback.

Relevant parts from DBConnection:

- https://github.com/elixir-ecto/db_connection/blob/master/lib/db_connection.ex#L1684
- https://github.com/elixir-ecto/db_connection/blob/master/lib/db_connection.ex#L1703
- https://github.com/elixir-ecto/db_connection/blob/master/lib/db_connection.ex#L1734