### PR TITLE
use private functions as report_cb

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -801,10 +801,7 @@ defmodule Postgrex.Protocol do
           pid: pid,
           timeout: timeout
         },
-        report_cb: fn %{source: {module, _}} = report ->
-          {"~ts (~tw) timed out because it was handshaking for longer than ~twms",
-           [inspect(module), report.pid, report.timeout]}
-        end
+        report_cb: &__MODULE__._format_handshake_shutdown/1
       )
 
       :gen_tcp.shutdown(sock, :read_write)
@@ -816,6 +813,12 @@ defmodule Postgrex.Protocol do
   def cancel_handshake_timer({:timer, tref}) do
     {:ok, _} = :timer.cancel(tref)
     :ok
+  end
+
+  @doc false
+  def _format_handshake_shutdown(%{source: {module, _}} = report) do
+    {"~ts (~tw) timed out because it was handshaking for longer than ~twms",
+     [inspect(module), report.pid, report.timeout]}
   end
 
   defp do_handshake(_host, s, %{ssl: nil} = status), do: startup(s, status)

--- a/lib/postgrex/replication_connection.ex
+++ b/lib/postgrex/replication_connection.ex
@@ -528,14 +528,7 @@ defmodule Postgrex.ReplicationConnection do
             mod: mod,
             reason: reason
           },
-          report_cb: fn report ->
-            {"~ts (~ts) failed to connect to Postgres: ~ts",
-             [
-               inspect(report.pid_or_name),
-               inspect(report.mod),
-               Exception.format(:error, report.reason)
-             ]}
-          end
+          report_cb: &__MODULE__._format_connection_error/1
         )
 
         if s.auto_reconnect do
@@ -565,6 +558,25 @@ defmodule Postgrex.ReplicationConnection do
   end
 
   ## Helpers
+  @doc false
+  def _format_connection_error(report) do
+    {"~ts (~ts) failed to connect to Postgres: ~ts",
+     [
+       inspect(report.pid_or_name),
+       inspect(report.mod),
+       Exception.format(:error, report.reason)
+     ]}
+  end
+
+  @doc false
+  def _format_reconnect_error(report) do
+    {"~ts (~ts) is reconnecting due to reason: ~ts",
+     [
+       inspect(report.pid_or_name),
+       inspect(report.mod),
+       Exception.format(:error, report.reason)
+     ]}
+  end
 
   defp handle_data([], s), do: {:keep_state, s}
 
@@ -674,14 +686,7 @@ defmodule Postgrex.ReplicationConnection do
         mod: mod,
         reason: reason
       },
-      report_cb: fn report ->
-        {"~ts (~ts) is reconnecting due to reason: ~ts",
-         [
-           inspect(report.pid_or_name),
-           inspect(report.mod),
-           Exception.format(:error, report.reason)
-         ]}
-      end
+      report_cb: &__MODULE__._format_reconnect_error/1
     )
 
     {:keep_state, s} = maybe_handle(mod, :handle_disconnect, [mod_state], s)

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -371,14 +371,7 @@ defmodule Postgrex.SimpleConnection do
             mod: mod,
             reason: reason
           },
-          report_cb: fn report ->
-            {"~ts (~ts) failed to connect to Postgres: ~ts",
-             [
-               inspect(report.pid_or_name),
-               inspect(report.mod),
-               Exception.format(:error, report.reason)
-             ]}
-          end
+          report_cb: &__MODULE__._format_connection_error/1
         )
 
         if state.auto_reconnect do
@@ -440,6 +433,15 @@ defmodule Postgrex.SimpleConnection do
   end
 
   ## Helpers
+  @doc false
+  def _format_connection_error(report) do
+    {"~ts (~ts) failed to connect to Postgres: ~ts",
+     [
+       inspect(report.pid_or_name),
+       inspect(report.mod),
+       Exception.format(:error, report.reason)
+     ]}
+  end
 
   defp maybe_handle(mod, fun, args, state) do
     if function_exported?(mod, fun, length(args)) do

--- a/lib/postgrex/simple_connection.ex
+++ b/lib/postgrex/simple_connection.ex
@@ -433,6 +433,7 @@ defmodule Postgrex.SimpleConnection do
   end
 
   ## Helpers
+
   @doc false
   def _format_connection_error(report) do
     {"~ts (~ts) failed to connect to Postgres: ~ts",


### PR DESCRIPTION
@hauleth [raised a good point](https://github.com/elixir-ecto/postgrex/pull/768#issuecomment-4847758237) that anonymous functions shouldn't be used as report callbacks. This PR uses private functions instead. Embarrassingly, this [isn't the first time](https://github.com/elixir-lang/elixir/pull/14380#issuecomment-2764222374) I'm making this mistake.

Anyways, I went with a private function per log message, but open to other arrangements (separate module? a single function with multiple heads matching on `log_id`?) if you think it's better.