### PR TITLE
Add support for the :json library

### DIFF
--- a/lib/postgrex/extensions/jsonb.ex
+++ b/lib/postgrex/extensions/jsonb.ex
@@ -3,12 +3,13 @@ defmodule Postgrex.Extensions.JSONB do
   import Postgrex.BinaryUtils, warn: false
 
   def init(opts) do
-    json =
+    json_library =
       Keyword.get_lazy(opts, :json, fn ->
-        Application.get_env(:postgrex, :json_library, Jason)
+        default = default_json_backend()
+        Application.get_env(:postgrex, :json_library, default)
       end)
 
-    {json, Keyword.get(opts, :decode_binary, :copy)}
+    {encode_fn(json_library), decode_fn(json_library), Keyword.get(opts, :decode_binary, :copy)}
   end
 
   def matching({nil, _}),
@@ -20,30 +21,50 @@ defmodule Postgrex.Extensions.JSONB do
   def format(_),
     do: :binary
 
-  def encode({library, _}) do
+  def encode({encode_fn, _decode_fn, _}) do
     quote location: :keep do
       map ->
-        data = unquote(library).encode_to_iodata!(map)
+        data = unquote(encode_fn).(map)
         [<<IO.iodata_length(data) + 1::int32(), 1>> | data]
     end
   end
 
-  def decode({library, :copy}) do
+  def decode({_encode_fn, decode_fn, :copy}) do
     quote location: :keep do
       <<len::int32(), data::binary-size(len)>> ->
         <<1, json::binary>> = data
 
         json
         |> :binary.copy()
-        |> unquote(library).decode!()
+        |> unquote(decode_fn).()
     end
   end
 
-  def decode({library, :reference}) do
+  def decode({_encode_fn, decode_fn, :reference}) do
     quote location: :keep do
       <<len::int32(), data::binary-size(len)>> ->
         <<1, json::binary>> = data
-        unquote(library).decode!(json)
+        unquote(decode_fn).(json)
     end
   end
+
+  defp encode_fn(:json), do: &:json.encode/1
+  defp encode_fn(json_library), do: &json_library.encode_to_iodata!/1
+
+  defp decode_fn(:json), do: &:json.decode/1
+  defp decode_fn(json_library), do: &json_library.decode!/1
+
+  defp default_json_backend() do
+    try do
+      # NOTE: it is not possible to see if the module is loaded, since it may
+      # not be as it is only loaded on first use. So we try to use it with apply
+      # which throws an exception if it doesn't not exist without also emitting
+      # warnings to the logger.
+      apply(&:json.encode/1, [""])
+      :json
+    rescue
+      _ -> Jason
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds support for the recently added built-in :json library.

It does this by checking to see if `:json` is available at runtime, and then binding the correct encode/decode functions which, unfortunately, vary  between libraries.

This PR allows one to drop a dependency when using Postgrex.