### PR TITLE
feat: add ability to pass comments in query statements

### DIFF
--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -25,6 +25,8 @@ defmodule Postgrex.Query do
           ref: reference | nil,
           name: iodata,
           statement: iodata,
+          prefix_comment: iodata | nil,
+          suffix_comment: iodata | nil,
           param_oids: [Postgrex.Types.oid()] | nil,
           param_formats: [:binary | :text] | nil,
           param_types: [Postgrex.Types.type()] | nil,
@@ -39,6 +41,8 @@ defmodule Postgrex.Query do
     :ref,
     :name,
     :statement,
+    :prefix_comment,
+    :suffix_comment,
     :param_oids,
     :param_formats,
     :param_types,
@@ -113,7 +117,13 @@ defimpl DBConnection.Query, for: Postgrex.Query do
 end
 
 defimpl String.Chars, for: Postgrex.Query do
-  def to_string(%Postgrex.Query{statement: statement}) do
+  def to_string(%Postgrex.Query{statement: statement, prefix_comment: nil, suffix_comment: nil}) do
     IO.iodata_to_binary(statement)
+  end
+
+  def to_string(%Postgrex.Query{statement: statement, prefix_comment: prefix, suffix_comment: suffix}) do
+    prefix_iodata = if is_nil(prefix), do: [], else: ["/*", prefix, "*/"]
+    suffix_iodata = if is_nil(suffix), do: [], else: ["/*", suffix, "*/"]
+    IO.iodata_to_binary([prefix_iodata, statement, suffix_iodata])
   end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1745,4 +1745,10 @@ defmodule QueryTest do
     {:ok, pid} = P.start_link(database: "postgrex_test", search_path: ["public", "test_schema"])
     %{rows: [[1, "foo"]]} = P.query!(pid, "SELECT * from test_table", [])
   end
+
+  test "prefixes query comments" do
+    assert [[42]] = query("SELECT 42", [], prefix_comment: "this is a prefix comment")
+    assert [[16]] = query("SELECT 16", [], suffix_comment: "this is a suffix comment")
+    assert [[13]] = query("SELECT 13", [], prefix_comment: "prefix", suffix_comment: "suffix")
+  end
 end


### PR DESCRIPTION
This allows the ability to pass in Postgres comments as a prefix or suffix to the actual query statement. This is useful for some third party services which link traces (OpenTelemetry, Jaeger, etc) to actual database queries. For instance, here is [the code](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/database.js#L41) that DataDog uses for tracing between services and databases.

This adds a `prefix_comment` and `suffix_comment` option to execute options which gets added to the query statement in the `String.Chars` implementation. I _did not_ do any sort of escaping or manipulation to the comments aside from wrapping them in comment blocks.

Conversation in the elixir-ecto group: https://groups.google.com/g/elixir-ecto/c/QjOJp12WgK0/m/gK-m5Dc0AAAJ