### PR TITLE
dk-remove_comment_sql_injection_validation

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -67,10 +67,6 @@ defmodule Postgrex do
   @max_rows 500
   @timeout 15_000
 
-  @comment_validation_error Postgrex.Error.exception(
-                              message: "`:comment` option cannot contain sequence \"*/\""
-                            )
-
   ### PUBLIC API ###
 
   @doc """
@@ -332,15 +328,9 @@ defmodule Postgrex do
 
   defp comment_not_present!(opts) do
     case Keyword.get(opts, :comment) do
-      nil ->
-        true
-
-      comment when is_binary(comment) ->
-        if String.contains?(comment, "*/") do
-          raise @comment_validation_error
-        else
-          false
-        end
+      nil -> true
+      comment when is_binary(comment) -> false
+      comment when is_list(comment) -> false
     end
   end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1603,7 +1603,7 @@ defmodule Postgrex.Protocol do
   end
 
   defp parse_describe_comment_msgs(query, comment, tail) when is_binary(comment) do
-    statement = [query.statement, "/*", comment, "*/"]
+    statement = [query.statement, ";/*", comment, "*/"]
     query = %{query | statement: statement}
     parse_describe_msgs(query, tail)
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1853,10 +1853,10 @@ defmodule QueryTest do
 
   test "comment", context do
     assert [[123]] = query("select 123", [], comment: "query comment goes here")
+    assert [[123]] = query("select 123", [], comment: "query comment goes here;")
+    %Postgrex.Error{postgres: error} = query("select 123", [], comment: "*/ select 456 --")
 
-    assert_raise Postgrex.Error, fn ->
-      query("select 123", [], comment: "*/ DROP TABLE 123 --")
-    end
+    assert error.message =~ "cannot insert multiple commands into a prepared statement"
   end
 
   @tag :big_binary

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1852,6 +1852,7 @@ defmodule QueryTest do
   end
 
   test "comment is not interfering with the query", context do
+    assert [[123]] = query("select 123", [], comment: ["query", "comment" | ["goes here"]])
     assert [[123]] = query("select 123", [], comment: "query comment goes here")
     assert [[123]] = query("select 123;", [], comment: "query comment goes here")
   end


### PR DESCRIPTION
I think we can remove the check for closing `*/` in comments, postgres does not allow to have 2 statements sent so a single `;` is enough to separate the comment.
This way we don't have to build the string and traverse it. it also enables to use iolists.
In the current implementation it is unnecessary because it's not allowed to send multiple queries, postgres throws an error in this case.
