### PR TITLE
Add support for Elixir Durations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           - pg:
               version: 14
             pair:
-              elixir: 1.16.2
+              elixir: 1.17.1
               otp: 25.3
             lint: lint
     env:

--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -75,7 +75,7 @@ defmodule Postgrex.Extensions.Interval do
     def encode(_) do
       quote location: :keep do
         %Postgrex.Interval{months: months, days: days, secs: seconds, microsecs: microseconds} ->
-          microseconds = 1_000_000 * secs + microseconds
+          microseconds = 1_000_000 * seconds + microseconds
           <<16::int32(), microseconds::int64(), days::int32(), months::int32()>>
 
         other ->

--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -3,23 +3,93 @@ defmodule Postgrex.Extensions.Interval do
   import Postgrex.BinaryUtils, warn: false
   use Postgrex.BinaryExtension, send: "interval_send"
 
-  def encode(_) do
-    quote location: :keep do
-      %Postgrex.Interval{months: months, days: days, secs: secs, microsecs: microsecs} ->
-        microsecs = secs * 1_000_000 + microsecs
-        <<16::int32(), microsecs::int64(), days::int32(), months::int32()>>
+  def init(opts), do: Keyword.get(opts, :interval_decode_type, Postgrex.Interval)
 
-      other ->
-        raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Interval)
+  if Version.match?(System.version(), ">= 1.17.0") do
+    def encode(_) do
+      quote location: :keep do
+        %Postgrex.Interval{months: months, days: days, secs: seconds, microsecs: microseconds} ->
+          microseconds = 1_000_000 * seconds + microseconds
+          <<16::int32(), microseconds::int64(), days::int32(), months::int32()>>
+
+        %Duration{
+          year: years,
+          month: months,
+          week: weeks,
+          day: days,
+          hour: hours,
+          minute: minutes,
+          second: seconds,
+          microsecond: {microseconds, _precision}
+        } ->
+          months = 12 * years + months
+          days = 7 * weeks + days
+          microseconds = 1_000_000 * (3600 * hours + 60 * minutes + seconds) + microseconds
+          <<16::int32(), microseconds::int64(), days::int32(), months::int32()>>
+
+        other ->
+          raise DBConnection.EncodeError,
+                Postgrex.Utils.encode_msg(other, {Postgrex.Interval, Duration})
+      end
     end
-  end
 
-  def decode(_) do
-    quote location: :keep do
-      <<16::int32(), microsecs::int64(), days::int32(), months::int32()>> ->
-        secs = div(microsecs, 1_000_000)
-        microsecs = rem(microsecs, 1_000_000)
-        %Postgrex.Interval{months: months, days: days, secs: secs, microsecs: microsecs}
+    def decode(type) do
+      quote location: :keep do
+        <<16::int32(), microseconds::int64(), days::int32(), months::int32()>> ->
+          seconds = div(microseconds, 1_000_000)
+          microseconds = rem(microseconds, 1_000_000)
+
+          case unquote(type) do
+            Postgrex.Interval ->
+              %Postgrex.Interval{
+                months: months,
+                days: days,
+                secs: seconds,
+                microsecs: microseconds
+              }
+
+            Duration ->
+              years = div(months, 12)
+              months = rem(months, 12)
+              weeks = div(days, 7)
+              days = rem(days, 7)
+              minutes = div(seconds, 60)
+              seconds = rem(seconds, 60)
+              hours = div(minutes, 60)
+              minutes = rem(minutes, 60)
+
+              Duration.new!(
+                year: years,
+                month: months,
+                week: weeks,
+                day: days,
+                hour: hours,
+                minute: minutes,
+                second: seconds,
+                microsecond: {microseconds, 6}
+              )
+          end
+      end
+    end
+  else
+    def encode(_) do
+      quote location: :keep do
+        %Postgrex.Interval{months: months, days: days, secs: seconds, microsecs: microseconds} ->
+          microseconds = 1_000_000 * secs + microseconds
+          <<16::int32(), microseconds::int64(), days::int32(), months::int32()>>
+
+        other ->
+          raise DBConnection.EncodeError, Postgrex.Utils.encode_msg(other, Postgrex.Interval)
+      end
+    end
+
+    def decode(_) do
+      quote location: :keep do
+        <<16::int32(), microseconds::int64(), days::int32(), months::int32()>> ->
+          seconds = div(microseconds, 1_000_000)
+          microseconds = rem(microseconds, 1_000_000)
+          %Postgrex.Interval{months: months, days: days, secs: seconds, microsecs: microseconds}
+      end
     end
   end
 end

--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -5,7 +5,7 @@ defmodule Postgrex.Extensions.Interval do
 
   def init(opts), do: Keyword.get(opts, :interval_decode_type, Postgrex.Interval)
 
-  if Version.match?(System.version(), ">= 1.17.0") do
+  if Code.ensure_loaded?(Duration) do
     def encode(_) do
       quote location: :keep do
         %Postgrex.Interval{months: months, days: days, secs: seconds, microsecs: microseconds} ->


### PR DESCRIPTION
Addresses https://github.com/elixir-ecto/postgrex/issues/688 besides the deprecation of `Postgrex.Interval`.

The following changes were made:

- allow encoding of `Duration` structs for postgres interval extension
- allow decoding postgres interval types to `Duration` structs if the option `:interval_decode_type` is set to `Duration`
- both of the above two are only allowed if the elixir version is at least 1.17.0

Some notes:

- when breaking down the postgres response (microseconds, days and months) into the fields for the `Duration` struct, I went with the same style we use for `Postgrex.Interval`: translate the lower units into the higher units as much as possible
- the type modifier postgres returns for intervals is not an integer from 0 to 6. i will try to find out what it means but it's not well documented so probably have to go through their source code. for now i always return precision of 6 because they are giving us microseconds in the response
- from what i can see we are not documenting anywhere the options that can be passed to any of our extensions. in a follow-up PR i'll try to collect them all and put them in a good place