### PR TITLE
Decode inet, pg_lsn, and ltree types on CockroachDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Fix encoding of domains over composite types
   * Enforce integer bounds in type encoders
   * Decode the `void` type on CockroachDB (`voidsend`/`voidout`)
+  * Decode the `inet`, `pg_lsn`, and `ltree` types on CockroachDB (`inetsend`/`pg_lsnsend`/`ltreesend`)
 
 ## v0.22.3 (2026-07-09)
 

--- a/lib/postgrex/extensions/inet.ex
+++ b/lib/postgrex/extensions/inet.ex
@@ -2,7 +2,9 @@ defmodule Postgrex.Extensions.INET do
   @moduledoc false
 
   import Postgrex.BinaryUtils, warn: false
-  use Postgrex.BinaryExtension, send: "cidr_send", send: "inet_send"
+  # CockroachDB names inet's send proc without an underscore (inetsend),
+  # so match its spelling in addition to Postgres'.
+  use Postgrex.BinaryExtension, send: "cidr_send", send: "inet_send", send: "inetsend"
 
   @octet_range 0..255
   @hextet_range 0..65535

--- a/lib/postgrex/extensions/int8.ex
+++ b/lib/postgrex/extensions/int8.ex
@@ -1,7 +1,9 @@
 defmodule Postgrex.Extensions.Int8 do
   @moduledoc false
   import Postgrex.BinaryUtils, warn: false
-  use Postgrex.BinaryExtension, send: "int8send", send: "pg_lsn_send"
+  # CockroachDB names pg_lsn's send proc without an underscore (pg_lsnsend),
+  # so match its spelling in addition to Postgres'.
+  use Postgrex.BinaryExtension, send: "int8send", send: "pg_lsn_send", send: "pg_lsnsend"
 
   @int8_range -9_223_372_036_854_775_808..9_223_372_036_854_775_807
 

--- a/lib/postgrex/extensions/ltree.ex
+++ b/lib/postgrex/extensions/ltree.ex
@@ -1,7 +1,9 @@
 defmodule Postgrex.Extensions.Ltree do
   @moduledoc false
   import Postgrex.BinaryUtils, warn: false
-  use Postgrex.BinaryExtension, send: "ltree_send"
+  # CockroachDB names ltree's send proc without an underscore (ltreesend),
+  # so match its spelling in addition to Postgres'.
+  use Postgrex.BinaryExtension, send: "ltree_send", send: "ltreesend"
 
   def init(opts), do: Keyword.fetch!(opts, :decode_binary)
 


### PR DESCRIPTION
Fixes a similar issue as in #791, but this time for: inet, pg_lsn, and ltree types on CockroachDB