### PR TITLE
Allow custom extensions to use options

### DIFF
--- a/lib/postgrex/type_module.ex
+++ b/lib/postgrex/type_module.ex
@@ -920,9 +920,12 @@ defmodule Postgrex.TypeModule do
     end
   end
 
-  defp configure(extensions, opts) do
-    defaults = Postgrex.Utils.default_extensions(opts)
-    Enum.map(extensions ++ defaults, &configure/1)
+  defp configure(customs, opts) do
+    defaults = Postgrex.Utils.default_extensions()
+
+    Enum.map(customs ++ defaults, fn extension ->
+      configure({extension, opts})
+    end)
   end
 
   defp configure({extension, opts}) do
@@ -930,10 +933,6 @@ defmodule Postgrex.TypeModule do
     matching = extension.matching(state)
     format = extension.format(state)
     {extension, {state, matching, format}}
-  end
-
-  defp configure(extension) do
-    configure({extension, []})
   end
 
   defp define_inline(module, config, opts) do

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -57,9 +57,9 @@ defmodule Postgrex.Utils do
   @doc """
   List all default extensions.
   """
-  @spec default_extensions(Keyword.t()) :: [{module(), Keyword.t()}]
-  def default_extensions(opts \\ []) do
-    Enum.map(@extensions, &{&1, opts})
+  @spec default_extensions() :: [module()]
+  def default_extensions() do
+    @extensions
   end
 
   @doc """

--- a/test/custom_extensions_test.exs
+++ b/test/custom_extensions_test.exs
@@ -10,8 +10,9 @@ defmodule CustomExtensionsTest do
   defmodule BinaryExtension do
     @behaviour Postgrex.Extension
 
-    def init([]),
-      do: []
+    def init(_opts) do
+      []
+    end
 
     def matching([]),
       do: [send: "int4send"]
@@ -36,7 +37,7 @@ defmodule CustomExtensionsTest do
   defmodule TextExtension do
     @behaviour Postgrex.Extension
 
-    def init([]),
+    def init(_opts),
       do: {}
 
     def matching({}),
@@ -63,7 +64,7 @@ defmodule CustomExtensionsTest do
   defmodule BadExtension do
     @behaviour Postgrex.Extension
 
-    def init([]),
+    def init(_opts),
       do: []
 
     def matching([]),


### PR DESCRIPTION
Currently the extensions users create themselves cannot access the options passed to the type module. A few of the options, like `:null` and `:decode_binary` seem like they should be passed to them. For example, we previously asked users to define their own `ltree` and `lquery` extensions and our own implementations are using the `:decode_binary` option. Also, our own documented example of a custom extension is passed the opts https://hexdocs.pm/postgrex/Postgrex.Extension.html
