### PR TITLE
Fix dialyzer issues with interval extension, part 2

### DIFF
--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -50,7 +50,7 @@ defmodule Postgrex.Extensions.Interval do
     end
 
     def decode(type) do
-      quote location: :keep do
+      quote location: :keep, generated: true do
         <<16::int32(), microseconds::int64(), days::int32(), months::int32()>> ->
           type_mod = var!(mod)
           precision = if type_mod, do: type_mod &&& unquote(@precision_mask)

--- a/lib/postgrex/extensions/interval.ex
+++ b/lib/postgrex/extensions/interval.ex
@@ -52,7 +52,8 @@ defmodule Postgrex.Extensions.Interval do
     def decode(type) do
       quote location: :keep do
         <<16::int32(), microseconds::int64(), days::int32(), months::int32()>> ->
-          precision = if var!(mod), do: var!(mod) &&& unquote(@precision_mask)
+          type_mod = var!(mod)
+          precision = if type_mod, do: type_mod &&& unquote(@precision_mask)
 
           unquote(__MODULE__).decode_interval(
             microseconds,


### PR DESCRIPTION
Really not sure about the latest warning

```elixir
deps/postgrex/lib/postgrex/type_module.ex:1084:call
The function call will not succeed.

:erlang.band(_mod :: nil, 65535)

will never return since the 1st arguments differ
from the success typing arguments:

(integer(), integer())
```

@oliver-kriska  could you try this branch before we merge? ty