### PR TITLE
Return ArgumentError when missing :database key in config

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -205,7 +205,7 @@ defmodule Postgrex.Protocol do
   defp fetch_database(opts) do
     case Keyword.fetch(opts, :database) do
       {:ok, value} ->
-        value
+        {:ok, value}
 
       :error ->
         message = "missing the :database key in options for #{inspect(opts[:repo])}"

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -208,10 +208,8 @@ defmodule Postgrex.Protocol do
         value
 
       :error ->
-        {:error,
-         %ArgumentError{
-           message: "missing the :database key in options for #{inspect(opts[:repo])}"
-         }}
+        message = "missing the :database key in options for #{inspect(opts[:repo])}"
+        {:error, %ArgumentError{message: message}}
     end
   end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -170,15 +170,12 @@ defmodule Postgrex.Protocol do
          %{opts: opts, types_mod: types_mod} = status,
          previous_errors
        ) do
-    types_key = if types_mod, do: {host, port, Keyword.fetch!(opts, :database)}
-    opts = Config.Reader.merge(opts, extra_opts)
-
-    status = %{status | types_key: types_key, opts: opts}
-
-    case connect_and_handshake(host, port, sock_opts, timeout, s, status) do
-      {:ok, _} = ret ->
-        ret
-
+    with {:ok, database} <- fetch_database(opts),
+         opts = Config.Reader.merge(opts, extra_opts),
+         status = %{status | types_key: if(types_mod, do: {host, port, database}), opts: opts},
+         {:ok, ret} <- connect_and_handshake(host, port, sock_opts, timeout, s, status) do
+      {:ok, ret}
+    else
       {:error, err} ->
         connect_endpoints(
           remaining_endpoints,
@@ -203,6 +200,19 @@ defmodule Postgrex.Protocol do
 
     message = "failed to establish connection to multiple endpoints:\n\n#{concat_messages}"
     {:error, %Postgrex.Error{message: message}}
+  end
+
+  defp fetch_database(opts) do
+    case Keyword.fetch(opts, :database) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        {:error,
+         %ArgumentError{
+           message: "missing the :database key in options for #{inspect(opts[:repo])}"
+         }}
+    end
   end
 
   defp connect_and_handshake(host, port, sock_opts, timeout, s, status) do


### PR DESCRIPTION
Sample message printed by DbConnection:

```
[error] Postgrex.Protocol (#PID<0.387.0>) failed to connect: ** (ArgumentError)
missing the :database key in options for repo TestEctoIssue.Repo
```