### PR TITLE
check_for_null_in_comment

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -68,7 +68,8 @@ defmodule Postgrex do
   @timeout 15_000
 
   @comment_validation_error Postgrex.Error.exception(
-                              message: "`:comment` option cannot contain sequence \"*/\""
+                              message:
+                                "`:comment` option cannot contain null bytes and \"*/\" sequence"
                             )
 
   ### PUBLIC API ###
@@ -336,7 +337,7 @@ defmodule Postgrex do
         true
 
       comment when is_binary(comment) ->
-        if String.contains?(comment, "*/") do
+        if String.contains?(comment, [<<0>>, "*/"]) do
           raise @comment_validation_error
         else
           false

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1857,6 +1857,10 @@ defmodule QueryTest do
     assert_raise Postgrex.Error, fn ->
       query("select 123", [], comment: "*/ DROP TABLE 123 --")
     end
+
+    assert_raise Postgrex.Error, fn ->
+      query("select 123", [], comment: <<0>> <> "comment")
+    end
   end
 
   @tag :big_binary


### PR DESCRIPTION
I'm not sure if it makes sense to precompile binary pattern for that? 