### PR TITLE
Add configuration to skip querying of comp_oids

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -167,6 +167,10 @@ defmodule Postgrex do
       See the [PostgreSQL docs](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH)
       for more details.
 
+    * `:disable_composite_types` - Set to `true` to disable composite types support.
+      This is useful when using Postgrex against systems that do not support composite types
+      (default: `false`).
+
 
   `Postgrex` uses the `DBConnection` library and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc. See `DBConnection.start_link/2`

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -171,7 +171,6 @@ defmodule Postgrex do
       This is useful when using Postgrex against systems that do not support composite types
       (default: `false`).
 
-
   `Postgrex` uses the `DBConnection` library and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc. See `DBConnection.start_link/2`
   for more information.

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -28,7 +28,7 @@ defmodule Postgrex.Protocol do
             buffer: nil,
             disconnect_on_error_codes: [],
             scram: nil,
-            skip_comp_oids: false
+            disable_composite_types: false
 
   @type state :: %__MODULE__{
           sock: {module, any},
@@ -81,7 +81,7 @@ defmodule Postgrex.Protocol do
     types_mod = Keyword.fetch!(opts, :types)
     disconnect_on_error_codes = opts[:disconnect_on_error_codes] || []
     target_server_type = opts[:target_server_type] || :any
-    skip_comp_oids = opts[:skip_comp_oids] || false
+    disable_composite_types = opts[:disable_composite_types] || false
 
     transactions =
       case opts[:transactions] || :naive do
@@ -101,7 +101,7 @@ defmodule Postgrex.Protocol do
       postgres: :idle,
       transactions: transactions,
       disconnect_on_error_codes: disconnect_on_error_codes,
-      skip_comp_oids: skip_comp_oids
+      disable_composite_types: disable_composite_types
     }
 
     connect_timeout = Keyword.get(opts, :connect_timeout, timeout)

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -87,12 +87,7 @@ defmodule Postgrex.Types do
 
     """
     SELECT t.oid, t.typname, t.typsend, t.typreceive, t.typoutput, t.typinput,
-           #{typelem}, #{rngsubtype}, ARRAY (
-      SELECT a.atttypid
-      FROM pg_attribute AS a
-      WHERE a.attrelid = t.typrelid AND a.attnum > 0 AND NOT a.attisdropped
-      ORDER BY a.attnum
-    )
+           #{typelem}, #{rngsubtype}, null
     FROM pg_type AS t
     #{join_domain}
     #{join_range}

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -86,7 +86,7 @@ defmodule Postgrex.Types do
       end
 
     comp_oids =
-      if s.skip_comp_oids do
+      if s.disable_composite_types do
         "null"
       else
         """

--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,7 @@
   "makeup": {:hex, :makeup, "1.1.0", "6b67c8bc2882a6b6a445859952a602afc1a41c2e08379ca057c0f525366fc3ca", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "0a45ed501f4a8897f580eabf99a2e5234ea3e75a4373c8a52824f6e873be57a6"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.1", "cc9e3ca312f1cfeccc572b37a09980287e243648108384b97ff2b76e505c3555", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "e127a341ad1b209bd80f7bd1620a15693a9908ed780c3b763bccf7d200c767c6"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.2", "ad87296a092a46e03b7e9b0be7631ddcf64c790fa68a9ef5323b6cbb36affc72", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f3f5a1ca93ce6e092d92b6d9c049bcda58a3b617a8d888f8e7231c85630e8108"},
-  "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "table": {:hex, :table, "0.1.0", "f16104d717f960a623afb134a91339d40d8e11e0c96cfce54fee086b333e43f0", [:mix], [], "hexpm", "bf533d3606823ad8a7ee16f41941e5e6e0e42a20c4504cdf4cfabaaed1c8acb9"},
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
 }


### PR DESCRIPTION
It is becoming more [common](https://github.com/elixir-ecto/postgrex/issues/645#issuecomment-1462931379) to use the "[postgres wire protocol](https://github.com/elixir-ecto/postgrex/issues?q=is%3Aissue+wire+protocol+is%3Aclosed)" for non-postgres projects. Many of these projects "support" the basic type bootstrap query, but do not support the [Array+subquery syntax nor custom types](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex/types.ex#L90). 

I added a configuration option to pass to the repo/start_link that enables this:

`skip_comp_oids: true|false` 

Appears to work in my test cases but its pretty difficult to write an actual test for this without mocking the connection? Any guidance would be helpful. 