### PR TITLE
Use cacerts on verify peer

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -166,7 +166,8 @@ defmodule Postgrex.Protocol do
       verify: :verify_peer,
       customize_hostname_check: [
         match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-      ]
+      ],
+      cacerts: :public_key.cacerts_get()
     ]
   end
 


### PR DESCRIPTION
Otherwise SSL fails, for example:

```
iex(1)> :ssl.connect ~c"google.com", 443, [verify: :verify_peer]
{:error, {:options, :incompatible, [verify: :verify_peer, cacerts: :undefined]}}
```