### PR TITLE
Streamline SSL experience

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -117,9 +117,9 @@ defmodule Postgrex do
     * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
       Defaults to 1000ms;
 
-    * `:ssl` - Enables SSL. Setting it to `true` enables SSL without host verification,
+    * `:ssl` - Enables SSL. Setting it to `true` enables SSL without server certificate verification,
       which emits a warning. Instead, prefer to set it to a keyword list, with either
-      `:cacerts` or `:cacertfile` pointing to the server certificate, to enable hostname
+      `:cacerts` or `:cacertfile` set to a CA trust store, to enable server certificate
       verification. Defaults to `false`;
 
     * `:socket_options` - Options to be given to the underlying socket

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -47,8 +47,7 @@ defmodule Postgrex do
           | {:connect_timeout, timeout}
           | {:handshake_timeout, timeout}
           | {:ping_timeout, timeout}
-          | {:ssl, boolean | :verify_full}
-          | {:ssl_opts, [:ssl.tls_client_option()]}
+          | {:ssl, boolean | [:ssl.tls_client_option()]}
           | {:socket_options, [:gen_tcp.connect_option()]}
           | {:prepare, :named | :unnamed}
           | {:transactions, :strict | :naive}
@@ -118,14 +117,10 @@ defmodule Postgrex do
     * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
       Defaults to 1000ms;
 
-    * `:ssl` - Set to `:verify_full` to enable full SSL verification, including peer
-      and hostname. You must also specify either `:cacerts` or `:cacertfile` in
-      `:ssl_opts`. Alternatively, you may set it to `true` for enabling SSL, but
-      use `:ssl_opts` to opt-in and control verification. Defaults to `false`;
-
-    * `:ssl_opts` - A list of ssl options, see the
-      [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option)
-      from the ssl docs. Only applies if `:ssl` is also enabled;
+    * `:ssl` - Enables SSL. Setting it to `true` enables SSL without host verification,
+      which emits a warning. Instead, prefer to set it to a keyword list, with either
+      `:cacerts` or `:cacertfile` pointing to the server certificate, to enable hostname
+      verification. Defaults to `false`;
 
     * `:socket_options` - Options to be given to the underlying socket
       (applies to both TCP and UNIX sockets);

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -47,7 +47,7 @@ defmodule Postgrex do
           | {:connect_timeout, timeout}
           | {:handshake_timeout, timeout}
           | {:ping_timeout, timeout}
-          | {:ssl, boolean}
+          | {:ssl, boolean | :verify_full}
           | {:ssl_opts, [:ssl.tls_client_option()]}
           | {:socket_options, [:gen_tcp.connect_option()]}
           | {:prepare, :named | :unnamed}

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -121,11 +121,11 @@ defmodule Postgrex do
     * `:ssl` - Set to `:verify_full` to enable full SSL verification, including peer
       and hostname. You must also specify either `:cacerts` or `:cacertfile` in
       `:ssl_opts`. Alternatively, you may set it to `true` for enabling SSL, but
-      use `:ssl_opts` to opt-in and control verification. Defaults to `false`.
+      use `:ssl_opts` to opt-in and control verification. Defaults to `false`;
 
     * `:ssl_opts` - A list of ssl options, see the
       [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option)
-      from the ssl docs;
+      from the ssl docs. Only applies if `:ssl` is also enabled;
 
     * `:socket_options` - Options to be given to the underlying socket
       (applies to both TCP and UNIX sockets);

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -118,7 +118,10 @@ defmodule Postgrex do
     * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
       Defaults to 1000ms;
 
-    * `:ssl` - Set to `true` if ssl should be used (default: `false`);
+    * `:ssl` - Set to `true` if ssl should be used (default: `false`). You may also
+      set it to `:verify_full`, which enables peer and hostname validation. You must
+      specify either `:cacerts` or `:cacertfile` in `:ssl_opts` if `:verify_full`
+      is enabled;
 
     * `:ssl_opts` - A list of ssl options, see the
       [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option)

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -118,10 +118,10 @@ defmodule Postgrex do
     * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
       Defaults to 1000ms;
 
-    * `:ssl` - Set to `true` if ssl should be used (default: `false`). You may also
-      set it to `:verify_full`, which enables peer and hostname validation. You must
-      specify either `:cacerts` or `:cacertfile` in `:ssl_opts` if `:verify_full`
-      is enabled;
+    * `:ssl` - Set to `:verify_full` to enable full SSL verification, including peer
+      and hostname. You must also specify either `:cacerts` or `:cacertfile` in
+      `:ssl_opts`. Alternatively, you may set it to `true` for enabling SSL, but
+      use `:ssl_opts` to opt-in and control verification. Defaults to `false`.
 
     * `:ssl_opts` - A list of ssl options, see the
       [`tls_client_option`](http://erlang.org/doc/man/ssl.html#type-tls_client_option)

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -92,7 +92,7 @@ defmodule Postgrex.Protocol do
           {nil, opts}
 
         {true, opts} ->
-          IO.warn(
+          Logger.warning(
             "setting ssl: true on your database connection offers only limited protection, " <>
               "as the hostname is not verified. Set \"ssl: [cacertfile: path/to/file]\" instead"
           )

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -101,7 +101,7 @@ defmodule Postgrex.Protocol do
           Keyword.pop(opts, :ssl_opts, [])
 
         {ssl_opts, opts} when is_list(ssl_opts) ->
-          {Keyword.merge(default_ssl_opts(opts), ssl_opts), opts}
+          {Keyword.merge(default_ssl_opts(), ssl_opts), opts}
       end
 
     transactions =
@@ -142,7 +142,7 @@ defmodule Postgrex.Protocol do
     connect_endpoints(endpoints, sock_opts ++ @sock_opts, connect_timeout, s, status, [])
   end
 
-  defp default_ssl_opts(opts) do
+  defp default_ssl_opts do
     [
       verify: :verify_peer,
       customize_hostname_check: [
@@ -171,7 +171,7 @@ defmodule Postgrex.Protocol do
                     {to_charlist(hostname), port}
 
                   {hostname, port, _extra_opts} ->
-                    Logger.warn(
+                    Logger.warning(
                       "Returning a triplet from :endpoints is deprecated, " <>
                         "the server name indicator is automatically set based on the hostname if SSL is enabled"
                     )

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -205,7 +205,7 @@ defmodule Postgrex.Protocol do
          previous_errors
        ) do
     with {:ok, database} <- fetch_database(opts),
-         status = %{status | types_key: if(types_mod, do: {host, port, database}), opts: opts},
+         status = %{status | types_key: if(types_mod, do: {host, port, database})},
          {:ok, ret} <- connect_and_handshake(host, port, sock_opts, timeout, s, status) do
       {:ok, ret}
     else
@@ -769,7 +769,12 @@ defmodule Postgrex.Protocol do
   defp do_handshake(_host, s, %{ssl: nil} = status), do: startup(s, status)
 
   defp do_handshake(host, s, %{ssl: ssl_opts} = status) do
-    ssl(s, status, Keyword.put_new(ssl_opts, :server_name_indicator, host))
+    ssl_opts =
+      if is_list(host),
+        do: Keyword.put_new(ssl_opts, :server_name_indication, host),
+        else: ssl_opts
+
+    ssl(s, status, ssl_opts)
   end
 
   ## ssl

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -94,7 +94,7 @@ defmodule Postgrex.Protocol do
         {true, opts} ->
           Logger.warning(
             "setting ssl: true on your database connection offers only limited protection, " <>
-              "as the hostname is not verified. Set \"ssl: [cacertfile: path/to/file]\" instead"
+              "as the server's certificate is not verified. Set \"ssl: [cacertfile: path/to/file]\" instead"
           )
 
           # Read ssl_opts for backwards compatibility

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -143,16 +143,12 @@ defmodule Postgrex.Protocol do
   end
 
   defp default_ssl_opts(opts) do
-    case Keyword.fetch(opts, :hostname) do
-      {:ok, hostname} -> [server_name_indication: String.to_charlist(hostname)]
-      :error -> []
-    end ++
-      [
-        verify: :verify_peer,
-        customize_hostname_check: [
-          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-        ]
+    [
+      verify: :verify_peer,
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
       ]
+    ]
   end
 
   defp endpoints(opts) do
@@ -160,19 +156,27 @@ defmodule Postgrex.Protocol do
 
     case Keyword.fetch(opts, :socket) do
       {:ok, file} ->
-        [{{:local, file}, 0, []}]
+        [{{:local, file}, 0}]
 
       :error ->
         case Keyword.fetch(opts, :socket_dir) do
           {:ok, dir} ->
-            [{{:local, "#{dir}/.s.PGSQL.#{port}"}, 0, []}]
+            [{{:local, "#{dir}/.s.PGSQL.#{port}"}, 0}]
 
           :error ->
             case Keyword.fetch(opts, :endpoints) do
               {:ok, endpoints} when is_list(endpoints) ->
                 Enum.map(endpoints, fn
-                  {hostname, port} -> {to_charlist(hostname), port, []}
-                  {hostname, port, extra_opts} -> {to_charlist(hostname), port, extra_opts}
+                  {hostname, port} ->
+                    {to_charlist(hostname), port}
+
+                  {hostname, port, _extra_opts} ->
+                    Logger.warn(
+                      "Returning a triplet from :endpoints is deprecated, " <>
+                        "the server name indicator is automatically set based on the hostname if SSL is enabled"
+                    )
+
+                    {to_charlist(hostname), port}
                 end)
 
               {:ok, _} ->
@@ -181,7 +185,7 @@ defmodule Postgrex.Protocol do
               :error ->
                 case Keyword.fetch(opts, :hostname) do
                   {:ok, hostname} ->
-                    [{to_charlist(hostname), port, []}]
+                    [{to_charlist(hostname), port}]
 
                   :error ->
                     raise ArgumentError,
@@ -193,7 +197,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp connect_endpoints(
-         [{host, port, extra_opts} | remaining_endpoints],
+         [{host, port} | remaining_endpoints],
          sock_opts,
          timeout,
          s,
@@ -201,7 +205,6 @@ defmodule Postgrex.Protocol do
          previous_errors
        ) do
     with {:ok, database} <- fetch_database(opts),
-         opts = Config.Reader.merge(opts, extra_opts),
          status = %{status | types_key: if(types_mod, do: {host, port, database}), opts: opts},
          {:ok, ret} <- connect_and_handshake(host, port, sock_opts, timeout, s, status) do
       {:ok, ret}
@@ -246,7 +249,7 @@ defmodule Postgrex.Protocol do
   defp connect_and_handshake(host, port, sock_opts, timeout, s, status) do
     case connect(host, port, sock_opts, timeout, s) do
       {:ok, s} ->
-        handshake(s, status)
+        handshake(host, s, status)
 
       {:error, _} = error ->
         error
@@ -712,13 +715,13 @@ defmodule Postgrex.Protocol do
 
   ## handshake
 
-  defp handshake(%{sock: {:gen_tcp, sock}, timeout: timeout} = s, status) do
+  defp handshake(host, %{sock: {:gen_tcp, sock}, timeout: timeout} = s, status) do
     {:ok, peer} = :inet.peername(sock)
     %{opts: opts} = status
     handshake_timeout = Keyword.get(opts, :handshake_timeout, timeout)
     timer = start_handshake_timer(handshake_timeout, sock)
 
-    case do_handshake(%{s | peer: peer}, status) do
+    case do_handshake(host, %{s | peer: peer}, status) do
       {:ok, %{parameters: parameters} = s} ->
         cancel_handshake_timer(timer)
         ref = Postgrex.Parameters.insert(parameters)
@@ -763,8 +766,11 @@ defmodule Postgrex.Protocol do
     :ok
   end
 
-  defp do_handshake(s, %{ssl: nil} = status), do: startup(s, status)
-  defp do_handshake(s, %{ssl: ssl_opts} = status), do: ssl(s, status, ssl_opts)
+  defp do_handshake(_host, s, %{ssl: nil} = status), do: startup(s, status)
+
+  defp do_handshake(host, s, %{ssl: ssl_opts} = status) do
+    ssl(s, status, Keyword.put_new(ssl_opts, :server_name_indicator, host))
+  end
 
   ## ssl
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -137,7 +137,7 @@ defmodule Postgrex.Protocol do
     case Keyword.fetch(opts, :hostname) do
       {:ok, hostname} ->
         [
-          server_name_indication: hostname,
+          server_name_indication: String.to_charlist(hostname),
           customize_hostname_check: [
             match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
           ]

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -88,21 +88,6 @@ defmodule LoginTest do
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
-  @tag :ssl
-  test "ssl with extra_ssl_opts in endpoints succeeds", context do
-    opts = [ssl: true, endpoints: [{"localhost", 5555, [ssl: [verify_peer: :none]]}]]
-    assert {:ok, pid} = P.start_link(opts ++ context[:options])
-    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
-  end
-
-  @tag :ssl
-  test "ssl with extra_ssl_opts in endpoints fails due to bad ssl_opt", context do
-    assert capture_log(fn ->
-             opts = [ssl: true, endpoints: [{"localhost", 5555, [ssl: [verify_peer: :foobar]]}]]
-             assert_start_and_killed(opts ++ context[:options])
-           end)
-  end
-
   test "env var defaults", context do
     assert {:ok, pid} = P.start_link(context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])


### PR DESCRIPTION
@chrismccord, let me know if this works. For now, this means you need to explicitly set `ssl: :verify_full` in your config file but we can support "ssl=verify_full" via query string too.