### PR TITLE
Respect precision for intervals

### DIFF
--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -6,7 +6,7 @@ defmodule Postgrex.Extensions.Interval do
   def init(opts), do: Keyword.get(opts, :interval_decode_type, Postgrex.Interval)
 
   if Code.ensure_loaded?(Duration) do
-    import Bitwise
+    import Bitwise, warn: false
     @default_precision 6
     @precision_mask 0xFFFF
 

--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -1,15 +1,15 @@
 defmodule Postgrex.Extensions.Interval do
   @moduledoc false
   import Postgrex.BinaryUtils, warn: false
-  import Bitwise
   use Postgrex.BinaryExtension, send: "interval_send"
-
-  @default_precision 6
-  @precision_mask 0xFFFF
 
   def init(opts), do: Keyword.get(opts, :interval_decode_type, Postgrex.Interval)
 
   if Code.ensure_loaded?(Duration) do
+    import Bitwise
+    @default_precision 6
+    @precision_mask 0xFFFF
+
     def encode(_) do
       quote location: :keep do
         %Postgrex.Interval{months: months, days: days, secs: seconds, microsecs: microseconds} ->

--- a/lib/postgrex/extensions/time.ex
+++ b/lib/postgrex/extensions/time.ex
@@ -4,6 +4,9 @@ defmodule Postgrex.Extensions.Time do
   use Postgrex.BinaryExtension, send: "time_send"
 
   @default_precision 6
+  # -1: user did not specify precision
+  # nil: coming from a super type that does not pass modifier for sub-type
+  @unspecified_precision [-1, nil]
 
   def encode(_) do
     quote location: :keep do
@@ -31,10 +34,7 @@ defmodule Postgrex.Extensions.Time do
   end
 
   def microsecond_to_elixir(microsec, precision) do
-    # use the default precision if the precision modifier from postgres is -1 (this means no precision specified)
-    # or if the precision is missing because we are in a super type which does not give us the sub-type's modifier
-    precision = if precision in [-1, nil], do: @default_precision, else: precision
-
+    precision = if precision in @unspecified_precision, do: @default_precision, else: precision
     sec = div(microsec, 1_000_000)
     microsec = rem(microsec, 1_000_000)
 

--- a/lib/postgrex/extensions/timestamp.ex
+++ b/lib/postgrex/extensions/timestamp.ex
@@ -9,6 +9,9 @@ defmodule Postgrex.Extensions.Timestamp do
   @plus_infinity 9_223_372_036_854_775_807
   @minus_infinity -9_223_372_036_854_775_808
   @default_precision 6
+  # -1: user did not specify precision
+  # nil: coming from a super type that does not pass modifier for sub-type
+  @unspecified_precision [-1, nil]
 
   def init(opts), do: Keyword.get(opts, :allow_infinite_timestamps, false)
 
@@ -77,9 +80,7 @@ defmodule Postgrex.Extensions.Timestamp do
   end
 
   defp split(secs, microsecs, precision) do
-    # use the default precision if the precision modifier from postgres is -1 (this means no precision specified)
-    # or if the precision is missing because we are in a super type which does not give us the sub-type's modifier
-    precision = if precision in [-1, nil], do: @default_precision, else: precision
+    precision = if precision in @unspecified_precision, do: @default_precision, else: precision
     NaiveDateTime.from_gregorian_seconds(secs + @gs_epoch, {microsecs, precision})
   end
 

--- a/lib/postgrex/extensions/timestamptz.ex
+++ b/lib/postgrex/extensions/timestamptz.ex
@@ -10,6 +10,9 @@ defmodule Postgrex.Extensions.TimestampTZ do
   @plus_infinity 9_223_372_036_854_775_807
   @minus_infinity -9_223_372_036_854_775_808
   @default_precision 6
+  # -1: user did not specify precision
+  # nil: coming from a super type that does not pass modifier for sub-type
+  @unspecified_precision [-1, nil]
 
   def init(opts), do: Keyword.get(opts, :allow_infinite_timestamps, false)
 
@@ -67,9 +70,7 @@ defmodule Postgrex.Extensions.TimestampTZ do
   end
 
   defp split(secs, microsecs, precision) do
-    # use the default precision if the precision modifier from postgres is -1 (this means no precision specified)
-    # or if the precision is missing because we are in a super type which does not give us the sub-type's modifier
-    precision = if precision in [-1, nil], do: @default_precision, else: precision
+    precision = if precision in @unspecified_precision, do: @default_precision, else: precision
     DateTime.from_gregorian_seconds(secs + @gs_epoch, {microsecs, precision})
   end
 

--- a/lib/postgrex/extensions/timetz.ex
+++ b/lib/postgrex/extensions/timetz.ex
@@ -5,6 +5,9 @@ defmodule Postgrex.Extensions.TimeTZ do
 
   @day (:calendar.time_to_seconds({23, 59, 59}) + 1) * 1_000_000
   @default_precision 6
+  # -1: user did not specify precision
+  # nil: coming from a super type that does not pass modifier for sub-type
+  @unspecified_precision [-1, nil]
 
   def encode(_) do
     quote location: :keep do
@@ -51,10 +54,7 @@ defmodule Postgrex.Extensions.TimeTZ do
   end
 
   defp microsecond_to_elixir(microsec, precision) do
-    # use the default precision if the precision modifier from postgres is -1 (this means no precision specified)
-    # or if the precision is missing because we are in a super type which does not give us the sub-type's modifier
-    precision = if precision in [-1, nil], do: @default_precision, else: precision
-
+    precision = if precision in @unspecified_precision, do: @default_precision, else: precision
     sec = div(microsec, 1_000_000)
     microsec = rem(microsec, 1_000_000)
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -194,7 +194,7 @@ defmodule QueryTest do
                P.query!(pid, "SELECT ARRAY[interval '10240000 microseconds']", []).rows
     end
 
-    test "decode interval with Elixir Duration and precision" do
+    test "decode interval with Elixir Duration: precision is given" do
       opts = [database: "postgrex_test", backoff_type: :stop, types: Postgrex.ElixirDurationTypes]
       {:ok, pid} = P.start_link(opts)
 
@@ -203,6 +203,17 @@ defmodule QueryTest do
 
       assert [[[%Duration{second: 10, microsecond: {0, 0}}]]] =
                P.query!(pid, "SELECT ARRAY[interval(0) '10240000 microseconds']", []).rows
+    end
+
+    test "decode interval with Elixir Duration: field is given but not precision" do
+      opts = [database: "postgrex_test", backoff_type: :stop, types: Postgrex.ElixirDurationTypes]
+      {:ok, pid} = P.start_link(opts)
+
+      assert [[%Duration{week: 1, day: 3, microsecond: {0, 6}}]] =
+               P.query!(pid, "SELECT interval '10' DAY", []).rows
+
+      assert [[[%Duration{week: 1, day: 3, microsecond: {0, 6}}]]] =
+               P.query!(pid, "SELECT ARRAY[interval '10' DAY]", []).rows
     end
   end
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -193,6 +193,17 @@ defmodule QueryTest do
       assert [[[%Duration{second: 10, microsecond: {240_000, 6}}]]] =
                P.query!(pid, "SELECT ARRAY[interval '10240000 microseconds']", []).rows
     end
+
+    test "decode interval with Elixir Duration and precision" do
+      opts = [database: "postgrex_test", backoff_type: :stop, types: Postgrex.ElixirDurationTypes]
+      {:ok, pid} = P.start_link(opts)
+
+      assert [[%Duration{second: 10, microsecond: {240_000, 2}}]] =
+               P.query!(pid, "SELECT interval(2) '10240000 microseconds'", []).rows
+
+      assert [[[%Duration{second: 10, microsecond: {0, 0}}]]] =
+               P.query!(pid, "SELECT ARRAY[interval(0) '10240000 microseconds']", []).rows
+    end
   end
 
   test "decode point", context do


### PR DESCRIPTION
In the previous PR we hardcoded the precision to 6 because we didn't know how to deal with the type modifier.

I got pointed in the right direction by the nice people at Postgres. The type modifier for intervals takes into account two different things:

1. The allowed fields (i.e. only `days`, `years`, `days to years` and stuff like that), represented as a 16-bit bit field
2. The precision represented as a 16 bit integer

The right most 16 bits in the type modifier are the precision. I was pointed to the right places in their code [here](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/utils/adt/timestamp.c;h=69fe7860ede062fc8be42e7545b35e69c3e068c4;hb=HEAD#l1151) and [here](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/utils/timestamp.h;h=a6ce03ed46045fb748daf02f0f6e06492ad5a181;hb=HEAD#l81)

We could probably do something about the fields modifier as well but that is a lot more complex. And we ignore it already today. So going to think on it a bit and save it for later.