### PR TITLE
Fix typo in docs for Types.define/3

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -254,7 +254,7 @@ defmodule Postgrex.Types do
 
   Type modules are given to Postgrex on `start_link` via the `:types`
   option and are used to control how Postgrex encodes and decodes data
-  coming from Postgrex.
+  coming from PostgreSQL.
 
   For example, to define a new type module with a custom extension
   called `MyExtension` while also changing `Postgrex`'s default


### PR DESCRIPTION
I'm not completely sure this is what you meant but I think `how Postgrex encodes and decodes data coming from Postgrex` seems to be a duplicate by mistake.