### PR TITLE
Remove max year from timestamptz

### DIFF
--- a/lib/postgrex/extensions/timestamptz.ex
+++ b/lib/postgrex/extensions/timestamptz.ex
@@ -4,15 +4,8 @@ defmodule Postgrex.Extensions.TimestampTZ do
   use Postgrex.BinaryExtension, send: "timestamptz_send"
 
   @gs_epoch NaiveDateTime.to_gregorian_seconds(~N[2000-01-01 00:00:00.0]) |> elem(0)
-
   @gs_unix_epoch NaiveDateTime.to_gregorian_seconds(~N[1970-01-01 00:00:00.0]) |> elem(0)
   @us_epoch (@gs_epoch - @gs_unix_epoch) * 1_000_000
-
-  @gs_max elem(NaiveDateTime.to_gregorian_seconds(~N[9999-01-01 00:00:00.0]), 0) - @gs_unix_epoch
-  @us_max @gs_max * 1_000_000
-
-  @gs_min elem(NaiveDateTime.to_gregorian_seconds(~N[-4713-01-01 00:00:00.0]), 0) - @gs_unix_epoch
-  @us_min @gs_min * 1_000_000
 
   @plus_infinity 9_223_372_036_854_775_807
   @minus_infinity -9_223_372_036_854_775_808
@@ -40,13 +33,8 @@ defmodule Postgrex.Extensions.TimestampTZ do
   ## Helpers
 
   def encode_elixir(%DateTime{utc_offset: 0, std_offset: 0} = datetime) do
-    case DateTime.to_unix(datetime, :microsecond) do
-      microsecs when microsecs in @us_min..@us_max ->
-        <<8::int32(), microsecs - @us_epoch::int64()>>
-
-      _ ->
-        raise ArgumentError, "#{inspect(datetime)} is not in the year range -4713..9999"
-    end
+    microsecs = DateTime.to_unix(datetime, :microsecond)
+    <<8::int32(), microsecs - @us_epoch::int64()>>
   end
 
   def encode_elixir(%DateTime{} = datetime) do

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -242,6 +242,13 @@ defmodule CalendarTest do
            ] = query("SELECT timestamp with time zone '1981-01-01BC 00:00:00.123456'", [])
   end
 
+  test "decode timestamptz out of bounds", context do
+    %Postgrex.Error{postgres: %{message: message}} =
+      query("SELECT timestamp with time zone '4714-01-01BC 00:00:00.123456'", [])
+
+    assert message =~ "timestamp out of range"
+  end
+
   @tag :capture_log
   test "decode infinity", context do
     assert_raise ArgumentError, fn -> query("SELECT 'infinity'::timestamp", []) end


### PR DESCRIPTION
I think we can just do this? Postgres will return an error if the timestamp is out of range with the message 

>message: "timestamp out of range:..."