### PR TITLE
Fix `stop` return from gen_statem `init`

### DIFF
--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -474,7 +474,7 @@ defmodule Postgrex.ReplicationConnection do
           case handle_event(:internal, {:connect, :init}, @state, state) do
             {:keep_state, state} -> {:ok, @state, state}
             {:keep_state, state, actions} -> {:ok, @state, state, actions}
-            {:stop, _reason, _state} = stop -> stop
+            {:stop, reason, _state} -> {:stop, reason}
           end
         else
           {:ok, @state, state, {:next_event, :internal, {:connect, :init}}}

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -325,7 +325,7 @@ defmodule Postgrex.SimpleConnection do
           case handle_event(:internal, {:connect, :init}, @state, state) do
             {:keep_state, state} -> {:ok, @state, state}
             {:keep_state, state, actions} -> {:ok, @state, state, actions}
-            {:stop, _reason, _state} = stop -> stop
+            {:stop, reason, _state} -> {:stop, reason}
           end
         else
           {:ok, @state, state, {:next_event, :internal, {:connect, :init}}}


### PR DESCRIPTION
When I was testing durations I kept seeing logs like this while running the tests

```elixir
07:40:52.702 [error] :gen_statem #PID<0.1557.0> terminating
** (stop) {:bad_return_from_init, {:stop, %Postgrex.Error{message: nil, postgres: %{code: :invalid_catalog_name, file: "postinit.c", line: "877", message: "database \"nobody_knows_it\" does not exist", pg_code: "3D000", routine: "InitPostgres", severity: "FATAL", unknown: "FATAL"}, connection_id: nil, query: nil}, %Postgrex.SimpleConnection{idle_interval: 5000, protocol: nil, auto_reconnect: false, reconnect_backoff: 500, state: {Postgrex.Notifications, %Postgrex.Notifications{from: nil, ref: nil, auto_reconnect: false, connected: false, listeners: %{}, listener_channels: %{}}}}}}
```

Checking the erlang docs it seems like `{:stop, reason}` should be returned here. The logs don't show up before 1.17 though. I'm guessing due to better error reporting but I'm not 100% sure.