### PR TITLE
call disconnect on protocol when reconnecting in simple connection

### DIFF
--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -337,7 +337,12 @@ defmodule Postgrex.SimpleConnection do
   @impl :gen_statem
   def handle_event(type, content, statem_state, state)
 
-  def handle_event(:internal, {:connect, _}, @state, %{state: {mod, mod_state}} = state) do
+  def handle_event(:internal, {:connect, :reconnect}, @state, %{protocol: protocol} = state) do
+    Protocol.disconnect(:reconnect, protocol)
+    {:keep_state, %{state | protocol: nil}, {:next_event, :internal, {:connect, :init}}}
+  end
+
+  def handle_event(:internal, {:connect, :init}, @state, %{state: {mod, mod_state}} = state) do
     opts =
       case Keyword.get(opts(mod), :configure) do
         {module, fun, args} -> apply(module, fun, [opts(mod) | args])


### PR DESCRIPTION
postgrex 0.17.5
oban 2.18.3

we are using oban with postgres notifiers and in a few services we have a port leaks

<img width="732" alt="image" src="https://github.com/user-attachments/assets/d235d2e2-8df6-4e3f-bc6f-985f44cc719c">

_blue line is fix hotload_

the problem is that the ports are not closed on `{:connect, :reconnect}` handle, it just drops the `protocol` state and creates a new one

```elixir
08:09:21.320006 <0.3785.0> Postgrex.SimpleConnection.handle_event(:info, {:tcp, #Port<0.84514854>,
 <<69, 0, 0, 0, 115, 83, 70, 65, 84, 65, 76, 0, 86, 70, 65, 84, 65, 76, 0, 67,
   53, 55, 80, 48, 53, 0, 77, 116, 101, 114, 109, 105, 110, 97, 116, 105, 110,
   103, 32, 99, 111, 110, 110, 101, 99, 116, 105, ...>>}, :no_state, %Postgrex.SimpleConnection{
  idle_interval: 5000,
  protocol: %Postgrex.Protocol{
    sock: {:gen_tcp, #Port<0.84514854>},
    connection_id: 3537365,
    connection_key: 904133435,
    peer: {{10, 129, 1, 100}, 5432},
    types: {Postgrex.DefaultTypes, #Reference<0.1812357926.8519733.135683>},
    null: nil,
    timeout: 15000,
    ping_timeout: 15000,
    parameters: #Reference<0.1812357926.1244921861.105622>,
    queries: nil,
    postgres: :idle,
    transactions: :naive,
    buffer: :active_once,
    disconnect_on_error_codes: [],
    scram: ...,
    disable_composite_types: false
  },
  auto_reconnect: true,
  reconnect_backoff: 500,
  state: {Oban.Notifiers.Postgres,
   %Oban.Notifiers.Postgres{
     conf: %Oban.Config{
       dispatch_cooldown: 5,
       engine: Oban.Engines.Basic,
       get_dynamic_repo: nil,
       insert_trigger: true,
       log: false,
       name: Oban,
       node: "service@172.18.0.1",
       notifier: {Oban.Notifiers.Postgres, []},
       peer: {Oban.Peers.Postgres, []},
       plugins: [{Oban.Plugins.Pruner, [max_age: 43200]}],
       prefix: "public",
       queues: [default: [limit: 10]],
       repo: Service.Repo,
       shutdown_grace_period: 15000,
       stage_interval: 1000,
       testing: :disabled
     },
     from: nil,
     key: nil,
     channels: %{
       "public.oban_insert" => [#PID<0.13379.92>],
       "public.oban_leader" => [#PID<0.3787.0>],
       "public.oban_signal" => [#PID<0.13379.92>, #PID<0.3789.0>],
       "public.oban_sonar" => [#PID<0.3788.0>]
     },
     connected?: true,
     listeners: %{
       #PID<0.3787.0> => {#Reference<0.1812357926.8388665.136456>,
        MapSet.new(["public.oban_leader"])},
       #PID<0.3788.0> => {#Reference<0.1812357926.8388663.136221>,
        MapSet.new(["public.oban_sonar"])},
       #PID<0.3789.0> => {#Reference<0.1812357926.8388663.136235>,
        MapSet.new(["public.oban_signal"])},
       #PID<0.13379.92> => {#Reference<0.1812357926.47972356.224570>,
        MapSet.new(["public.oban_insert", "public.oban_signal"])}
     }
   }}
})

08:09:21.321766 <0.3785.0> Postgrex.Protocol.handle_info({:tcp, #Port<0.84514854>,
 <<69, 0, 0, 0, 115, 83, 70, 65, 84, 65, 76, 0, 86, 70, 65, 84, 65, 76, 0, 67,
   53, 55, 80, 48, 53, 0, 77, 116, 101, 114, 109, 105, 110, 97, 116, 105, 110,
   103, 32, 99, 111, 110, 110, 101, 99, 116, 105, ...>>}, [notify: #Function<2.75911949/2 in Postgrex.SimpleConnection.handle_event/4>], %Postgrex.Protocol{
  sock: {:gen_tcp, #Port<0.84514854>},
  connection_id: 3537365,
  connection_key: 904133435,
  peer: {{10, 129, 1, 100}, 5432},
  types: {Postgrex.DefaultTypes, #Reference<0.1812357926.8519733.135683>},
  null: nil,
  timeout: 15000,
  ping_timeout: 15000,
  parameters: #Reference<0.1812357926.1244921861.105622>,
  queries: nil,
  postgres: :idle,
  transactions: :naive,
  buffer: :active_once,
  disconnect_on_error_codes: [],
  scram: ...,
  disable_composite_types: false
})

08:09:21.322877 <0.3785.0> Postgrex.Protocol.handle_info/3 --> {:disconnect,
 %Postgrex.Error{
   message: nil,
   postgres: %{
     code: nil,
     file: "postgres.c",
     line: "3381",
     message: "terminating connection due to idle-session timeout",
     pg_code: "57P05",
     routine: "ProcessInterrupts",
     severity: "FATAL",
     unknown: "FATAL"
   },
   connection_id: 3537365,
   query: nil
 },
 %Postgrex.Protocol{
   sock: {:gen_tcp, #Port<0.84514854>},
   connection_id: 3537365,
   connection_key: 904133435,
   peer: {{10, 129, 1, 100}, 5432},
   types: {Postgrex.DefaultTypes, #Reference<0.1812357926.8519733.135683>},
   null: nil,
   timeout: 15000,
   ping_timeout: 15000,
   parameters: #Reference<0.1812357926.1244921861.105622>,
   queries: nil,
   postgres: :idle,
   transactions: :naive,
   buffer: "",
   disconnect_on_error_codes: [],
   scram: ...,
   disable_composite_types: false
 }}

08:09:21.323738 <0.3785.0> Postgrex.SimpleConnection.handle_event/4 --> {:keep_state,
 %Postgrex.SimpleConnection{
   idle_interval: 5000,
   protocol: %Postgrex.Protocol{
     sock: {:gen_tcp, #Port<0.84514854>},
     connection_id: 3537365,
     connection_key: 904133435,
     peer: {{10, 129, 1, 100}, 5432},
     types: {Postgrex.DefaultTypes, #Reference<0.1812357926.8519733.135683>},
     null: nil,
     timeout: 15000,
     ping_timeout: 15000,
     parameters: #Reference<0.1812357926.1244921861.105622>,
     queries: nil,
     postgres: :idle,
     transactions: :naive,
     buffer: :active_once,
     disconnect_on_error_codes: [],
     scram: ...,
     disable_composite_types: false
   },
   auto_reconnect: true,
   reconnect_backoff: 500,
   state: {Oban.Notifiers.Postgres,
    %Oban.Notifiers.Postgres{
      conf: %Oban.Config{
        dispatch_cooldown: 5,
        engine: Oban.Engines.Basic,
        get_dynamic_repo: nil,
        insert_trigger: true,
        log: false,
        name: Oban,
        node: "service@172.18.0.1",
        notifier: {Oban.Notifiers.Postgres, []},
        peer: {Oban.Peers.Postgres, []},
        plugins: [{Oban.Plugins.Pruner, [max_age: 43200]}],
        prefix: "public",
        queues: [default: [limit: 10]],
        repo: Service.Repo,
        shutdown_grace_period: 15000,
        stage_interval: 1000,
        testing: :disabled
      },
      from: nil,
      key: nil,
      channels: %{
        "public.oban_insert" => [#PID<0.13379.92>],
        "public.oban_leader" => [#PID<0.3787.0>],
        "public.oban_signal" => [#PID<0.13379.92>, #PID<0.3789.0>],
        "public.oban_sonar" => [#PID<0.3788.0>]
      },
      connected?: false,
      listeners: %{
        #PID<0.3787.0> => {#Reference<0.1812357926.8388665.136456>,
         MapSet.new(["public.oban_leader"])},
        #PID<0.3788.0> => {#Reference<0.1812357926.8388663.136221>,
         MapSet.new(["public.oban_sonar"])},
        #PID<0.3789.0> => {#Reference<0.1812357926.8388663.136235>,
         MapSet.new(["public.oban_signal"])},
        #PID<0.13379.92> => {#Reference<0.1812357926.47972356.224570>,
         MapSet.new(["public.oban_insert", "public.oban_signal"])}
      }
    }}
 }, {:next_event, :internal, {:connect, :reconnect}}}

08:09:21.325981 <0.3785.0> Postgrex.SimpleConnection.handle_event(:internal, {:connect, :reconnect}, :no_state, %Postgrex.SimpleConnection{
  idle_interval: 5000,
  protocol: %Postgrex.Protocol{
    sock: {:gen_tcp, #Port<0.84514854>},
    connection_id: 3537365,
    connection_key: 904133435,
    peer: {{10, 129, 1, 100}, 5432},
    types: {Postgrex.DefaultTypes, #Reference<0.1812357926.8519733.135683>},
    null: nil,
    timeout: 15000,
    ping_timeout: 15000,
    parameters: #Reference<0.1812357926.1244921861.105622>,
    queries: nil,
    postgres: :idle,
    transactions: :naive,
    buffer: :active_once,
    disconnect_on_error_codes: [],
    scram: ...,
    disable_composite_types: false
  },
  auto_reconnect: true,
  reconnect_backoff: 500,
  state: {Oban.Notifiers.Postgres,
   %Oban.Notifiers.Postgres{
     conf: %Oban.Config{
       dispatch_cooldown: 5,
       engine: Oban.Engines.Basic,
       get_dynamic_repo: nil,
       insert_trigger: true,
       log: false,
       name: Oban,
       node: "service@172.18.0.1",
       notifier: {Oban.Notifiers.Postgres, []},
       peer: {Oban.Peers.Postgres, []},
       plugins: [{Oban.Plugins.Pruner, [max_age: 43200]}],
       prefix: "public",
       queues: [default: [limit: 10]],
       repo: Service.Repo,
       shutdown_grace_period: 15000,
       stage_interval: 1000,
       testing: :disabled
     },
     from: nil,
     key: nil,
     channels: %{
       "public.oban_insert" => [#PID<0.13379.92>],
       "public.oban_leader" => [#PID<0.3787.0>],
       "public.oban_signal" => [#PID<0.13379.92>, #PID<0.3789.0>],
       "public.oban_sonar" => [#PID<0.3788.0>]
     },
     connected?: false,
     listeners: %{
       #PID<0.3787.0> => {#Reference<0.1812357926.8388665.136456>,
        MapSet.new(["public.oban_leader"])},
       #PID<0.3788.0> => {#Reference<0.1812357926.8388663.136221>,
        MapSet.new(["public.oban_sonar"])},
       #PID<0.3789.0> => {#Reference<0.1812357926.8388663.136235>,
        MapSet.new(["public.oban_signal"])},
       #PID<0.13379.92> => {#Reference<0.1812357926.47972356.224570>,
        MapSet.new(["public.oban_insert", "public.oban_signal"])}
     }
   }}
})
```