### PR TITLE
feat: `commit_comment` option for prepending a SQL comment to a `COMMIT` statement

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -578,11 +578,14 @@ defmodule Postgrex do
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
     * `:mode` - Set to `:savepoint` to use savepoints instead of an SQL
     transaction, otherwise set to `:transaction` (default: `:transaction`);
+    * `:commit_comment` - When a binary string is provided, prepends the text as
+    a comment attached to the `COMMIT` statement issued to close the transaction (default: `nil`);
 
   The `:timeout` is for the duration of the transaction and all nested
   transactions and requests. This timeout overrides timeouts set by internal
   transactions and requests. The `:mode` will be used for all requests inside
-  the transaction function.
+  the transaction function. The `:commit_comment` can be helpful in distinguishing
+  between transactions in query performance monitoring tools.
 
   ## Example
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -3390,6 +3390,10 @@ defmodule Postgrex.Protocol do
     {:disconnect, %{err | connection_id: connection_id}, %{s | buffer: buffer}}
   end
 
+  defp disconnect(s, %Postgrex.QueryError{} = err, buffer) do
+    {:disconnect, err, %{s | buffer: buffer}}
+  end
+
   defp disconnect(s, %RuntimeError{} = err, buffer) do
     {:disconnect, err, %{s | buffer: buffer}}
   end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -545,7 +545,12 @@ defmodule Postgrex.Protocol do
   def handle_commit(opts, %{postgres: postgres} = s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction when postgres == :transaction ->
-        statement = "COMMIT"
+        statement =
+          case Keyword.get(opts, :commit_comment) do
+            comment when is_binary(comment) -> "-- #{comment}\nCOMMIT"
+            _ -> "COMMIT"
+          end
+
         handle_transaction(statement, opts, s)
 
       :savepoint when postgres == :transaction ->

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -13,7 +13,7 @@ defmodule Postgrex.Protocol do
   @max_rows 500
   @text_type_oid 25
   @commit_comment_validation_error Postgrex.QueryError.exception(
-                                     "`:comment_comment` option cannot contain sequence \"*/\""
+                                     "`:commit_comment` option cannot contain sequence \"*/\""
                                    )
 
   defstruct sock: nil,

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -89,8 +89,8 @@ defmodule TransactionTest do
   @tag mode: :transaction
   test "commit comment with possible SQL injection returns error and disconnects", context do
     assert_raise(
-      Postgrex.QueryError,
-      "`:comment_comment` option cannot contain sequence \"*/\"",
+      Postgrex.Error,
+      "`:commit_comment` option cannot contain sequence \"*/\"",
       fn ->
         transaction(
           fn conn ->

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -87,6 +87,22 @@ defmodule TransactionTest do
   end
 
   @tag mode: :transaction
+  test "commit comment with possible SQL injection returns error and disconnects", context do
+    assert_raise(
+      Postgrex.QueryError,
+      "`:comment_comment` option cannot contain sequence \"*/\"",
+      fn ->
+        transaction(
+          fn conn ->
+            assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+          end,
+          commit_comment: "invalid */ comment"
+        )
+      end
+    )
+  end
+
+  @tag mode: :transaction
   @tag prepare: :unnamed
   test "transaction commits with unnamed queries", context do
     assert transaction(fn conn ->


### PR DESCRIPTION
We're using this option at @knocklabs to inject comments for all transactions executed via the `Ecto.Repo.transaction/2` callback, which is gives us more granular insight into transaction performance in our RDS performance insights dashboard. We'd like to upstream it!

I wasn't sure where to add unit test coverage for this, if anywhere. Nor was I sure how I should try to sanitize the input, if at all.

More context in the ecto-elixir Google Group discussion here: https://groups.google.com/g/elixir-ecto/c/vUImb5ZX_CI