### PR TITLE
Fix "Contiuous" typo in a test comment

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -716,7 +716,7 @@ defmodule QueryTest do
                []
              )
 
-    # Contiuous ranges can't be normalized
+    # Continuous ranges can't be normalized
     expected_num_multirange = %Postgrex.Multirange{
       ranges: [
         %Postgrex.Range{


### PR DESCRIPTION
Fixes a small typo in a test comment: "Contiuous" → "Continuous".