### PR TITLE
Return proper error when getting tcp closed after fatal errors

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -3068,20 +3068,19 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp error_ready(s, _status, %Postgrex.Error{postgres: %{severity: severity}} = err, buffer)
-       when severity in ["FATAL", "PANIC"] do
-    %{connection_id: connection_id} = s
-    {:disconnect, %{err | connection_id: connection_id}, %{s | buffer: buffer}}
-  end
-
   defp error_ready(s, status, %Postgrex.Error{} = err, buffer) do
+    %{connection_id: connection_id} = s
+
     case recv_ready(s, status, buffer) do
       {:ok, s} ->
-        %{connection_id: connection_id} = s
         {:error, %{err | connection_id: connection_id}, s}
 
       {:disconnect, _, _} = disconnect ->
-        disconnect
+        if err.postgres.severity in ["FATAL", "PANIC"] do
+          {:disconnect, %{err | connection_id: connection_id}, %{s | buffer: buffer}}
+        else
+          disconnect
+        end
     end
   end
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -3068,6 +3068,12 @@ defmodule Postgrex.Protocol do
     end
   end
 
+  defp error_ready(s, _status, %Postgrex.Error{postgres: %{severity: severity}} = err, buffer)
+       when severity in ["FATAL", "PANIC"] do
+    %{connection_id: connection_id} = s
+    {:disconnect, %{err | connection_id: connection_id}, %{s | buffer: buffer}}
+  end
+
   defp error_ready(s, status, %Postgrex.Error{} = err, buffer) do
     case recv_ready(s, status, buffer) do
       {:ok, s} ->

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1945,19 +1945,29 @@ defmodule QueryTest do
 
     %Postgrex.Result{connection_id: connection_id} = Postgrex.query!(pid, "SELECT 42", [])
 
-    # Start a long-running query in a separate process so we can terminate the
-    # backend while it's executing.
     task =
       Task.async(fn ->
+        receive do
+          :go -> :ok
+        end
+
         Postgrex.query(pid, "SELECT pg_sleep(10)", [])
       end)
 
-    Process.sleep(100)
+    :erlang.trace(task.pid, true, [:call])
+    :erlang.trace_pattern({Postgrex.Protocol, :recv_bind, :_}, [], [:local])
+
+    send(task.pid, :go)
+
+    assert_receive {:trace, _, :call, {Postgrex.Protocol, :recv_bind, _}}, 200
 
     assert [[true]] = query("SELECT pg_terminate_backend($1)", [connection_id])
 
     assert {:error, %Postgrex.Error{postgres: %{code: :admin_shutdown, severity: "FATAL"}}} =
              Task.await(task, 5000)
+  after
+    :erlang.trace_pattern({Postgrex.Protocol, :recv_bind, :_}, false, [])
+    :erlang.trace(:all, false, [:call])
   end
 
   test "terminate backend with socket", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1940,6 +1940,26 @@ defmodule QueryTest do
            end) =~ "** (Postgrex.Error) FATAL 57P01 (admin_shutdown)"
   end
 
+  test "terminate backend during query returns FATAL error", context do
+    assert {:ok, pid} = P.start_link([idle_interval: 10] ++ context[:options])
+
+    %Postgrex.Result{connection_id: connection_id} = Postgrex.query!(pid, "SELECT 42", [])
+
+    # Start a long-running query in a separate process so we can terminate the
+    # backend while it's executing.
+    task =
+      Task.async(fn ->
+        Postgrex.query(pid, "SELECT pg_sleep(10)", [])
+      end)
+
+    Process.sleep(100)
+
+    assert [[true]] = query("SELECT pg_terminate_backend($1)", [connection_id])
+
+    assert {:error, %Postgrex.Error{postgres: %{code: :admin_shutdown, severity: "FATAL"}}} =
+             Task.await(task, 5000)
+  end
+
   test "terminate backend with socket", context do
     Process.flag(:trap_exit, true)
     socket = System.get_env("PG_SOCKET_DIR") || "/tmp"


### PR DESCRIPTION
When PostgreSQL sends a FATAL or PANIC ErrorResponse, it closes the connection immediately without sending ReadyForQuery.

Postgrex unconditionally waited for ReadyForQuery, which would hit tcp_closed and return a generic disconnect error, discarding the original error message.

I've included in the PR a test that would fail with the previous implementation. The query would return a
```elixir
{:error,
   %DBConnection.ConnectionError{
     message: "tcp recv: closed",
     severity: :error,
     reason: :closed
   }}
```

