### PR TITLE
Decode void type on CockroachDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Fix composite type loading when `record_send` is duplicated
   * Fix encoding of domains over composite types
   * Enforce integer bounds in type encoders
+  * Decode the `void` type on CockroachDB (`voidsend`/`voidout`)
 
 ## v0.22.3 (2026-07-09)
 

--- a/lib/postgrex/extensions/void_binary.ex
+++ b/lib/postgrex/extensions/void_binary.ex
@@ -1,7 +1,9 @@
 defmodule Postgrex.Extensions.VoidBinary do
   @moduledoc false
   import Postgrex.BinaryUtils, warn: false
-  use Postgrex.BinaryExtension, send: "void_send"
+  # CockroachDB names void's send/output procs without underscores
+  # (voidsend / voidout), so match its spelling in addition to Postgres'.
+  use Postgrex.BinaryExtension, send: "void_send", send: "voidsend"
 
   def encode(_) do
     quote location: :keep do

--- a/lib/postgrex/extensions/void_text.ex
+++ b/lib/postgrex/extensions/void_text.ex
@@ -5,7 +5,9 @@ defmodule Postgrex.Extensions.VoidText do
 
   def init(_), do: nil
 
-  def matching(_), do: [output: "void_out"]
+  # CockroachDB names void's send/output procs without underscores
+  # (voidsend / voidout), so match its spelling in addition to Postgres'.
+  def matching(_), do: [output: "void_out", output: "voidout"]
 
   def format(_), do: :text
 


### PR DESCRIPTION
CockroachDB names the void type's send/output procs without underscores (`voidsend` / `voidout`), so the built-in `VoidBinary`/`VoidText` extensions never bind and `SELECT`s returning void (e.g. pg_advisory_xact_lock/1) raise `type "void" can not be handled`.

Match CRDB's proc spelling in addition to Postgres' so void decodes on both engines. The wire format is identical; only the matching changes, and the Postgres path is unaffected.