### PR TITLE
Demonitor on Parameters delete to stop monitor leak

### DIFF
--- a/lib/postgrex/parameters.ex
+++ b/lib/postgrex/parameters.ex
@@ -60,6 +60,7 @@ defmodule Postgrex.Parameters do
   end
 
   def handle_cast({:delete, ref}, state) do
+    Process.demonitor(ref, [:flush])
     :ets.delete(state, ref)
     {:noreply, state}
   end


### PR DESCRIPTION
Fixes #780.

`Postgrex.Parameters` monitors on insert but never demonitors on delete, so every in-place reconnect leaks a monitor. This adds the `Process.demonitor(ref, [:flush])` already used in the other monitoring modules.