### PR TITLE
Make timeouts for TypeServer configurable

### DIFF
--- a/lib/postgrex/type_server.ex
+++ b/lib/postgrex/type_server.ex
@@ -5,8 +5,6 @@ defmodule Postgrex.TypeServer do
 
   defstruct [:types, :connections, :lock, :waiting]
 
-  @timeout 60_000
-
   @doc """
   Starts a type server.
   """
@@ -24,8 +22,10 @@ defmodule Postgrex.TypeServer do
   @spec fetch(pid) ::
           {:lock, reference, Postgrex.Types.state()} | :noproc | :error
   def fetch(server) do
+    timeout = Application.fetch_env!(:postgrex, :type_server_timeout)
+
     try do
-      GenServer.call(server, :fetch, @timeout)
+      GenServer.call(server, :fetch, timeout)
     catch
       # module timed out, pretend it did not exist.
       :exit, {:normal, _} -> :noproc
@@ -38,7 +38,8 @@ defmodule Postgrex.TypeServer do
   """
   @spec update(pid, reference, [Postgrex.TypeInfo.t()]) :: :ok
   def update(server, ref, [_ | _] = type_infos) do
-    GenServer.call(server, {:update, ref, type_infos}, @timeout)
+    timeout = Application.fetch_env!(:postgrex, :type_server_timeout)
+    GenServer.call(server, {:update, ref, type_infos}, timeout)
   end
 
   def update(server, ref, []) do

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Postgrex.Mixfile do
     [
       extra_applications: [:logger, :crypto, :ssl],
       mod: {Postgrex.App, []},
-      env: [type_server_reap_after: 3 * 60_000, json_library: Jason]
+      env: [type_server_reap_after: 3 * 60_000, type_server_timeout: 60_000, json_library: Jason]
     ]
   end
 


### PR DESCRIPTION
We were testing out YugabyteDB with nodes in Australia, France, and the Eastern US and found that Postgrex connections were consistently failing to startup when connecting to nodes in France or Australia if we wanted to have a pool size greater than one.

The root cause is that the bootstrap queries Postgrex makes are taking a lot longer than the 60 seconds the TypeServer allows while a connection is waiting to get the lock.

This is because the first query of a connection forces the node to cache cluster information from the leader node, which can take a long time when the leader is on the opposite side of the world.

Yugabyte has "smart" drivers that are able to work around this issue, but there isn't one in Elixir so the simplest solution would be us being able to raise this timeout to a much higher number.