### PR TITLE
Widen Postgrex.Result.t num_rows typespec to include :copy_stream and nil

### DIFF
--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -7,7 +7,8 @@ defmodule Postgrex.Result do
     * `columns` - The column names;
     * `rows` - The result set. A list of lists, each inner list corresponding to a
       row, each element in the inner list corresponds to a column;
-    * `num_rows` - The number of fetched or affected rows;
+    * `num_rows` - The number of fetched or affected rows, or `:copy_stream` while
+      a COPY FROM STDIN stream is in progress, or `nil` for multi-command results;
     * `connection_id` - The OS pid of the PostgreSQL backend that executed the query;
     * `messages` - A list of maps of messages, such as hints and notices, sent by the
       driver during the execution of the query.
@@ -17,7 +18,7 @@ defmodule Postgrex.Result do
           command: atom | [atom],
           columns: [String.t()] | nil,
           rows: [[term] | binary] | nil,
-          num_rows: integer,
+          num_rows: integer | :copy_stream | nil,
           connection_id: pos_integer,
           messages: [map()]
         }


### PR DESCRIPTION
The `@type t` declaration in `Postgrex.Result` declares `num_rows: integer`, but the driver produces two other values in practice:

- `num_rows: :copy_stream` — set by `copied/1` in `protocol.ex` (line 2733) as a sentinel while a COPY FROM STDIN stream is in progress.
- `num_rows: nil` — set by `done/2` in `protocol.ex` (line 3099) for multi-command transaction results (e.g. `ROLLBACK TO SAVEPOINT ...;RELEASE SAVEPOINT ...`).

Both values are intentional and have existing test coverage (stream_test.exs lines 412, 681, 709, 749 explicitly assert `num_rows: :copy_stream`). The typespec was too narrow.

This mismatch is surfaced as a `:badstructfield` diagnostic by the set-theoretic type checker being developed in elixir-lang/elixir#15366.

## Change

```diff
-          num_rows: integer,
+          num_rows: integer | :copy_stream | nil,
```

The `@moduledoc` description of `num_rows` is updated to document the two additional values.

## Notes for callers

Widening `num_rows` to allow an atom or nil is a typespec-only change with no runtime effect. Downstream code that pattern-matches or arithmetic-operates on `num_rows` assuming it is always an integer was already broken at runtime; this change makes the contract explicit.

## Compile and test status

`mix compile` is clean under both the standard Elixir release and the local Elixir build from elixir-lang/elixir#15366.

The full test suite requires a running PostgreSQL instance. Tests pass locally where Postgres is available; CI will provide full coverage.
