### PR TITLE
fix incorrect match in report_cb callback

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -816,9 +816,9 @@ defmodule Postgrex.Protocol do
   end
 
   @doc false
-  def _format_handshake_shutdown(%{source: {module, _}} = report) do
+  def _format_handshake_shutdown(report) do
     {"~ts (~tw) timed out because it was handshaking for longer than ~twms",
-     [inspect(module), report.pid, report.timeout]}
+     [inspect(__MODULE__), report.pid, report.timeout]}
   end
 
   defp do_handshake(_host, s, %{ssl: nil} = status), do: startup(s, status)


### PR DESCRIPTION
The changes from `source` to `log_id` in https://github.com/elixir-ecto/postgrex/pull/768 left an invalid match in the code, apologies. I also made it just `inspect(__MODULE__)` so that log message is fully identical to the one in the current released version.