### PR TITLE
Allow comments as iodata.

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -67,9 +67,7 @@ defmodule Postgrex do
   @max_rows 500
   @timeout 15_000
 
-  @comment_validation_error Postgrex.Error.exception(
-                              message: "`:comment` option cannot contain sequence \"*/\""
-                            )
+  @comment_validation_error Postgrex.Error.exception(message: "`:comment` not an iodata term")
 
   ### PUBLIC API ###
 
@@ -332,15 +330,9 @@ defmodule Postgrex do
 
   defp comment_not_present!(opts) do
     case Keyword.get(opts, :comment) do
-      nil ->
-        true
-
-      comment when is_binary(comment) ->
-        if String.contains?(comment, "*/") do
-          raise @comment_validation_error
-        else
-          false
-        end
+      nil -> true
+      comment when is_binary(comment) or is_list(comment) -> false
+      _ -> raise @comment_validation_error
     end
   end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1595,8 +1595,9 @@ defmodule Postgrex.Protocol do
     transaction_error(s, postgres)
   end
 
-  defp parse_describe_comment_msgs(query, comment, tail) when is_binary(comment) do
-    statement = [query.statement, "/*", comment, "*/"]
+  defp parse_describe_comment_msgs(query, comment, tail)
+       when is_binary(comment) or is_list(comment) do
+    statement = [query.statement, ";/*", comment, "*/"]
     query = %{query | statement: statement}
     parse_describe_msgs(query, tail)
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1851,12 +1851,28 @@ defmodule QueryTest do
     assert [["1", "2"], ["3", "4"]] = query("COPY (VALUES (1, 2), (3, 4)) TO STDOUT", [], opts)
   end
 
-  test "comment", context do
+  test "binary comment" do
     assert [[123]] = query("select 123", [], comment: "query comment goes here")
+  end
 
+  test "iodata comment" do
+    assert [[123]] = query("select 123", [], comment: ["query", ?=, ?', "comment", ?'])
+  end
+
+  test "comment validation error when comment is not iodata" do
     assert_raise Postgrex.Error, fn ->
-      query("select 123", [], comment: "*/ DROP TABLE 123 --")
+      query("select 123", [], comment: 123)
     end
+  end
+
+  test "comment error when comment tries sql injection" do
+    assert %Postgrex.Error{
+             postgres: %{
+               code: :syntax_error,
+               message: "cannot insert multiple commands into a prepared statement"
+             }
+           } =
+             query("select now()", [], comment: "*/ select sleep(1000)--")
   end
 
   @tag :big_binary

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1851,21 +1851,21 @@ defmodule QueryTest do
     assert [["1", "2"], ["3", "4"]] = query("COPY (VALUES (1, 2), (3, 4)) TO STDOUT", [], opts)
   end
 
-  test "binary comment" do
+  test "binary comment", context do
     assert [[123]] = query("select 123", [], comment: "query comment goes here")
   end
 
-  test "iodata comment" do
+  test "iodata comment", context do
     assert [[123]] = query("select 123", [], comment: ["query", ?=, ?', "comment", ?'])
   end
 
-  test "comment validation error when comment is not iodata" do
+  test "comment validation error when comment is not iodata", context do
     assert_raise Postgrex.Error, fn ->
       query("select 123", [], comment: 123)
     end
   end
 
-  test "comment error when comment tries sql injection" do
+  test "comment error when comment tries sql injection", context do
     assert %Postgrex.Error{
              postgres: %{
                code: :syntax_error,


### PR DESCRIPTION
When I wrote the test for the original implementation, I noticed that it couldn't be exploited when there was a `;` at the end of the original statement. Postgres returned an error stating, `cannot insert multiple commands into a prepared statement.` Initially, I abandoned this idea as I didn't want to be the person who introduced SQLI into Postgrex. However, the more I think about it, the more useful it seems to remove the binary requirement for scanning. Without validation, we can use Iodata. 

I sought advice and even posted a potentially vulnerable app on a security forum. I also conducted a self-scan using SQLMap, and it seems safe. Golang PGX is using this. 

The only issue I found was at https://adeadfed.com/posts/postgresql-select-only-rce/, but I don't think it can be used after `;` looking at the example. I tried but no luck.
Also sqlcommenter specification require to escape the string.