### PR TITLE
Use ubuntu-latest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     services:
       pg:


### PR DESCRIPTION
I'm noticing the CI jobs are getting queued and never starting. I'm wondering if they finally stopped supporting 18.04