### PR TITLE
Prioritize explicit endpoint options over PGHOST-derived defaults

### DIFF
--- a/test/utils/envs_test.exs
+++ b/test/utils/envs_test.exs
@@ -72,4 +72,37 @@ defmodule Utils.EnvsTest do
       assert ctx.opts[:socket] == <<0, "foo">>
     end
   end
+
+  describe "PGHOST with manual overrides" do
+    @env PGHOST: "/test/socket"
+    test "respects explicit hostname even if PGHOST is set" do
+      opts = Postgrex.Utils.default_opts(hostname: "localhost")
+
+      assert Keyword.get(opts, :hostname) == "localhost"
+      refute Keyword.has_key?(opts, :socket_dir)
+    end
+
+    @env PGHOST: "/test/socket"
+    test "respects explicit endpoints even if PGHOST is set" do
+      opts = Postgrex.Utils.default_opts(endpoints: [{"localhost", 5432}])
+
+      assert Keyword.get(opts, :endpoints) == [{"localhost", 5432}]
+      refute Keyword.has_key?(opts, :socket_dir)
+    end
+
+    @env PGHOST: "/test/socket"
+    test "respects explicit socket even if PGHOST is set" do
+      opts = Postgrex.Utils.default_opts(socket: "/var/run/postgresql")
+
+      assert Keyword.get(opts, :socket) == "/var/run/postgresql"
+      refute Keyword.has_key?(opts, :socket_dir)
+    end
+
+    @env PGHOST: "/test/socket"
+    test "respects explicit socket_dir even if PGHOST is set" do
+      opts = Postgrex.Utils.default_opts(socket_dir: "/another/test/socket")
+
+      assert Keyword.get(opts, :socket_dir) == "/another/test/socket"
+    end
+  end
 end


### PR DESCRIPTION
Hello! First of all, thank you for this amazing library

This PR addresses a bug where setting the `PGHOST` environment variable can unintentionally override explicitly passed connection options like `:hostname`, `:socket_dir`, `:socket`, or `:endpoints`.

## Summary

- Fix: Updated `default_opts/1` to derive the host from `PGHOST` **only if** no endpoint-related options are explicitly provided (`:socket`, `:socket_dir`, `:hostname`, or `:endpoints`).
- Test: Added test coverage to ensure that explicitly provided connection options correctly take precedence over environment-derived defaults.
- Important note: This might cause breaking changes to existing users if they might be inadvertently overriding values that are currently ignored.

## Motivation

When `PGHOST` is set (e.g., to a Unix socket path), Postgrex currently prioritizes it over explicitly passed options like `:hostname`. This causes surprising behavior: users trying to connect to a remote host (e.g., localhost over TCP) may find Postgrex silently attempting to connect over a non-existent socket.

This PR brings Postgrex closer in behavior to `psql`, which properly prioritizes CLI-supplied options over `PGHOST`.


---


## Replication Instructions

You can reproduce the issue as follows:

1. Set `PGHOST` to any path:
    ```sh
    PGHOST=/whatever iex -S mix
    ```
   
2. Attempt to start a connection using valid TCP settings:

    Expected: Should connect over TCP to `localhost`
    Actual: Fails, as Postgrex attempts to connect via `/whatever/.s.PGSQL.5432` socket specified via PGHOST.

    ```elixir
    {:ok, pid} = Postgrex.start_link(
      hostname: "localhost",
      username: "postgres",
      password: "postgres",
      database: "postgres",
      port: 5432
    )
    
    Postgrex.query(pid, "SELECT 1", [])
    ```


3. Current workaround (demonstrating expected behavior with a workaround using manual override to `socket_dir: nil`):

    ```elixir
    {:ok, pid} = Postgrex.start_link(
      hostname: "localhost",
      username: "postgres",
      password: "postgres",
      database: "postgres",
      port: 5432,
      socket_dir: nil
    )
    
    Postgrex.query(pid, "SELECT 1", [])
    ```

## Behavior Comparison with `psql`

To reinforce expected behavior, here’s how `psql` treats similar inputs:

Explicit `-h localhost` takes precedence over `PGHOST`:

```sh
PGHOST=/whatever psql -d postgres -h localhost -U postgres -c "SELECT 1"
```

This should fail as no `-h` is provided and the `PGHOST` socket doesn't exist

```sh
PGHOST=/whatever psql -d postgres -U postgres -c "SELECT 1"
```