### PR TITLE
Fix start_link typespec

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -246,7 +246,7 @@ defmodule Postgrex do
       ]
 
   """
-  @spec start_link([start_option]) :: {:ok, pid} | {:error, Postgrex.Error.t() | term}
+  @spec start_link([start_option]) :: GenServer.on_start()
   def start_link(opts) do
     opts = Postgrex.Utils.default_opts(opts)
     DBConnection.start_link(Postgrex.Protocol, opts)


### PR DESCRIPTION
The [typespec](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex.ex#L249) for `Postgrex.start_link/1` is incorrect. This function wraps `DBConnection.start_link/2` which has a `GenServer.on_start()` [type](https://github.com/elixir-lang/elixir/blob/v1.14.1/lib/elixir/lib/gen_server.ex#L714C34-L714C84).

I'd like to introduce an accurate type for `Postgrex.start_link/1`.