### PR TITLE
Fix encoding of domains over composite types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - fix_domain
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - fix_domain
+      - master
   pull_request:
 
 jobs:

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -93,7 +93,7 @@ defmodule Postgrex.Types do
         ARRAY (
           SELECT a.atttypid
           FROM pg_attribute AS a
-          WHERE a.attrelid = t.typrelid AND a.attnum > 0 AND NOT a.attisdropped
+          WHERE a.attrelid = coalesce(d.typrelid, t.typrelid) AND a.attnum > 0 AND NOT a.attisdropped
           ORDER BY a.attnum
         )
         """

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -84,6 +84,16 @@ defmodule QueryTest do
     assert [[^uuid]] = query("SELECT 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid", [])
   end
 
+  @tag min_pg_version: "11.0"
+  test "decode composite domain", context do
+    assert [[{"a", 1}]] = query("SELECT '(a, 1)'::composite_domain", [])
+  end
+
+  @tag min_pg_version: "11.0"
+  test "decode arrays of composite domain", context do
+    assert [[[{"a", 1}]]] = query("SELECT ARRAY['(a, 1)']::composite_domain[]", [])
+  end
+
   test "decode arrays", context do
     assert [[[]]] = query("SELECT ARRAY[]::integer[]", [])
     assert [[[1]]] = query("SELECT ARRAY[1]", [])
@@ -119,6 +129,16 @@ defmodule QueryTest do
 
     points_string = "{\"(1,1)\",\"(2,2)\",\"(3,3)\"}"
     assert [[^points_string]] = query("SELECT $1::points_domain::text", [points])
+  end
+
+  @tag min_pg_version: "11.0"
+  test "encode composite domain", context do
+    assert [[{"a", 1}]] = query("SELECT $1::composite_domain", [{"a", 1}])
+  end
+
+  @tag min_pg_version: "11.0"
+  test "encode arrays of composite domain", context do
+    assert [[[{"a", 1}]]] = query("SELECT $1::composite_domain[]", [[{"a", 1}]])
   end
 
   test "decode interval", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -72,7 +72,20 @@ replication_exclude =
   end
 
 version_exclude =
-  [{8, 4}, {9, 0}, {9, 1}, {9, 2}, {9, 3}, {9, 4}, {9, 5}, {10, 0}, {13, 0}, {14, 0}, {17, 0}]
+  [
+    {8, 4},
+    {9, 0},
+    {9, 1},
+    {9, 2},
+    {9, 3},
+    {9, 4},
+    {9, 5},
+    {10, 0},
+    {11, 0},
+    {13, 0},
+    {14, 0},
+    {17, 0}
+  ]
   |> Enum.filter(fn x -> x > pg_version end)
   |> Enum.map(fn {major, minor} -> {:min_pg_version, "#{major}.#{minor}"} end)
 
@@ -122,6 +135,20 @@ sql_test =
       SET password_encryption = 'scram-sha-256';
       CREATE USER postgrex_scram_pw WITH PASSWORD 'postgrex_scram_pw';
       CREATE PUBLICATION postgrex_example FOR ALL TABLES;
+      """
+  else
+    sql_test
+  end
+
+sql_test =
+  if pg_version >= {11, 0} do
+    sql_test <>
+      """
+      DROP TYPE IF EXISTS composite_test;
+      CREATE TYPE composite_test AS (a text, b integer);
+
+      DROP DOMAIN IF EXISTS composite_domain;
+      CREATE DOMAIN composite_domain AS composite_test CHECK ((VALUE).a is NOT NULL);
       """
   else
     sql_test


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/postgrex/issues/766 

It turns out we were not encoding domains over composite types. The issue is that it relies on `typrelid` which is not defined for the domain but rather the underlying composite.