### PR TITLE
Replace deprecated xref: [exclude: ...] with elixirc_options: [no_warn_undefined: ...]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Postgrex.Mixfile do
       description: "PostgreSQL driver for Elixir",
       docs: docs(),
       package: package(),
-      xref: [exclude: [Jason]]
+      elixirc_options: [no_warn_undefined: [Jason]]
     ]
   end
 


### PR DESCRIPTION
Elixir 1.20 deprecates the `xref: [exclude: ...]` project option in `mix.exs` in favor of `elixirc_options: [no_warn_undefined: ...]`. The new option suppresses the same undefined-module warning that the old `xref` exclude silenced for the optional `Jason` dependency.

### Deprecation warning

```
warning: "xref: [exclude: ...]" in your mix.exs file is deprecated, instead use: "elixirc_options: [no_warn_undefined: ...]"
  (mix 1.20.1) lib/mix/tasks/compile.elixir.ex:243: Mix.Tasks.Compile.Elixir.xref_exclude_opts/2
```

### Change

```diff
-      xref: [exclude: [Jason]]
+      elixirc_options: [no_warn_undefined: [Jason]]
```

### Why `[Jason]` (bare module) rather than a tuple

The only references to `Jason` in the codebase are as default values for `Application.get_env/3` (in `lib/postgrex/types.ex`, `lib/postgrex/extensions/jsonb.ex`, `lib/postgrex/extensions/json.ex`) — no `Jason.foo/n` function is called directly. The bare module form is the natural fit and matches the old `xref: [exclude: [Jason]]` semantics.

### Verification

```
$ mix compile --force --warnings-as-errors
Compiling 70 files (.ex)
Generated postgrex app
```

No deprecation warning, no other warnings.