### PR TITLE
replication connection respects reconnect_backoff option

### DIFF
--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -487,6 +487,7 @@ defmodule Postgrex.ReplicationConnection do
   def handle_event(type, content, state, s)
 
   def handle_event({:timeout, :backoff}, nil, @state, s) do
+    Process.sleep(s.reconnect_backoff)
     {:keep_state, s, {:next_event, :internal, {:connect, :backoff}}}
   end
 


### PR DESCRIPTION
Replication Connection's {:timeout, :backoff} action does not wait for the time as reconnect_backoff option set.