### PR TITLE
Improve SSL docs

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -119,10 +119,10 @@ defmodule Postgrex do
     * `:idle_interval` - Ping connections after a period of inactivity in milliseconds.
       Defaults to 1000ms;
 
-    * `:ssl` - Enables SSL. Setting it to `true` enables SSL without server certificate verification,
-      which emits a warning. Instead, prefer to set it to a keyword list, with either
-      `:cacerts` or `:cacertfile` set to a CA trust store, to enable server certificate
-      verification. Defaults to `false`;
+    * `:ssl` - Enables SSL. Set to:
+       - false (default): no SSL.
+       - true: enable SSL with secure defaults, including peer certificate verification and hostname checking.
+       - keyword list of `t::ssl.tls_client_option()/0` values: enable SSL and merge your options on top of secure defaults.
 
     * `:socket_options` - Options to be given to the underlying socket
       (applies to both TCP and UNIX sockets);


### PR DESCRIPTION
I believe the implementation is actually more secure by default than the documentation suggests.

By setting SSL to true, [`:cacerts` is configured](https://github.com/elixir-ecto/postgrex/blob/f20274a7c88f795f9126925c7e9e237aa8de9615/lib/postgrex/protocol.ex#L98), [and `verify_peer` and `pkix_verify_hostname_match_fun` are set](https://github.com/elixir-ecto/postgrex/blob/f20274a7c88f795f9126925c7e9e237aa8de9615/lib/postgrex/protocol.ex#L166-L171).
The current documentation claims that these are not set.