### PR TITLE
Use gen_statem in Postgrex.ReplicationConnection

### DIFF
--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -241,7 +241,7 @@ defmodule Postgrex.ReplicationConnection do
   been replied to should eventually do so. One simple approach is to
   reply to any pending commands on `c:handle_disconnect/1`.
   """
-  @callback handle_call(term, GenServer.from(), state) ::
+  @callback handle_call(term, :gen_statem.from(), state) ::
               {:noreply, state}
               | {:noreply, ack, state}
               | {:query, query, state}
@@ -251,7 +251,7 @@ defmodule Postgrex.ReplicationConnection do
   Callback for `:query` outputs.
 
   If any callback returns `{:query, iodata, state}`,
-  then this callback will be immediatelly called with
+  then this callback will be immediately called with
   the result of the query. Please note that even though
   replication connections use the simple query protocol,
   Postgres currently limits them to single command queries.

--- a/test/replication_connection_test.exs
+++ b/test/replication_connection_test.exs
@@ -288,7 +288,8 @@ defmodule ReplicationTest do
   end
 
   defp disconnect(repl) do
-    {:gen_tcp, sock} = :sys.get_state(repl).mod_state.protocol.sock
+    {_, state} = :sys.get_state(repl)
+    {:gen_tcp, sock} = state.protocol.sock
     :gen_tcp.shutdown(sock, :read_write)
   end
 end


### PR DESCRIPTION
Similar to https://github.com/elixir-ecto/postgrex/pull/643, but for the other connection. Once the other PR is merged, we can also remove the direct dependency to connection in the meantime.