### PR TITLE
allow to  append comment to query

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -289,6 +289,9 @@ defmodule Postgrex do
   @spec query(conn, iodata, list, [execute_option]) ::
           {:ok, Postgrex.Result.t()} | {:error, Exception.t()}
   def query(conn, statement, params, opts \\ []) do
+    prepare? = !Keyword.get(opts, :comment)
+    opts = Keyword.put(opts, :postgrex_prepare, prepare?)
+
     if name = Keyword.get(opts, :cache_statement) do
       query = %Query{name: name, cache: :statement, statement: IO.iodata_to_binary(statement)}
 

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -363,7 +363,8 @@ defmodule Postgrex do
           {:ok, Postgrex.Query.t()} | {:error, Exception.t()}
   def prepare(conn, name, statement, opts \\ []) do
     query = %Query{name: name, statement: statement}
-    opts = Keyword.put(opts, :postgrex_prepare, true)
+    prepare? = !Keyword.get(opts, :comment)
+    opts = Keyword.put(opts, :postgrex_prepare, prepare?)
     DBConnection.prepare(conn, query, opts)
   end
 
@@ -373,7 +374,8 @@ defmodule Postgrex do
   """
   @spec prepare!(conn, iodata, iodata, [option]) :: Postgrex.Query.t()
   def prepare!(conn, name, statement, opts \\ []) do
-    opts = Keyword.put(opts, :postgrex_prepare, true)
+    prepare? = !Keyword.get(opts, :comment)
+    opts = Keyword.put(opts, :postgrex_prepare, prepare?)
     DBConnection.prepare!(conn, %Query{name: name, statement: statement}, opts)
   end
 

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -289,9 +289,6 @@ defmodule Postgrex do
   @spec query(conn, iodata, list, [execute_option]) ::
           {:ok, Postgrex.Result.t()} | {:error, Exception.t()}
   def query(conn, statement, params, opts \\ []) do
-    prepare? = !Keyword.get(opts, :comment)
-    opts = Keyword.put(opts, :postgrex_prepare, prepare?)
-
     if name = Keyword.get(opts, :cache_statement) do
       query = %Query{name: name, cache: :statement, statement: IO.iodata_to_binary(statement)}
 
@@ -366,7 +363,7 @@ defmodule Postgrex do
           {:ok, Postgrex.Query.t()} | {:error, Exception.t()}
   def prepare(conn, name, statement, opts \\ []) do
     query = %Query{name: name, statement: statement}
-    prepare? = !Keyword.get(opts, :comment)
+    prepare? = Keyword.get(opts, :comment) == nil
     opts = Keyword.put(opts, :postgrex_prepare, prepare?)
     DBConnection.prepare(conn, query, opts)
   end
@@ -377,7 +374,7 @@ defmodule Postgrex do
   """
   @spec prepare!(conn, iodata, iodata, [option]) :: Postgrex.Query.t()
   def prepare!(conn, name, statement, opts \\ []) do
-    prepare? = !Keyword.get(opts, :comment)
+    prepare? = Keyword.get(opts, :comment) == nil
     opts = Keyword.put(opts, :postgrex_prepare, prepare?)
     DBConnection.prepare!(conn, %Query{name: name, statement: statement}, opts)
   end

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -169,6 +169,11 @@ defmodule Postgrex do
       This is useful when using Postgrex against systems that do not support composite types
       (default: `false`).
 
+    * `:comment` - When a binary string is provided, appends the given text as a comment to the
+      query.  This can be useful for tracing purposes, such as when using SQLCommenter or similar
+      tools to track query performance and behavior. Note that including a comment disables query
+      caching since each query with a different comment is treated as unique (default: `nil`).
+
   `Postgrex` uses the `DBConnection` library and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc. See `DBConnection.start_link/2`
   for more information.

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -371,11 +371,11 @@ defmodule Postgrex.Protocol do
     if new_query = cached_query(s, query) do
       {:ok, new_query, s}
     else
-      prepare = Keyword.get(opts, :postgrex_prepare, false)
-      status = new_status(opts, prepare: prepare)
+      prepare? = Keyword.get(opts, :postgrex_prepare, false)
+      status = new_status(opts, prepare: prepare?)
 
       result =
-        case prepare do
+        case prepare? do
           true -> close_parse_describe(s, status, query)
           false -> close_parse_describe_flush(s, status, query)
         end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1607,7 +1607,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp parse_describe_comment_msgs(query, comment, tail) when is_binary(comment) do
-    statement = query.statement <> "/*#{comment}*/"
+    statement = [query.statement, "/*", comment, "*/"]
     query = %{query | statement: statement}
     parse_describe_msgs(query, tail)
   end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1605,7 +1605,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp parse_describe_comment_msgs(query, comment, tail) when is_binary(comment) do
-    statement = "/* #{comment} */\n" <> query.statement
+    statement = query.statement <> "/* #{comment} */"
     query = %{query | statement: statement}
     parse_describe_msgs(query, tail)
   end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -16,9 +16,6 @@ defmodule Postgrex.Protocol do
                                      message:
                                        "`:commit_comment` option cannot contain sequence \"*/\""
                                    )
-  @comment_validation_error Postgrex.Error.exception(
-                              message: "`:comment` option cannot contain sequence \"*/\""
-                            )
 
   defstruct sock: nil,
             connection_id: nil,
@@ -355,12 +352,7 @@ defmodule Postgrex.Protocol do
 
       false ->
         comment = Keyword.get(opts, :comment)
-
-        if is_binary(comment) && String.contains?(comment, "*/") do
-          raise @comment_validation_error
-        else
-          parse_describe_flush(s, status, query, comment)
-        end
+        parse_describe_flush(s, status, query, comment)
     end
   end
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1853,6 +1853,10 @@ defmodule QueryTest do
 
   test "comment", context do
     assert [[123]] = query("select 123", [], comment: "query comment goes here")
+
+    assert_raise Postgrex.Error, fn ->
+      query("select 123", [], comment: "*/ DROP TABLE 123 --")
+    end
   end
 
   @tag :big_binary

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1851,6 +1851,15 @@ defmodule QueryTest do
     assert [["1", "2"], ["3", "4"]] = query("COPY (VALUES (1, 2), (3, 4)) TO STDOUT", [], opts)
   end
 
+  test "comment", context do
+    assert [[123]] = query("select 123", [], comment: "query comment goes here")
+
+    assert_raise Postgrex.Error, fn ->
+      query("select 123", [], comment: "*/ DROP TABLE 123 --")
+    end
+  end
+
+  @tag :big_binary
   test "receive packet with remainder greater than 64MB", context do
     # to ensure remainder is more than 64MB use 64MBx2+1
     big_binary = :binary.copy(<<1>>, 128 * 1024 * 1024 + 1)

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1853,10 +1853,6 @@ defmodule QueryTest do
 
   test "comment", context do
     assert [[123]] = query("select 123", [], comment: "query comment goes here")
-
-    assert_raise Postgrex.Error, fn ->
-      query("select 123", [], comment: "*/ DROP TABLE 123 --")
-    end
   end
 
   @tag :big_binary


### PR DESCRIPTION
Recently there was introduced commit_comment to prepend comment before the commit keyword
I wanted to propose something similar for all queries - It will be useful for prepending [sqlcommenter](https://github.com/QuerySorcery/sqlcommenter) comments to queries but any other info is possible. 
I tried different hacks to get around this limitation but this has to be implemented in postgrex just before the query is sent to the database.
I found the place where to add this code by trial and error, any suggestion welcome how to make it better.
Also is it possible to test it somehow? Currently I'm logging it in the database but it would be nice to log the data that is sent to the database. Maybe testing the encoder is enough?
```
2024-10-11 21:44:02.715 BST,"kuku","postgrex_test",624085,"127.0.0.1:55774",67098e12.985d5,1,"SELECT",2024-10-11 21:44:02 BST,3/2286,0,LOG,00000,"execute <unnamed>: /*comment*/
SELECT 321",,,,,,,,,"","client backend",,0  
```