### PR TITLE
Default to system certificate store

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -143,12 +143,18 @@ defmodule Postgrex.Protocol do
   end
 
   defp default_ssl_opts do
-    [
+    opts = [
       verify: :verify_peer,
       customize_hostname_check: [
         match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
       ]
     ]
+
+    try do
+      Keyword.put(opts, :cacerts, :public_key.cacerts_get())
+    rescue
+      _ -> opts
+    end
   end
 
   defp endpoints(opts) do


### PR DESCRIPTION
Does this fit in with the recent changes to the `:ssl` option? If the user provides ssl options but does not supply `:cacerts` or `:cacertfile` then it uses the erlang default.