### PR TITLE
Add text query support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - text_query
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - text_query
   pull_request:
 
 jobs:

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1,7 +1,7 @@
 defmodule Postgrex.Protocol do
   @moduledoc false
 
-  alias Postgrex.{Types, TypeServer, Query, Cursor, Copy}
+  alias Postgrex.{Types, TypeServer, Query, TextQuery, TextQueries, Cursor, Copy}
   import Postgrex.{Messages, BinaryUtils}
   require Logger
   use DBConnection
@@ -54,6 +54,9 @@ defmodule Postgrex.Protocol do
         }
 
   @type notify :: (binary, binary -> any)
+
+  @type binary_or_text_query ::
+          Postgrex.Query.t() | Postgrex.TextQuery.t() | Postgrex.TextQueries.t()
 
   defmacrop new_status(opts, fields \\ []) do
     defaults =
@@ -421,8 +424,9 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  @spec handle_execute(Postgrex.Query.t(), list, Keyword.t(), state) ::
-          {:ok, Postgrex.Query.t(), Postgrex.Result.t() | Postgrex.Copy.t(), state}
+  @spec handle_execute(binary_or_text_query, list, Keyword.t(), state) ::
+          {:ok, binary_or_text_query,
+           Postgrex.Result.t() | [Postgrex.Result.t()] | Postgrex.Copy.t(), state}
           | {:error, %ArgumentError{} | Postgrex.Error.t(), state}
           | {:error, %DBConnection.TransactionError{}, state}
           | {:disconnect, %RuntimeError{}, state}
@@ -434,6 +438,26 @@ defmodule Postgrex.Protocol do
 
       false ->
         handle_execute_result(query, params, opts, s)
+    end
+  end
+
+  def handle_execute(%TextQuery{statement: statement} = query, [], opts, s) do
+    case handle_simple(statement, opts, s) do
+      {:ok, [first_result | _], s} ->
+        {:ok, query, first_result, s}
+
+      {error, _, _} = other when error in [:error, :disconnect] ->
+        other
+    end
+  end
+
+  def handle_execute(%TextQueries{statement: statement} = query, [], opts, s) do
+    case handle_simple(statement, opts, s) do
+      {:ok, results, s} ->
+        {:ok, query, results, s}
+
+      {error, _, _} = other when error in [:error, :disconnect] ->
+        other
     end
   end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1,7 +1,7 @@
 defmodule Postgrex.Protocol do
   @moduledoc false
 
-  alias Postgrex.{Types, TypeServer, Query, TextQuery, TextQueries, Cursor, Copy}
+  alias Postgrex.{Types, TypeServer, Query, TextQuery, Cursor, Copy}
   import Postgrex.{Messages, BinaryUtils}
   require Logger
   use DBConnection
@@ -55,8 +55,7 @@ defmodule Postgrex.Protocol do
 
   @type notify :: (binary, binary -> any)
 
-  @type binary_or_text_query ::
-          Postgrex.Query.t() | Postgrex.TextQuery.t() | Postgrex.TextQueries.t()
+  @type binary_or_text_query :: Postgrex.Query.t() | Postgrex.TextQuery.t()
 
   defmacrop new_status(opts, fields \\ []) do
     defaults =
@@ -445,16 +444,6 @@ defmodule Postgrex.Protocol do
     case handle_simple(statement, opts, s) do
       {:ok, [first_result | _], s} ->
         {:ok, query, first_result, s}
-
-      {error, _, _} = other when error in [:error, :disconnect] ->
-        other
-    end
-  end
-
-  def handle_execute(%TextQueries{statement: statement} = query, [], opts, s) do
-    case handle_simple(statement, opts, s) do
-      {:ok, results, s} ->
-        {:ok, query, results, s}
 
       {error, _, _} = other when error in [:error, :disconnect] ->
         other

--- a/lib/postgrex/text_query.ex
+++ b/lib/postgrex/text_query.ex
@@ -24,7 +24,7 @@ defimpl DBConnection.Query, for: [Postgrex.TextQuery, Postgrex.TextQueries] do
   def decode(_query, result, _opts), do: result
 end
 
-defimpl String.Chars, for: [Postgrex.TextQuery, Postgrex.TextQuery] do
+defimpl String.Chars, for: [Postgrex.TextQuery, Postgrex.TextQueries] do
   def to_string(%{statement: statement}) do
     IO.iodata_to_binary(statement)
   end

--- a/lib/postgrex/text_query.ex
+++ b/lib/postgrex/text_query.ex
@@ -1,0 +1,31 @@
+defmodule Postgrex.TextQuery do
+  @moduledoc false
+
+  defstruct [:statement]
+end
+
+defmodule Postgrex.TextQueries do
+  @moduledoc false
+
+  defstruct [:statement]
+end
+
+defimpl DBConnection.Query, for: [Postgrex.TextQuery, Postgrex.TextQueries] do
+  def parse(query, _opts), do: query
+
+  def describe(query, _opts), do: query
+
+  def encode(_query, [], _opts), do: []
+
+  def encode(_query, params, _opts) do
+    raise ArgumentError, "text queries cannot use parameters, got: #{inspect(params)}"
+  end
+
+  def decode(_query, result, _opts), do: result
+end
+
+defimpl String.Chars, for: [Postgrex.TextQuery, Postgrex.TextQuery] do
+  def to_string(%{statement: statement}) do
+    IO.iodata_to_binary(statement)
+  end
+end

--- a/lib/postgrex/text_query.ex
+++ b/lib/postgrex/text_query.ex
@@ -4,13 +4,7 @@ defmodule Postgrex.TextQuery do
   defstruct [:statement]
 end
 
-defmodule Postgrex.TextQueries do
-  @moduledoc false
-
-  defstruct [:statement]
-end
-
-defimpl DBConnection.Query, for: [Postgrex.TextQuery, Postgrex.TextQueries] do
+defimpl DBConnection.Query, for: Postgrex.TextQuery do
   def parse(query, _opts), do: query
 
   def describe(query, _opts), do: query
@@ -24,7 +18,7 @@ defimpl DBConnection.Query, for: [Postgrex.TextQuery, Postgrex.TextQueries] do
   def decode(_query, result, _opts), do: result
 end
 
-defimpl String.Chars, for: [Postgrex.TextQuery, Postgrex.TextQueries] do
+defimpl String.Chars, for: Postgrex.TextQuery do
   def to_string(%{statement: statement}) do
     IO.iodata_to_binary(statement)
   end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/postgrex/issues/757

We didn't discuss this so I'm completely ok discarding it if the decision is to not add it.

The idea came from a google group message here: https://groups.google.com/g/elixir-ecto/c/mooS_UwcuwU. Basically they are trying to use Postgres's explain generic plan statement (e.g. `EXPLAIN (GENERIC_PLAN) SELECT * FROM pg_class WHERE relname = $1;`) but it does not play nice with the binary protocol because it thinks you need to supply $1 instead of it just being  a signal that it's a generic query that you want explained.

Aside from the one specific use case, they also mentioned they are using livebook. And that got me thinking it might be cool to be able to use livebook like an alternative to psql where you can just type in your queries and not worry about binary types and extensions and all that.

I didn't add query_many because it's a bit weird and I would have to think about the implementation. The reason it's weird is because it would only work for the text protocol. So I didn't want to think of a solution if we will not go this direction at all.