### PR TITLE
Add `Duration` to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ iex> Postgrex.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'hey
 | `timestamp`        | `%NaiveDateTime{year: 2013, month: 10, day: 12, hour: 0, minute: 37, second: 14}`                                                           |
 | `timestamptz`      | `%DateTime{year: 2013, month: 10, day: 12, hour: 0, minute: 37, second: 14, time_zone: "Etc/UTC"}` (2)                                      |
 | `interval`         | `%Postgrex.Interval{months: 14, days: 40, secs: 10920, microsecs: 315}`                                                                     |
+| `interval`         | `%Duration{year: 1, month: 2, week: 5, day: 5, hour: 3, minute: 2, second: 0, microsecond: {315, 6}}` (3)                                   |
 | `array`            | `[1, 2, 3]`                                                                                                                                 |
 | `composite type`   | `{42, "title", "content"}`                                                                                                                  |
 | `range`            | `%Postgrex.Range{lower: 1, upper: 5}`                                                                                                       |
@@ -50,7 +51,7 @@ iex> Postgrex.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'hey
 | `uuid`             | `<<160,238,188,153,156,11,78,248,187,109,107,185,189,56,10,17>>`                                                                            |
 | `hstore`           | `%{"foo" => "bar"}`                                                                                                                         |
 | `oid types`        | `42`                                                                                                                                        |
-| `enum`             | `"ok"` (3)                                                                                                                                  |
+| `enum`             | `"ok"` (4)                                                                                                                                  |
 | `bit`              | `<< 1::1, 0::1 >>`                                                                                                                          |
 | `varbit`           | `<< 1::1, 0::1 >>`                                                                                                                          |
 | `tsvector`         | `[%Postgrex.Lexeme{positions: [{1, :A}], word: "a"}]`                                                                                       |
@@ -59,9 +60,11 @@ iex> Postgrex.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'hey
 
 (2) Timezones will always be normalized to UTC or assumed to be UTC when no information is available, either by PostgreSQL or Postgrex
 
-(3) Enumerated types (enum) are custom named database types with strings as values.
+(3) `%Duration{}` may only be used with Elixir 1.17.0+. Intervals will only be decoded into a `%Duration{}` struct if the option `interval_decode_type: Duration` is passed to `Postgrex.Types.define/3`.
 
-(4) Anonymous composite types are decoded (read) as tuples but they cannot be encoded (written) to the database
+(4) Enumerated types (enum) are custom named database types with strings as values.
+
+(5) Anonymous composite types are decoded (read) as tuples but they cannot be encoded (written) to the database
 
 Postgrex does not automatically cast between types. For example, you can't pass a string where a date is expected. To add type casting, support new types, or change how any of the types above are encoded/decoded, you can use extensions.
 

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -314,6 +314,14 @@ defmodule Postgrex.Types do
 
     * `:moduledoc` - The moduledoc to be used for the generated module.
 
+    * `:allow_infinite_timestamps` - A boolean controlling whether or not
+      the built-in extensions `timestamp` and `timestamptz` will allow
+      a value of infinity to be decoded. Defaults to `false`.
+
+    * `:interval_decode_type` - The struct that intervals will be decoded
+      into. Either `Postgrex.Interval` or `Duration` (Elixir 1.17.0+ only).
+      Defaults to `Postgrex.Interval`.
+
   """
   def define(module, extensions, opts \\ []) do
     Postgrex.TypeModule.define(module, extensions, opts)


### PR DESCRIPTION
Adds `Duration` to the docs. I also added the `:allow_infinite_timestamps` option to the documentation because I saw it was missing.