### PR TITLE
Call disconnect on protocol when reconnecting in Replication connection 

### DIFF
--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -490,6 +490,12 @@ defmodule Postgrex.ReplicationConnection do
     {:keep_state, s, {:next_event, :internal, {:connect, :backoff}}}
   end
 
+  def handle_event(:internal, {:connect, :reconnect}, @state, %{protocol: protocol} = state)
+      when protocol != nil do
+    Protocol.disconnect(:reconnect, protocol)
+    {:keep_state, %{state | protocol: nil}, {:next_event, :internal, {:connect, :init}}}
+  end
+
   def handle_event(:internal, {:connect, _info}, @state, %{state: {mod, mod_state}} = s) do
     case Protocol.connect(opts()) do
       {:ok, protocol} ->

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -502,6 +502,10 @@ defmodule Postgrex.ReplicationConnection do
         maybe_handle(mod, :handle_connect, [mod_state], %{s | protocol: protocol})
 
       {:error, reason} ->
+        Logger.error(
+          "#{inspect(pid_or_name())} (#{inspect(mod)}) failed to connect to Postgres: #{Exception.format(:error, reason)}"
+        )
+
         if s.auto_reconnect do
           {:keep_state, s, {{:timeout, :backoff}, s.reconnect_backoff, nil}}
         else

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -362,6 +362,10 @@ defmodule Postgrex.SimpleConnection do
         end
 
       {:error, reason} ->
+        Logger.error(
+          "#{inspect(pid_or_name())} (#{inspect(mod)}) failed to connect to Postgres: #{Exception.format(:error, reason)}"
+        )
+
         if state.auto_reconnect do
           {:keep_state, state, {{:timeout, :backoff}, state.reconnect_backoff, nil}}
         else
@@ -463,6 +467,13 @@ defmodule Postgrex.SimpleConnection do
       {:keep_state, state, {:next_event, :internal, {:connect, :reconnect}}}
     else
       {:stop, reason, %{state | protocol: protocol}}
+    end
+  end
+
+  defp pid_or_name do
+    case Process.info(self(), :registered_name) do
+      {:registered_name, atom} when is_atom(atom) -> atom
+      _ -> self()
     end
   end
 


### PR DESCRIPTION
### Problems
- When the ReplicationConnection encounters a socket error, it reconnects to another socket without properly closing the current one (similar to #717).
- When the ReplicationConnection fails to establish a connection, it doesn’t log any errors and simply retries indefinitely.

### Worst Case Scenario
If Postgres terminates a replication connection process due to an OOM issue or a network error:

- Postgrex creates a new ReplicationConnection without closing the previous one.
- This repeats up to 10 times. (with auto_reconnect option)
- The max_wal_senders limit (default: 10) is reached, preventing new ReplicationConnection from being created.
- The system enters a silent infinite loop of reconnecting without any logs.

This issue has occurred in my production app during periods of network instability.

<img width="1023" alt="Screenshot 2025-01-22 at 6 39 53 PM" src="https://github.com/user-attachments/assets/33d9ffa1-d845-4dcb-86f7-e262c9f75d4c" />


## Commit Changes
- Invoke disconnect on the protocol when reconnecting to a ReplicationConnection.
- Log an error message when a ReplicationConnection fails to establish a connection.




