### PR TITLE
Fix composite type loading when `record_send` is duplicated.

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -134,7 +134,7 @@ defmodule Postgrex.Types do
     %TypeInfo{
       oid: oid,
       type: :binary.copy(type),
-      send: :binary.copy(send),
+      send: unqualify_proc(send),
       receive: :binary.copy(receive),
       output: :binary.copy(output),
       input: :binary.copy(input),
@@ -143,6 +143,9 @@ defmodule Postgrex.Types do
       comp_elems: comp_oids
     }
   end
+
+  defp unqualify_proc("pg_catalog." <> name), do: :binary.copy(name)
+  defp unqualify_proc(name), do: :binary.copy(name)
 
   @doc false
   @spec associate_type_infos([TypeInfo.t()], state) :: :ok

--- a/test/ambiguous_builtin_function_test.exs
+++ b/test/ambiguous_builtin_function_test.exs
@@ -1,0 +1,31 @@
+defmodule AmbiguousBuiltinFunctionTest do
+  use ExUnit.Case, async: false
+  alias Postgrex, as: P
+
+  setup do
+    opts = [database: "postgrex_test", backoff_type: :stop, max_restarts: 0]
+    {:ok, pid} = Postgrex.start_link(opts)
+
+    P.query!(
+      pid,
+      "CREATE OR REPLACE FUNCTION public.record_send(integer) RETURNS bytea LANGUAGE sql AS $$ SELECT ''::bytea $$",
+      []
+    )
+
+    P.query!(pid, "DROP TYPE IF EXISTS my_type CASCADE", [])
+    P.query!(pid, "CREATE TYPE my_type AS (a int, b text)", [])
+
+    {:ok, [pid: pid, options: opts]}
+  end
+
+  test "composite type loads when a user function duplicates built-in record_send", %{pid: pid} do
+    assert {:ok, %Postgrex.Result{rows: [[[]]]}} =
+             P.query(pid, "SELECT $1::my_type[]", [[]])
+  end
+
+  test "regproc raises when a user function duplicates built-in record_send", %{pid: pid} do
+    assert_raise Postgrex.Error, ~r/ambiguous/, fn ->
+      P.query!(pid, "SELECT 'record_send'::regproc", [])
+    end
+  end
+end


### PR DESCRIPTION
The type-loading query does return qualified names when they are duplicated, for example when a user-defined `record_send` is present:

```
CREATE TYPE my_composite AS (a int, b text);
CREATE FUNCTION public.record_send(integer) RETURNS bytea LANGUAGE sql AS $$ SELECT ''::bytea $$;
Postgrex.query(conn, "SELECT $1::my_composite[]", [[]])
{:error, %Postgrex.QueryError{message: "type `_my_composite` can not be handled by the types module Postgrex.DefaultTypes"}}
```

This naive fix strips out the `pg_catalog.` prefix to keep only the bare name as expected by Postgrex.

--

For context, this was reported by a customer of Supabase Realtime and I tried the smallest fix possible to not cause too many changes and not cause any performance impact.