### PR TITLE
possible typo

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -3286,7 +3286,7 @@ defmodule Postgrex.Protocol do
         disconnect(s, :tcp, "async_recv", reason, :active_once)
     after
       timeout ->
-        disconnect(s, :tcp, "async_recv", :timeout, :active_one)
+        disconnect(s, :tcp, "async_recv", :timeout, :active_once)
     end
   end
 


### PR DESCRIPTION
Not actually sure if it's a typo, but I couldn't quickly [find](https://github.com/search?q=repo%3Aelixir-ecto%2Fpostgrex%20active_one&type=code) any other instances of `:active_one` in the codebase :)