### PR TITLE
Use reports for logging errors

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -795,15 +795,17 @@ defmodule Postgrex.Protocol do
   @doc false
   def handshake_shutdown(timeout, pid, sock) do
     if Process.alive?(pid) do
-      Logger.error(fn ->
-        [
-          inspect(__MODULE__),
-          " (",
-          inspect(pid),
-          ") timed out because it was handshaking for longer than ",
-          to_string(timeout) | "ms"
-        ]
-      end)
+      Logger.error(
+        %{
+          log_id: {Postgrex, :handshake_shutdown},
+          pid: pid,
+          timeout: timeout
+        },
+        report_cb: fn %{source: {module, _}} = report ->
+          {"~ts (~tw) timed out because it was handshaking for longer than ~twms",
+           [inspect(module), report.pid, report.timeout]}
+        end
+      )
 
       :gen_tcp.shutdown(sock, :read_write)
     end

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -522,7 +522,20 @@ defmodule Postgrex.ReplicationConnection do
 
       {:error, reason} ->
         Logger.error(
-          "#{inspect(pid_or_name())} (#{inspect(mod)}) failed to connect to Postgres: #{Exception.format(:error, reason)}"
+          %{
+            log_id: {Postgrex, :connection_error},
+            pid_or_name: pid_or_name(),
+            mod: mod,
+            reason: reason
+          },
+          report_cb: fn report ->
+            {"~ts (~ts) failed to connect to Postgres: ~ts",
+             [
+               inspect(report.pid_or_name),
+               inspect(report.mod),
+               Exception.format(:error, report.reason)
+             ]}
+          end
         )
 
         if s.auto_reconnect do
@@ -655,7 +668,20 @@ defmodule Postgrex.ReplicationConnection do
     %{state: {mod, mod_state}} = s
 
     Logger.error(
-      "#{inspect(pid_or_name())} (#{inspect(mod)}) is reconnecting due to reason: #{Exception.format(:error, reason)}"
+      %{
+        log_id: {Postgrex, :reconnect},
+        pid_or_name: pid_or_name(),
+        mod: mod,
+        reason: reason
+      },
+      report_cb: fn report ->
+        {"~ts (~ts) is reconnecting due to reason: ~ts",
+         [
+           inspect(report.pid_or_name),
+           inspect(report.mod),
+           Exception.format(:error, report.reason)
+         ]}
+      end
     )
 
     {:keep_state, s} = maybe_handle(mod, :handle_disconnect, [mod_state], s)

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -365,7 +365,20 @@ defmodule Postgrex.SimpleConnection do
 
       {:error, reason} ->
         Logger.error(
-          "#{inspect(pid_or_name())} (#{inspect(mod)}) failed to connect to Postgres: #{Exception.format(:error, reason)}"
+          %{
+            log_id: {Postgrex, :connection_error},
+            pid_or_name: pid_or_name(),
+            mod: mod,
+            reason: reason
+          },
+          report_cb: fn report ->
+            {"~ts (~ts) failed to connect to Postgres: ~ts",
+             [
+               inspect(report.pid_or_name),
+               inspect(report.mod),
+               Exception.format(:error, report.reason)
+             ]}
+          end
         )
 
         if state.auto_reconnect do


### PR DESCRIPTION
This PR proposes to log error using report format instead of simple string. The change should be transparent, except for those who potentially relied on log message structure.

## More Context

One of the more common experiences when working with Ecto in production is whenever there is a problem with DB, there is a influx of errors that all have the same root cause, but different stacktraces and, more importantly, different message. For example:

> Postgrex.Protocol (#PID<0.2021.0> ("db_conn_4")) failed to connect: ** (Postgrex.Error) FATAL 53300 (too_many_connections) remaining connection slots are reserved for roles with the SUPERUSER attribute

This one is coming from a simple `Logger.error` call which interpolates pid, connection name and formatted underlying error. This provides a good UX in dev, but isn't great for structured logging solutions and error tracking systems used in production, as it makes it harder to group errors.

One way to address this is to use reports for logging, which allows for passing structured data to logger handlers while still defining a preferred way to format report. Logging libraries then can choose what to do with a report.

I don't think report logging is currently common in Elixir, so for me the feedback for this PR is important for this direction as a whole. If it's officially blessed, then it might be a good candidate for inclusion into library guidelines?