### PR TITLE
Set process labels

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -229,6 +229,7 @@ defmodule Postgrex.Protocol do
     with {:ok, database} <- fetch_database(opts),
          status = %{status | types_key: if(types_mod, do: {host, port, database})},
          {:ok, ret} <- connect_and_handshake(host, port, sock_opts, timeout, s, status) do
+      Postgrex.Utils.set_label({Postgrex.Protocol, database})
       {:ok, ret}
     else
       {:error, err} ->
@@ -1907,7 +1908,12 @@ defmodule Postgrex.Protocol do
     end)
 
     ref = make_ref()
-    {_, mon} = spawn_monitor(fn -> reload_init(s, status, oids, ref, buffer) end)
+
+    {_, mon} =
+      spawn_monitor(fn ->
+        Postgrex.Utils.set_label({Postgrex.Protocol, :fetch_type_info})
+        reload_init(s, status, oids, ref, buffer)
+      end)
 
     receive do
       {:DOWN, ^mon, _, _, {^ref, s, buffer}} ->

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -466,6 +466,8 @@ defmodule Postgrex.ReplicationConnection do
   @doc false
   @impl :gen_statem
   def init({mod, arg, opts}) do
+    Postgrex.Utils.set_label({Postgrex.ReplicationConnection, mod})
+
     case mod.init(arg) do
       {:ok, mod_state} ->
         opts =

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -299,6 +299,8 @@ defmodule Postgrex.SimpleConnection do
   @doc false
   @impl :gen_statem
   def init({mod, args, opts}) do
+    Postgrex.Utils.set_label({Postgrex.SimpleConnection, mod})
+
     case mod.init(args) do
       {:ok, mod_state} ->
         idle_timeout = opts[:idle_timeout]

--- a/lib/postgrex/type_server.ex
+++ b/lib/postgrex/type_server.ex
@@ -57,6 +57,7 @@ defmodule Postgrex.TypeServer do
   ## Callbacks
 
   def init({module, starter}) do
+    Postgrex.Utils.set_label({Postgrex.TypeServer, module})
     _ = Process.flag(:trap_exit, true)
     Process.link(starter)
 

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -170,6 +170,17 @@ defmodule Postgrex.Utils do
 
   ## Helpers
 
+  @doc """
+  Set a process label if `Process.set_label/1` is available.
+  """
+  def set_label(label) do
+    if function_exported?(Process, :set_label, 1) do
+      apply(Process, :set_label, [label])
+    else
+      :ok
+    end
+  end
+
   defp parse_version_bit(bit) do
     {int, _} = Integer.parse(bit)
     int


### PR DESCRIPTION
This makes it easier to understand the process tree in tools like Observer and Phoenix LiveDashboard and gives clearer errors for crashes.

<img width="1650" height="226" alt="CleanShot 2026-03-12 at 16 46 18@2x" src="https://github.com/user-attachments/assets/2b31e11d-ec1d-4f60-a1ba-c7708d32bc46" />


**Update** - after discussion, I updated this label to include only the database name, in case the rest is sensitive.