### PR TITLE
Add ssl_negotiation_direct option

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -48,6 +48,7 @@ defmodule Postgrex do
           | {:handshake_timeout, timeout}
           | {:ping_timeout, timeout}
           | {:ssl, boolean | [:ssl.tls_client_option()]}
+          | {:ssl_negotiation_direct, boolean}
           | {:socket_options, [:gen_tcp.connect_option()]}
           | {:prepare, :named | :unnamed}
           | {:transactions, :strict | :naive}
@@ -124,6 +125,10 @@ defmodule Postgrex do
       `:cacerts` or `:cacertfile` set to a CA trust store, to enable server certificate
       verification. Defaults to `false`;
 
+    * `:ssl_negotiation_direct - Initiate directly SSL handshake without asking server if it supports it.
+      Use this option for networks that only allow TLS traffic and you already know the server supports
+      SSL. Defaults to `false`; Requires ssl: true or configured
+
     * `:socket_options` - Options to be given to the underlying socket
       (applies to both TCP and UNIX sockets);
 
@@ -197,6 +202,19 @@ defmodule Postgrex do
   The server name indication (SNI) will be automatically set based on the `:hostname`
   configuration, if one was provided. Other options, such as `depth: 3`, may be necessary
   depending on the server.
+
+  ## sslnegotiation direct
+
+  Start the SSL handshake before asking the Postgres server if it supports SSL
+
+  [ssl_negotiation_direct: true]
+
+  Usually the client driver will ask the server if it supports SSL in plain
+  text before establishing the SSL connection, this doesn't work in networks
+  that only allow TLS traffic, more common on corporate or cloud environments
+  (like AWS PrivateLink, Google Cloud SQL).
+
+  This option only has effect when [ssl: true] or configured
 
   ## PgBouncer
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -804,6 +804,10 @@ defmodule Postgrex.Protocol do
 
   ## ssl
 
+  defp ssl(s, %{opts: %{ ssl_negotiaton_direct: true}} = status, ssl_opts) do
+    ssl_recv(s, status, ssl_opts)
+  end
+
   defp ssl(s, status, ssl_opts) do
     case msg_send(s, msg_ssl_request(), "") do
       :ok -> ssl_recv(s, status, ssl_opts)

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -103,6 +103,7 @@ defmodule Postgrex.Utils do
     |> Keyword.put_new(:port, System.get_env("PGPORT"))
     |> Keyword.update!(:port, &normalize_port/1)
     |> Keyword.put_new(:types, Postgrex.DefaultTypes)
+    |> Keyword.put_new(:ssl_negotiation_direct, false)
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
   end
 

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -88,6 +88,14 @@ defmodule LoginTest do
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
+  @tag :ssl
+  test "ssl negotiation direct", context do
+    opts = [ssl: true, ssl_negotiation_direct: true]
+
+    assert {:ok, pid} = P.start_link(opts ++ context[:options])
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+  end
+
   test "env var defaults", context do
     assert {:ok, pid} = P.start_link(context[:options])
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])


### PR DESCRIPTION
Adds `ssl_negotiation_direct` option

Added in Postgresql 17 libpq and client drivers that use it already support this option, it was introduced to save a round trip and also help with networks and infrastructure setups that only allow TLS traffic. More common in corporate networks or cloud environments (for example AWS Privatelinks).

Without this option it is necessary to run a proxy to deal with the upgrade of the connection to TLS before contacting the Posgres server.

This is my first contribution here and to an elixir lib, so let me know if you want me to change/add anything and if its appropriate for inclusion.