### PR TITLE
Honour precision with timestamptz extension

### DIFF
--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -104,6 +104,14 @@ defmodule CalendarTest do
              query("SELECT timestamp '4713-01-01BC 00:00:00.123456'", [])
   end
 
+  test "decode timestamp with precision", context do
+    assert [[~N[2001-01-01 00:00:00.00]]] =
+             query("SELECT timestamp(2) '2001-01-01 00:00:00'", [])
+
+    assert [[[~N[2001-01-01 00:00:00.00]]]] =
+             query("SELECT ARRAY[timestamp(2) '2001-01-01 00:00:00']", [])
+  end
+
   test "decode timestamptz", context do
     assert [
              [
@@ -220,6 +228,42 @@ defmodule CalendarTest do
                }
              ]
            ] = query("SELECT timestamp with time zone '1980-01-01 01:00:00.123456'", [])
+  end
+
+  test "decode timestamptz with precision", context do
+    assert [
+             [
+               %DateTime{
+                 year: 2001,
+                 month: 1,
+                 day: 1,
+                 hour: 0,
+                 minute: 0,
+                 second: 0,
+                 microsecond: {0, 1},
+                 time_zone: "Etc/UTC",
+                 utc_offset: 0
+               }
+             ]
+           ] = query("SELECT timestamp(1) with time zone '2001-01-01 00:00:00 UTC'", [])
+
+    assert [
+             [
+               [
+                 %DateTime{
+                   year: 2001,
+                   month: 1,
+                   day: 1,
+                   hour: 0,
+                   minute: 0,
+                   second: 0,
+                   microsecond: {0, 1},
+                   time_zone: "Etc/UTC",
+                   utc_offset: 0
+                 }
+               ]
+             ]
+           ] = query("SELECT ARRAY[timestamp(1) with time zone '2001-01-01 00:00:00 UTC']", [])
   end
 
   test "decode negative timestampz", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1769,24 +1769,4 @@ defmodule QueryTest do
     {:ok, pid} = P.start_link(database: "postgrex_test", search_path: ["public", "test_schema"])
     %{rows: [[1, "foo"]]} = P.query!(pid, "SELECT * from test_table", [])
   end
-
-  test "timestamp precision", context do
-    :ok =
-      query(
-        """
-        INSERT INTO timestamps (micro, milli, sec, sec_arr)
-        VALUES ('2000-01-01', '2000-01-01', '2000-01-01', '{2000-01-01, 2000-01-02}'),
-        ('3000-01-01', '3000-01-01', '3000-01-01', '{3000-01-01, 3000-01-02}')
-        """,
-        []
-      )
-
-    assert [row1, row2] = query("SELECT * FROM timestamps", [])
-
-    assert [6, 3, 0, [0, 0]] = precision(row1)
-    assert [6, 3, 0, [0, 0]] = precision(row2)
-  end
-
-  defp precision([_ | _] = dts), do: Enum.map(dts, &precision(&1))
-  defp precision(%NaiveDateTime{microsecond: {_, p}}), do: p
 end


### PR DESCRIPTION
The old code was using `DateTime.from_unix` to decode the result for Postgres so I changed it to be like the timestamp extension and use `DateTime.from_gregorian_seconds`. This seems to be the best way to get arbitrary precision in the Elixir struct, from what I can see.

I also moved some of the timestamp tests to be in the calendar test module so that all the tests are in there.