### PR TITLE
Add missing :unix tag to backend termination test

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1990,6 +1990,7 @@ defmodule QueryTest do
     :erlang.trace(:all, false, [:call])
   end
 
+  @tag :unix
   test "terminate backend with socket", context do
     Process.flag(:trap_exit, true)
     socket = System.get_env("PG_SOCKET_DIR") || "/tmp"


### PR DESCRIPTION
Found this while running tests on a dockerized postgres.