### PR TITLE
Raise a nice error message of params is not a list

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -297,7 +297,7 @@ defmodule Postgrex do
   """
   @spec query(conn, iodata, list, [execute_option]) ::
           {:ok, Postgrex.Result.t()} | {:error, Exception.t()}
-  def query(conn, statement, params, opts \\ []) do
+  def query(conn, statement, params, opts \\ []) when is_list(params) do
     name = Keyword.get(opts, :cache_statement)
 
     if comment_not_present!(opts) && name do
@@ -349,7 +349,7 @@ defmodule Postgrex do
   there was an error. See `query/3`.
   """
   @spec query!(conn, iodata, list, [execute_option]) :: Postgrex.Result.t()
-  def query!(conn, statement, params, opts \\ []) do
+  def query!(conn, statement, params, opts \\ []) when is_list(params) do
     case query(conn, statement, params, opts) do
       {:ok, result} -> result
       {:error, err} -> raise err
@@ -434,7 +434,7 @@ defmodule Postgrex do
   """
   @spec prepare_execute(conn, iodata, iodata, list, [execute_option]) ::
           {:ok, Postgrex.Query.t(), Postgrex.Result.t()} | {:error, Postgrex.Error.t()}
-  def prepare_execute(conn, name, statement, params, opts \\ []) do
+  def prepare_execute(conn, name, statement, params, opts \\ []) when is_list(params) do
     query = %Query{name: name, statement: statement}
     opts = Keyword.put(opts, :postgrex_prepare, comment_not_present!(opts))
     DBConnection.prepare_execute(conn, query, params, opts)
@@ -446,7 +446,7 @@ defmodule Postgrex do
   """
   @spec prepare_execute!(conn, iodata, iodata, list, [execute_option]) ::
           {Postgrex.Query.t(), Postgrex.Result.t()}
-  def prepare_execute!(conn, name, statement, params, opts \\ []) do
+  def prepare_execute!(conn, name, statement, params, opts \\ []) when is_list(params) do
     query = %Query{name: name, statement: statement}
     opts = Keyword.put(opts, :postgrex_prepare, comment_not_present!(opts))
     DBConnection.prepare_execute!(conn, query, params, opts)
@@ -482,7 +482,7 @@ defmodule Postgrex do
   """
   @spec execute(conn, Postgrex.Query.t(), list, [execute_option]) ::
           {:ok, Postgrex.Query.t(), Postgrex.Result.t()} | {:error, Postgrex.Error.t()}
-  def execute(conn, query, params, opts \\ []) do
+  def execute(conn, query, params, opts \\ []) when is_list(params) do
     DBConnection.execute(conn, query, params, opts)
   end
 
@@ -492,7 +492,7 @@ defmodule Postgrex do
   """
   @spec execute!(conn, Postgrex.Query.t(), list, [execute_option]) ::
           Postgrex.Result.t()
-  def execute!(conn, query, params, opts \\ []) do
+  def execute!(conn, query, params, opts \\ []) when is_list(params) do
     DBConnection.execute!(conn, query, params, opts)
   end
 

--- a/lib/postgrex/type_module.ex
+++ b/lib/postgrex/type_module.ex
@@ -178,12 +178,8 @@ defmodule Postgrex.TypeModule do
       unquote(encodes)
 
       @doc false
-      def encode_params(params, types) when is_list(params) do
+      def encode_params(params, types) do
         encode_params(params, types, [])
-      end
-
-      def encode_params(params, _types) do
-        raise ArgumentError, "expected params to be a list, got: #{inspect(params)}"
       end
 
       defp encode_params([param | params], [type | types], encoded) do

--- a/lib/postgrex/type_module.ex
+++ b/lib/postgrex/type_module.ex
@@ -178,8 +178,12 @@ defmodule Postgrex.TypeModule do
       unquote(encodes)
 
       @doc false
-      def encode_params(params, types) do
+      def encode_params(params, types) when is_list(params) do
         encode_params(params, types, [])
+      end
+
+      def encode_params(params, _types) do
+        raise ArgumentError, "expected params to be a list, got: #{inspect(params)}"
       end
 
       defp encode_params([param | params], [type | types], encoded) do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -384,6 +384,10 @@ defmodule QueryTest do
     assert [[[{1, "2"}]]] = query("SELECT ARRAY[(1, '2')::composite1]", [])
   end
 
+  test "decode enum", context do
+    assert [["elixir"]] = query("SELECT 'elixir'::enum1", [])
+  end
+
   @tag min_pg_version: "9.2"
   test "decode range", context do
     # These do not appear to match what is selected, but that's because

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -384,10 +384,6 @@ defmodule QueryTest do
     assert [[[{1, "2"}]]] = query("SELECT ARRAY[(1, '2')::composite1]", [])
   end
 
-  test "decode enum", context do
-    assert [["elixir"]] = query("SELECT 'elixir'::enum1", [])
-  end
-
   @tag min_pg_version: "9.2"
   test "decode range", context do
     # These do not appear to match what is selected, but that's because
@@ -1926,5 +1922,13 @@ defmodule QueryTest do
     # search path does contain the appropriate schema
     {:ok, pid} = P.start_link(database: "postgrex_test", search_path: ["public", "test_schema"])
     %{rows: [[1, "foo"]]} = P.query!(pid, "SELECT * from test_table", [])
+  end
+
+  test "raise a nice message if params is not a list", context do
+    msg = ~r"expected params to be a list"
+
+    assert_raise ArgumentError, msg, fn ->
+      query("SELECT 'hi ' <> $1", "postgrex")
+    end
   end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1929,10 +1929,28 @@ defmodule QueryTest do
   end
 
   test "raise a nice message if params is not a list", context do
-    msg = ~r"expected params to be a list"
-
-    assert_raise ArgumentError, msg, fn ->
+    assert_raise FunctionClauseError, fn ->
       query("SELECT 'hi ' <> $1", "postgrex")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Postgrex.query!(context[:pid], "SELECT 'hi ' <> $1", "postgrex")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      prepare_execute("name", "SELECT 'hi ' <> $1", "postgrex")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Postgrex.prepare_execute!(context[:pid], "name", "SELECT 'hi ' <> $1", "postgrex")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      execute("name", "postgrex")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Postgrex.execute!(context[:pid], "name", "postgrex")
     end
   end
 end


### PR DESCRIPTION
This can help if the user is passing a single value as a parameter or something like that. Otherwise the function clause error can be a bit cryptic.