### PR TITLE
Do not UNLISTEN while disconnected

### DIFF
--- a/lib/postgrex/notifications.ex
+++ b/lib/postgrex/notifications.ex
@@ -280,7 +280,13 @@ defmodule Postgrex.Notifications do
         if map_size(state.listener_channels[channel]) == 0 do
           {_, state} = pop_in(state.listener_channels[channel])
 
-          {:query, ~s(UNLISTEN #{quote_channel(channel)}), %{state | from: from}}
+          if state.connected do
+            {:query, ~s(UNLISTEN #{quote_channel(channel)}), %{state | from: from}}
+          else
+            from && SimpleConnection.reply(from, :ok)
+
+            {:noreply, state}
+          end
         else
           from && SimpleConnection.reply(from, :ok)
 

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -24,31 +24,25 @@ defmodule NotificationTest do
   end
 
   test "does not fail on sync connection with auto reconnect" do
-    Process.flag(:trap_exit, true)
     assert {:ok, pid} = PN.start_link(database: "nobody_knows_it", auto_reconnect: true)
     assert {:eventually, _} = PN.listen(pid, "channel")
+    assert Process.alive?(pid)
   end
 
   test "does not fail on async connection with auto reconnect" do
-    Process.flag(:trap_exit, true)
-
     assert {:ok, pid} =
              PN.start_link(database: "nobody_knows_it", auto_reconnect: true, sync_connect: false)
 
     assert {:eventually, _} = PN.listen(pid, "channel")
-    refute_receive {:EXIT, _, ^pid}, 100
+    assert Process.alive?(pid)
   end
 
   test "does not fail on unlisten while disconnected" do
-    Process.flag(:trap_exit, true)
-
     assert {:ok, pid} =
              PN.start_link(database: "nobody_knows_it", auto_reconnect: true, sync_connect: false)
 
     assert {:eventually, ref} = PN.listen(pid, "channel")
-
     assert :ok = PN.unlisten(pid, ref)
-    refute_receive {:EXIT, _, ^pid}, 100
     assert Process.alive?(pid)
   end
 

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -39,6 +39,19 @@ defmodule NotificationTest do
     refute_receive {:EXIT, _, ^pid}, 100
   end
 
+  test "does not fail on unlisten while disconnected" do
+    Process.flag(:trap_exit, true)
+
+    assert {:ok, pid} =
+             PN.start_link(database: "nobody_knows_it", auto_reconnect: true, sync_connect: false)
+
+    assert {:eventually, ref} = PN.listen(pid, "channel")
+
+    assert :ok = PN.unlisten(pid, ref)
+    refute_receive {:EXIT, _, ^pid}, 100
+    assert Process.alive?(pid)
+  end
+
   test "listening", context do
     assert {:ok, ref} = PN.listen(context.pid_ps, "channel")
 


### PR DESCRIPTION
We send the `UNLISTEN` query unconditionally when removing the last subscriber, which can crash the process if there is no DB connection to receive it. Similar to how we have a safety mechanism for queuing `LISTEN` queries, I think we can have a simple guard that ignores `UNLISTEN` if the connection doesn't exist anymore.