### PR TITLE
Reject auth downgrade when channel binding required

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -907,7 +907,26 @@ defmodule Postgrex.Protocol do
   defp auth_recv(s, status, buffer) do
     case msg_recv(s, :infinity, buffer) do
       {:ok, msg_auth(type: :ok), buffer} ->
-        init_recv(s, status, buffer)
+        # When channel binding is required, the server must not be able to
+        # finish authentication without it.
+        if status.channel_binding == :require and
+             not match?({"SCRAM-SHA-256-PLUS", _, _}, s.scram_cb) do
+          disconnect(
+            s,
+            %Postgrex.Error{message: "channel binding is required but the server did not use it"},
+            buffer
+          )
+        else
+          init_recv(s, status, buffer)
+        end
+
+      {:ok, msg_auth(type: type), buffer}
+      when status.channel_binding == :require and type in [:cleartext, :md5] ->
+        disconnect(
+          s,
+          %Postgrex.Error{message: "channel binding is required but the server did not use it"},
+          buffer
+        )
 
       {:ok, msg_auth(type: :cleartext), buffer} ->
         auth_cleartext(s, status, buffer)

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -143,6 +143,30 @@ defmodule LoginTest do
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
   end
 
+  test "channel binding required refuses cleartext authentication downgrade", context do
+    assert capture_log(fn ->
+             opts = [
+               username: "postgrex_cleartext_pw",
+               password: "postgrex_cleartext_pw",
+               channel_binding: :require
+             ]
+
+             assert_start_and_killed(opts ++ context[:options])
+           end) =~ "channel binding is required"
+  end
+
+  test "channel binding required refuses md5 authentication downgrade", context do
+    assert capture_log(fn ->
+             opts = [
+               username: "postgrex_md5_pw",
+               password: "postgrex_md5_pw",
+               channel_binding: :require
+             ]
+
+             assert_start_and_killed(opts ++ context[:options])
+           end) =~ "channel binding is required"
+  end
+
   # gen_statem reports (raised in connect/2) are only captured on Elixir v1.17+,
   # and a bug crashes the Logger on v1.17.0/v1.17.1.
   if Version.match?(System.version(), ">= 1.17.2") do


### PR DESCRIPTION
Following up on #776. I think we shouldn't allow downgrading to cleartext/md5 if we have channel_binding as `:require`. This aligns with libpq. I missed this the last time.