### PR TITLE
Update PgBouncer docs around prepared statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,13 @@ query("select nextval($1)", [sequence_oid])
 
 ## PgBouncer
 
-When using PgBouncer with transaction or statement pooling named prepared
-queries can not be used because the bouncer may route requests from the same
-postgrex connection to different PostgreSQL backend processes and discards named
-queries after the transactions closes. To force unnamed prepared queries:
+PgBouncer versions 1.21.0 and later support named prepared statements. If you are using an older version of PgBouncer with transaction or statement pooling, named prepared queries cannot be used because the bouncer may route requests from the same Postgrex connection to different PostgreSQL backend processes and discards named queries after the transaction closes. To force unnamed prepared queries in such older versions:
 
 ```elixir
 Postgrex.start_link(prepare: :unnamed)
 ```
+
+[PgBouncer 1.21.0 release notes](https://www.pgbouncer.org/changelog.html#pgbouncer-121x)
 
 ## Contributing
 

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -200,11 +200,11 @@ defmodule Postgrex do
 
   ## PgBouncer
 
-  When using PgBouncer with transaction or statement pooling named prepared
-  queries can not be used because the bouncer may route requests from
-  the same postgrex connection to different PostgreSQL backend processes
-  and discards named queries after the transactions closes.
-  To force unnamed prepared queries set the `:prepare` option to `:unnamed`.
+  PgBouncer versions 1.21.0 and later support named prepared statements. If you are using an
+  older version of PgBouncer with transaction or statement pooling, named prepared queries
+  cannot be used because the bouncer may route requests from the same Postgrex connection
+  to different PostgreSQL backend processes and discards named queries after the transaction closes.
+  To force unnamed prepared queries in such older versions, set the `:prepare` option to `:unnamed`.
 
   ## Handling failover
 


### PR DESCRIPTION
So PgBouncer actually supports named prepared statements after 1.21.0 (release in late 2023)

I thought we might benefit from updating the docs so we don't confuse developers using new versions of PgBouncer

(Also named prepared statements have some advantages when it comes around re-using query execution plans)