### PR TITLE
Explain unnamed prepared statements in docs

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -390,7 +390,8 @@ defmodule Postgrex do
 
   For unnamed prepared statements, pass an empty string for `name`. This can be useful
   when trying to avoid the generic query plan Postgres creates for named prepared
-  statements.
+  statements. You may also set `prepare: :unnamed` at the connection level so that
+  every prepared statement using that connection will be unnamed.
 
   ## Options
 
@@ -430,7 +431,8 @@ defmodule Postgrex do
 
   For unnamed prepared statements, pass an empty string for `name`. This can be useful
   when trying to avoid the generic query plan Postgres creates for named prepared
-  statements.
+  statements. You may also set `prepare: :unnamed` at the connection level so that
+  every prepared statement using that connection will be unnamed.
 
   See the README for information on how Postgrex encodes and decodes Elixir
   values by default. See `Postgrex.Query` for the query data and

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -379,7 +379,7 @@ defmodule Postgrex do
   @doc """
   Prepares an (extended) query.
 
-  It returns the result as`{:ok, %Postgrex.Query{}}` or `{:error, %Postgrex.Error{}}`
+  It returns the result as `{:ok, %Postgrex.Query{}}` or `{:error, %Postgrex.Error{}}`
   if there was an error. Parameters can be set in the query as `$1` embedded in the
   query string. To execute execute the query call `execute/4`. To close the prepared query
   call `close/3`. See `Postgrex.Query` for the query data.

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -377,15 +377,20 @@ defmodule Postgrex do
   end
 
   @doc """
-  Prepares an (extended) query and returns the result as
-  `{:ok, %Postgrex.Query{}}` or `{:error, %Postgrex.Error{}}` if there was an
-  error. Parameters can be set in the query as `$1` embedded in the query
-  string. To execute the query call `execute/4`. To close the prepared query
+  Prepares an (extended) query.
+
+  It returns the result as`{:ok, %Postgrex.Query{}}` or `{:error, %Postgrex.Error{}}`
+  if there was an error. Parameters can be set in the query as `$1` embedded in the
+  query string. To execute execute the query call `execute/4`. To close the prepared query
   call `close/3`. See `Postgrex.Query` for the query data.
 
   This function may still raise an exception if there is an issue with types
   (`ArgumentError`), connection (`DBConnection.ConnectionError`), ownership
   (`DBConnection.OwnershipError`) or other error (`RuntimeError`).
+
+  For unnamed prepared statements, pass an empty string for `name`. This can be useful
+  when trying to avoid the generic query plan Postgres creates for named prepared
+  statements.
 
   ## Options
 
@@ -422,6 +427,10 @@ defmodule Postgrex do
   It returns the result as `{:ok, %Postgrex.Query{}, %Postgrex.Result{}}` or
   `{:error, %Postgrex.Error{}}` if there was an error. Parameters are given as
   part of the prepared query, `%Postgrex.Query{}`.
+
+  For unnamed prepared statements, pass an empty string for `name`. This can be useful
+  when trying to avoid the generic query plan Postgres creates for named prepared
+  statements.
 
   See the README for information on how Postgrex encodes and decodes Elixir
   values by default. See `Postgrex.Query` for the query data and


### PR DESCRIPTION
Based on [this comment](https://github.com/elixir-ecto/postgrex/issues/497#issuecomment-1404321658), it seems helpful to highlight this. 

It's a bit hidden in the Postgres docs,  you'd have to know where to find it in the protocol pages https://www.postgresql.org/docs/current/protocol-flow.html.