### PR TITLE
Fix nested super type modifier handling

### DIFF
--- a/lib/postgrex/extensions/array.ex
+++ b/lib/postgrex/extensions/array.ex
@@ -33,13 +33,13 @@ defmodule Postgrex.Extensions.Array do
           data::binary>> = binary
 
         # decode_list/2 defined by TypeModule
-        type =
+        sub_type_with_mod =
           case type do
             {extension, sub_oids, sub_types} -> {extension, sub_oids, sub_types, var!(mod)}
             extension -> {extension, var!(mod)}
           end
 
-        flat = decode_list(data, type)
+        flat = decode_list(data, sub_type_with_mod)
 
         unquote(__MODULE__).decode(dims, flat)
     end

--- a/lib/postgrex/extensions/multirange.ex
+++ b/lib/postgrex/extensions/multirange.ex
@@ -34,6 +34,7 @@ defmodule Postgrex.Extensions.Multirange do
         type =
           case type do
             {extension, sub_oids, sub_types} -> {extension, sub_oids, sub_types, nil}
+            {extension, _} -> {extension, nil}
             extension -> {extension, nil}
           end
 

--- a/lib/postgrex/extensions/multirange.ex
+++ b/lib/postgrex/extensions/multirange.ex
@@ -31,14 +31,13 @@ defmodule Postgrex.Extensions.Multirange do
         <<_num_ranges::int32(), ranges::binary>> = data
 
         # decode_list/2 defined by TypeModule
-        type =
+        sub_type_with_mod =
           case type do
             {extension, sub_oids, sub_types} -> {extension, sub_oids, sub_types, nil}
-            {extension, _} -> {extension, nil}
             extension -> {extension, nil}
           end
 
-        bound_decoder = &decode_list(&1, type)
+        bound_decoder = &decode_list(&1, sub_type_with_mod)
         unquote(__MODULE__).decode(ranges, bound_decoder, [])
     end
   end

--- a/lib/postgrex/extensions/range.ex
+++ b/lib/postgrex/extensions/range.ex
@@ -42,6 +42,7 @@ defmodule Postgrex.Extensions.Range do
         type =
           case type do
             {extension, sub_oids, sub_types} -> {extension, sub_oids, sub_types, nil}
+            {extension, _} -> {extension, nil}
             extension -> {extension, nil}
           end
 

--- a/lib/postgrex/extensions/range.ex
+++ b/lib/postgrex/extensions/range.ex
@@ -39,14 +39,13 @@ defmodule Postgrex.Extensions.Range do
         <<flags, data::binary>> = binary
 
         # decode_list/2 defined by TypeModule
-        type =
+        sub_type_with_mod =
           case type do
             {extension, sub_oids, sub_types} -> {extension, sub_oids, sub_types, nil}
-            {extension, _} -> {extension, nil}
             extension -> {extension, nil}
           end
 
-        case decode_list(data, type) do
+        case decode_list(data, sub_type_with_mod) do
           [upper, lower] ->
             unquote(__MODULE__).decode(flags, [lower, upper])
 

--- a/test/calendar_test.exs
+++ b/test/calendar_test.exs
@@ -27,6 +27,12 @@ defmodule CalendarTest do
   test "decode time with precision", context do
     assert [[~T[00:00:00.000]]] = query("SELECT time(3) '00:00:00'", [])
     assert [[[~T[00:00:00.000]]]] = query("SELECT ARRAY[time(3) '00:00:00']", [])
+
+    assert [[[[~T[00:00:00.000], ~T[00:00:00.000]], [~T[01:00:00.000], ~T[01:00:00.000]]]]] =
+             query(
+               "SELECT ARRAY[ARRAY[time(3) '00:00:00', time(3) '00:00:00'], ARRAY[time(3) '01:00:00', time(3) '01:00:00']]",
+               []
+             )
   end
 
   test "decode timetz", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -531,6 +531,27 @@ defmodule QueryTest do
                }
              ]
            ] = query("SELECT '[2014-1-1,2014-12-31)'::tsrange", [])
+
+    assert [
+      [
+        [
+          %Postgrex.Range{
+            lower: ~N[2014-01-01 00:00:00.000000],
+            upper: ~N[2014-12-31 00:00:00.000000],
+            lower_inclusive: true,
+            upper_inclusive: false
+          },
+          %Postgrex.Range{
+            lower: ~N[2014-01-01 00:00:00.000000],
+            upper: ~N[2014-12-31 00:00:00.000000],
+            lower_inclusive: true,
+            upper_inclusive: false
+          }
+        ]
+      ]
+    ]
+
+    query("SELECT ARRAY['[2014-1-1,2014-12-31)'::tsrange, '[2014-1-1,2014-12-31)'::tsrange]", [])
   end
 
   @tag min_pg_version: "14.0"


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/postgrex/issues/704

The issue is with nested super types we may pass `{extension, modifier}` down so we end up with `{{extension, modifier}, nil}`. 

We want to flatten it out and pass `nil` for the range modifier because we don't know how the Postgres modifier for ranges works yet. Passing `nil` will have it default to what it was before we started handling modifiers.